### PR TITLE
Integrate upstream LOOP implementation

### DIFF
--- a/jscl.lisp
+++ b/jscl.lisp
@@ -83,6 +83,8 @@
      ("codegen"      :both)
      ("compiler"     :both))
     ("documentation" :target)
+    ("ansiloop"
+     ("ansi-loop"    :target))
     ("toplevel"      :target)))
 
 

--- a/jscl.lisp
+++ b/jscl.lisp
@@ -35,13 +35,13 @@
   ;; and we are not using ASDF yet.
   (with-open-file (in (merge-pathnames "package.json" *base-directory*))
     (loop
-       for line = (read-line in nil)
-       while line
-       when (search "\"version\":" line)
-       do (let ((colon (position #\: line))
-                (comma (position #\, line)))
-            (return (string-trim '(#\newline #\" #\tab #\space)
-                                 (subseq line (1+ colon) comma)))))))
+      for line = (read-line in nil)
+      while line
+      when (search "\"version\":" line)
+        do (let ((colon (position #\: line))
+                 (comma (position #\, line)))
+             (return (string-trim '(#\newline #\" #\tab #\space)
+                                  (subseq line (1+ colon) comma)))))))
 
 
 ;;; List of all the source files that need to  be compiled, and whether they are to be compiled just
@@ -153,14 +153,14 @@
     (let ((in (make-string-stream (read-whole-file filename))))
       (format t "Compiling ~a...~%" (enough-namestring filename))
       (loop
-         with eof-mark = (gensym)
-         for form = (ls-read in nil eof-mark)
-         until (eq form eof-mark)
-         do (let ((compilation (compile-toplevel form)))
-              (if (possibly-valid-js-p compilation)
-                  (when (plusp (length compilation))
-                    (write-string compilation out))
-                  (complain-about-illegal-chars form in compilation)))))))
+        with eof-mark = (gensym)
+        for form = (ls-read in nil eof-mark)
+        until (eq form eof-mark)
+        do (let ((compilation (compile-toplevel form)))
+             (if (possibly-valid-js-p compilation)
+                 (when (plusp (length compilation))
+                   (write-string compilation out))
+                 (complain-about-illegal-chars form in compilation)))))))
 
 (defun dump-global-environment (stream)
   (flet ((late-compile (form)
@@ -204,8 +204,8 @@
 (defun compile-test-suite ()
   (compile-application
    `(,(source-pathname "tests.lisp" :directory nil)
-      ,@(directory (source-pathname "*" :directory '(:relative "tests") :type "lisp"))
-      ,(source-pathname "tests-report.lisp" :directory nil))
+     ,@(directory (source-pathname "*" :directory '(:relative "tests") :type "lisp"))
+     ,(source-pathname "tests-report.lisp" :directory nil))
    (merge-pathnames "tests.js" *base-directory*)))
 
 (defun compile-web-repl ()

--- a/repl-node/repl.lisp
+++ b/repl-node/repl.lisp
@@ -1,13 +1,15 @@
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading repl-node/repl.lisp!")
 

--- a/repl-web/repl.lisp
+++ b/repl-web/repl.lisp
@@ -1,13 +1,15 @@
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading repl-web/repl.lisp!")
 
@@ -25,13 +27,14 @@
   (#j:localStorage:setItem "jqhist" (#j:JSON:stringify (#j:jqconsole:GetHistory))))
 
 
-;;; Decides wheater the input the user has entered is completed or we should accept one more line.
+;;; Decides wheater  the input the user  has entered is completed  or we
+;;; should accept one more line.
 (defun indent-level (string)
   (let ((i 0)
         (stringp nil)
         (s (length string))
         (depth 0))
-    
+
     (while (< i s)
       (cond
         (stringp

--- a/src/ansiloop/ansi-loop.lisp
+++ b/src/ansiloop/ansi-loop.lisp
@@ -1,0 +1,2134 @@
+;;;   -*- Mode: LISP; Syntax: Common-lisp; Base: 10; Lowercase:T -*-
+;;;>
+;;;> Portions of LOOP are Copyright (c) 1986 by the Massachusetts Institute of Technology.
+;;;> All Rights Reserved.
+;;;> 
+;;;> Permission to use, copy, modify and distribute this software and its
+;;;> documentation for any purpose and without fee is hereby granted,
+;;;> provided that the M.I.T. copyright notice appear in all copies and that
+;;;> both that copyright notice and this permission notice appear in
+;;;> supporting documentation.  The names "M.I.T." and "Massachusetts
+;;;> Institute of Technology" may not be used in advertising or publicity
+;;;> pertaining to distribution of the software without specific, written
+;;;> prior permission.  Notice must be given in supporting documentation that
+;;;> copying distribution is by permission of M.I.T.  M.I.T. makes no
+;;;> representations about the suitability of this software for any purpose.
+;;;> It is provided "as is" without express or implied warranty.
+;;;> 
+;;;>      Massachusetts Institute of Technology
+;;;>      77 Massachusetts Avenue
+;;;>      Cambridge, Massachusetts  02139
+;;;>      United States of America
+;;;>      +1-617-253-1000
+;;;>
+;;;> Portions of LOOP are Copyright (c) 1989, 1990, 1991, 1992 by Symbolics, Inc.
+;;;> All Rights Reserved.
+;;;> 
+;;;> Permission to use, copy, modify and distribute this software and its
+;;;> documentation for any purpose and without fee is hereby granted,
+;;;> provided that the Symbolics copyright notice appear in all copies and
+;;;> that both that copyright notice and this permission notice appear in
+;;;> supporting documentation.  The name "Symbolics" may not be used in
+;;;> advertising or publicity pertaining to distribution of the software
+;;;> without specific, written prior permission.  Notice must be given in
+;;;> supporting documentation that copying distribution is by permission of
+;;;> Symbolics.  Symbolics makes no representations about the suitability of
+;;;> this software for any purpose.  It is provided "as is" without express
+;;;> or implied warranty.
+;;;> 
+;;;> Symbolics, CLOE Runtime, and Minima are trademarks, and CLOE, Genera,
+;;;> and Zetalisp are registered trademarks of Symbolics, Inc.
+;;;>
+;;;>      Symbolics, Inc.
+;;;>      8 New England Executive Park, East
+;;;>      Burlington, Massachusetts  01803
+;;;>      United States of America
+;;;>      +1-617-221-1000
+
+;; $aclHeader: loop.cl,v 1.5 91/12/04 01:13:48 cox acl4_1 $
+
+;;;; LOOP Iteration Macro
+
+#+allegro
+(in-package :excl)
+#-allegro
+(in-package :ansi-loop)
+
+(provide :loop)
+
+#+Cloe-Runtime					;Don't ask.
+(car (push "%Z% %M% %I% %E% %U%" system::*module-identifications*))
+
+;;; Technology.
+;;;
+;;; The LOOP iteration macro is one of a number of pieces of code
+;;; originally developed at MIT for which free distribution has been
+;;; permitted, as long as the code is not sold for profit, and as long
+;;; as notification of MIT's interest in the code is preserved.
+;;;
+;;; This version of LOOP, which is almost entirely rewritten both as
+;;; clean-up and to conform with the ANSI Lisp LOOP standard, started
+;;; life as MIT LOOP version 829 (which was a part of NIL, possibly
+;;; never released).
+;;;
+;;; A "light revision" was performed by me (Glenn Burke) while at
+;;; Palladian Software in April 1986, to make the code run in Common
+;;; Lisp.  This revision was informally distributed to a number of
+;;; people, and was sort of the "MIT" version of LOOP for running in
+;;; Common Lisp.
+;;;
+;;; A later more drastic revision was performed at Palladian perhaps a
+;;; year later.  This version was more thoroughly Common Lisp in style,
+;;; with a few miscellaneous internal improvements and extensions.  I
+;;; have lost track of this source, apparently never having moved it to
+;;; the MIT distribution point.  I do not remember if it was ever
+;;; distributed.
+;;;
+;;; This revision for the ANSI standard is based on the code of my April
+;;; 1986 version, with almost everything redesigned and/or rewritten.
+
+
+;;; The design of this LOOP is intended to permit, using mostly the same
+;;; kernel of code, up to three different "loop" macros:
+;;; 
+;;; (1) The unextended, unextensible ANSI standard LOOP;
+;;;
+;;; (2) A clean "superset" extension of the ANSI LOOP which provides
+;;; functionality similar to that of the old LOOP, but "in the style of"
+;;; the ANSI LOOP.  For instance, user-definable iteration paths, with a
+;;; somewhat cleaned-up interface.
+;;;
+;;; (3) Extensions provided in another file which can make this LOOP
+;;; kernel behave largely compatibly with the Genera-vintage LOOP macro,
+;;; with only a small addition of code (instead of two whole, separate,
+;;; LOOP macros).
+;;;
+;;; Each of the above three LOOP variations can coexist in the same LISP
+;;; environment.
+;;; 
+
+
+;;;; Miscellaneous Environment Things
+
+
+
+;;;@@@@The LOOP-Prefer-POP feature makes LOOP generate code which "prefers" to use POP or
+;;; its obvious expansion (prog1 (car x) (setq x (cdr x))).  Usually this involves
+;;; shifting fenceposts in an iteration or series of carcdr operations.  This is
+;;; primarily recognized in the list iterators (FOR .. {IN,ON}), and LOOP's
+;;; destructuring setq code.
+(eval-when (compile load eval)
+  #+(or Genera Minima) (pushnew :LOOP-Prefer-POP *features*)
+  )
+
+
+;;; The uses of this macro are retained in the CL version of loop, in
+;;; case they are needed in a particular implementation.  Originally
+;;; dating from the use of the Zetalisp COPYLIST* function, this is used
+;;; in situations where, were cdr-coding in use, having cdr-NIL at the
+;;; end of the list might be suboptimal because the end of the list will
+;;; probably be RPLACDed and so cdr-normal should be used instead.
+(defmacro loop-copylist* (l)
+  #+Genera `(lisp:copy-list ,l nil t)		; arglist = (list &optional area force-dotted)
+  ;;@@@@Explorer??
+  #-Genera `(copy-list ,l)
+  )
+
+
+(defvar *loop-gentemp*
+	nil)
+
+(defun loop-gentemp (&optional (pref 'loopvar-))
+  (if *loop-gentemp*
+      (gentemp (string pref))
+      (gensym)))
+
+
+
+(defvar *loop-real-data-type* 'real)
+
+
+(defun loop-optimization-quantities (env)
+  ;;@@@@ The ANSI conditionalization here is for those lisps that implement
+  ;; DECLARATION-INFORMATION (from cleanup SYNTACTIC-ENVIRONMENT-ACCESS).
+  ;; It is really commentary on how this code could be written.  I don't
+  ;; actually expect there to be an ANSI #+-conditional -- it should be
+  ;; replaced with the appropriate conditional name for your
+  ;; implementation/dialect.
+  (declare #-ANSI (ignore env)
+	   #+Genera (values speed space safety compilation-speed debug))
+  #+ANSI (let ((stuff (declaration-information 'optimize env)))
+	   (values (or (cdr (assoc 'speed stuff)) 1)
+		   (or (cdr (assoc 'space stuff)) 1)
+		   (or (cdr (assoc 'safety stuff)) 1)
+		   (or (cdr (assoc 'compilation-speed stuff)) 1)
+		   (or (cdr (assoc 'debug stuff)) 1)))
+  #+CLOE-Runtime (values compiler::time compiler::space
+			 compiler::safety compiler::compilation-speed 1)
+  #-(or ANSI CLOE-Runtime) (values 1 1 1 1 1))
+
+
+;;;@@@@ The following form takes a list of variables and a form which presumably
+;;; references those variables, and wraps it somehow so that the compiler does not
+;;; consider those variables have been referenced.  The intent of this is that
+;;; iteration variables can be flagged as unused by the compiler, e.g. I in
+;;; (loop for i from 1 to 10 do (print t)), since we will tell it when a usage
+;;; of it is "invisible" or "not to be considered".
+;;;We implicitly assume that a setq does not count as a reference.  That is, the
+;;; kind of form generated for the above loop construct to step I, simplified, is
+;;; `(SETQ I ,(HIDE-VARIABLE-REFERENCES '(I) '(1+ I))).
+(defun hide-variable-references (variable-list form)
+  (declare #-Genera (ignore variable-list))
+  #+Genera (if variable-list `(compiler:invisible-references ,variable-list ,form) form)
+  #-Genera form)
+
+
+;;;@@@@ The following function takes a flag, a variable, and a form which presumably
+;;; references that variable, and wraps it somehow so that the compiler does not
+;;; consider that variable to have been referenced.  The intent of this is that
+;;; iteration variables can be flagged as unused by the compiler, e.g. I in
+;;; (loop for i from 1 to 10 do (print t)), since we will tell it when a usage
+;;; of it is "invisible" or "not to be considered".
+;;;We implicitly assume that a setq does not count as a reference.  That is, the
+;;; kind of form generated for the above loop construct to step I, simplified, is
+;;; `(SETQ I ,(HIDE-VARIABLE-REFERENCES T 'I '(1+ I))).
+;;;Certain cases require that the "invisibility" of the reference be conditional upon
+;;; something.  This occurs in cases of "named" variables (the USING clause).  For instance,
+;;; we want IDX in (LOOP FOR E BEING THE VECTOR-ELEMENTS OF V USING (INDEX IDX) ...)
+;;; to be "invisible" when it is stepped, so that the user gets informed if IDX is
+;;; not referenced.  However, if no USING clause is present, we definitely do not
+;;; want to be informed that some random gensym is not used.
+;;;It is easier for the caller to do this conditionally by passing a flag (which
+;;; happens to be the second value of NAMED-VARIABLE, q.v.) to this function than
+;;; for all callers to contain the conditional invisibility construction.
+(defun hide-variable-reference (really-hide variable form)
+  (declare #-Genera (ignore really-hide variable))
+  #+Genera (if (and really-hide variable (atom variable))	;Punt on destructuring patterns
+	       `(compiler:invisible-references (,variable) ,form)
+	       form)
+  #-Genera form)
+
+
+;;;; List Collection Macrology
+
+
+(defmacro with-loop-list-collection-head ((head-var tail-var &optional user-head-var)
+					  &body body)
+  ;;@@@@ TI? Exploder?
+  #+LISPM (let ((head-place (or user-head-var head-var)))
+	    `(let* ((,head-place nil)
+		    (,tail-var
+		      ,(hide-variable-reference
+			 user-head-var user-head-var
+			 `(progn #+Genera (scl:locf ,head-place)
+				 #-Genera (system:variable-location ,head-place)))))
+	       ,@body))
+  #-LISPM (let ((l (and user-head-var (list (list user-head-var nil)))))
+	    #+CLOE `(sys::with-stack-list* (,head-var nil nil)
+		      (let ((,tail-var ,head-var) ,@l)
+			,@body))
+	    #-CLOE `(let* ((,head-var (list nil)) (,tail-var ,head-var) ,@l)
+		      ,@body)))
+
+
+(defmacro loop-collect-rplacd (&environment env
+			       (head-var tail-var &optional user-head-var) form)
+  (declare
+    #+LISPM (ignore head-var user-head-var)	;use locatives, unconditionally update through the tail.
+    )
+  (setq form (macroexpand form env))
+  (flet ((cdr-wrap (form n)
+	   (declare (fixnum n))
+	   (do () ((<= n 4) (setq form `(,(case n
+					    (1 'cdr)
+					    (2 'cddr)
+					    (3 'cdddr)
+					    (4 'cddddr))
+					 ,form)))
+	     (setq form `(cddddr ,form) n (- n 4)))))
+    (let ((tail-form form) (ncdrs nil))
+      ;;Determine if the form being constructed is a list of known length.
+      (when (consp form)
+	(cond ((eq (car form) 'list)
+	       (setq ncdrs (1- (length (cdr form))))
+	       ;;@@@@ Because the last element is going to be RPLACDed,
+	       ;; we don't want the cdr-coded implementations to use
+	       ;; cdr-nil at the end (which would just force copying
+	       ;; the whole list again).
+	       #+LISPM (setq tail-form `(list* ,@(cdr form) nil)))
+	      ((member (car form) '(list* cons))
+	       (when (and (cddr form) (member (car (last form)) '(nil 'nil)))
+		 (setq ncdrs (- (length (cdr form)) 2))))))
+      (let ((answer
+	      (cond ((null ncdrs)
+		     `(when (setf (cdr ,tail-var) ,tail-form)
+			(setq ,tail-var (last (cdr ,tail-var)))))
+		    ((< ncdrs 0) (return-from loop-collect-rplacd nil))
+		    ((= ncdrs 0)
+		     ;;@@@@ Here we have a choice of two idioms:
+		     ;; (rplacd tail (setq tail tail-form))
+		     ;; (setq tail (setf (cdr tail) tail-form)).
+		     ;;Genera and most others I have seen do better with the former.
+		     `(rplacd ,tail-var (setq ,tail-var ,tail-form)))
+		    (t `(setq ,tail-var ,(cdr-wrap `(setf (cdr ,tail-var) ,tail-form)
+						   ncdrs))))))
+	;;If not using locatives or something similar to update the user's
+	;; head variable, we've got to set it...  It's harmless to repeatedly set it
+	;; unconditionally, and probably faster than checking.
+	#-LISPM (when user-head-var
+		  (setq answer `(progn ,answer (setq ,user-head-var (cdr ,head-var)))))
+	answer))))
+
+
+(defmacro loop-collect-answer (head-var &optional user-head-var)
+  (or user-head-var
+      (progn
+	;;If we use locatives to get tail-updating to update the head var,
+	;; then the head var itself contains the answer.  Otherwise we
+	;; have to cdr it.
+	#+LISPM head-var
+	#-LISPM `(cdr ,head-var))))
+
+
+;;;; Maximization Technology
+
+
+#|
+The basic idea of all this minimax randomness here is that we have to
+have constructed all uses of maximize and minimize to a particular
+"destination" before we can decide how to code them.  The goal is to not
+have to have any kinds of flags, by knowing both that (1) the type is
+something which we can provide an initial minimum or maximum value for
+and (2) know that a MAXIMIZE and MINIMIZE are not being combined.
+
+SO, we have a datastructure which we annotate with all sorts of things,
+incrementally updating it as we generate loop body code, and then use
+a wrapper and internal macros to do the coding when the loop has been
+constructed.
+|#
+
+
+(defstruct (loop-minimax
+	     (:constructor make-loop-minimax-internal)
+	     (:copier nil)
+	     (:predicate nil))
+  answer-variable
+  type
+  temp-variable
+  flag-variable
+  operations
+  infinity-data)
+
+
+(defvar *loop-minimax-type-infinities-alist*
+	;;@@@@ This is the sort of value this should take on for a Lisp that has
+	;; "eminently usable" infinities.  n.b. there are neither constants nor
+	;; printed representations for infinities defined by CL.
+	;;@@@@ This grotesque read-from-string below is to help implementations
+	;; which croak on the infinity character when it appears in a token, even
+	;; conditionalized out.
+	#+Genera
+	  '#.(read-from-string
+	      "((fixnum 	most-positive-fixnum	 most-negative-fixnum)
+		(short-float 	+1s			 -1s)
+		(single-float	+1f			 -1f)
+		(double-float	+1d			 -1d)
+		(long-float	+1l			 -1l))")
+	;;This is how the alist should look for a lisp that has no infinities.  In
+	;; that case, MOST-POSITIVE-x-FLOAT really IS the most positive.
+	#+(or CLOE-Runtime Minima)
+	  '((fixnum   		most-positive-fixnum		most-negative-fixnum)
+	    (short-float	most-positive-short-float	most-negative-short-float)
+	    (single-float	most-positive-single-float	most-negative-single-float)
+	    (double-float	most-positive-double-float	most-negative-double-float)
+	    (long-float		most-positive-long-float	most-negative-long-float))
+	;;If we don't know, then we cannot provide "infinite" initial values for any of the
+	;; types but FIXNUM:
+	#-(or Genera CLOE-Runtime Minima)
+	  '((fixnum   		most-positive-fixnum		most-negative-fixnum))
+	  )
+
+
+(defun make-loop-minimax (answer-variable type)
+  (let ((infinity-data (cdr (assoc type *loop-minimax-type-infinities-alist* :test #'subtypep))))
+    (make-loop-minimax-internal
+      :answer-variable answer-variable
+      :type type
+      :temp-variable (loop-gentemp 'loop-maxmin-temp-)
+      :flag-variable (and (not infinity-data) (loop-gentemp 'loop-maxmin-flag-))
+      :operations nil
+      :infinity-data infinity-data)))
+
+
+(defun loop-note-minimax-operation (operation minimax)
+  (pushnew (the symbol operation) (loop-minimax-operations minimax))
+  (when (and (cdr (loop-minimax-operations minimax))
+	     (not (loop-minimax-flag-variable minimax)))
+    (setf (loop-minimax-flag-variable minimax) (loop-gentemp 'loop-maxmin-flag-)))
+  operation)
+
+
+(defmacro with-minimax-value (lm &body body)
+  (let ((init (loop-typed-init (loop-minimax-type lm)))
+	(which (car (loop-minimax-operations lm)))
+	(infinity-data (loop-minimax-infinity-data lm))
+	(answer-var (loop-minimax-answer-variable lm))
+	(temp-var (loop-minimax-temp-variable lm))
+	(flag-var (loop-minimax-flag-variable lm))
+	(type (loop-minimax-type lm)))
+    (if flag-var
+	`(let ((,answer-var ,init) (,temp-var ,init) (,flag-var nil))
+	   (declare (type ,type ,answer-var ,temp-var))
+	   ,@body)
+	`(let ((,answer-var ,(if (eq which 'min) (first infinity-data) (second infinity-data)))
+	       (,temp-var ,init))
+	   (declare (type ,type ,answer-var ,temp-var))
+	   ,@body))))
+
+
+(defmacro loop-accumulate-minimax-value (lm operation form)
+  (let* ((answer-var (loop-minimax-answer-variable lm))
+	 (temp-var (loop-minimax-temp-variable lm))
+	 (flag-var (loop-minimax-flag-variable lm))
+	 (test
+	   (hide-variable-reference
+	     t (loop-minimax-answer-variable lm)
+	     `(,(ecase operation
+		  (min '<)
+		  (max '>))
+	       ,temp-var ,answer-var))))
+    `(progn
+       (setq ,temp-var ,form)
+       (when ,(if flag-var `(or (not ,flag-var) ,test) test)
+	 (setq ,@(and flag-var `(,flag-var t))
+	       ,answer-var ,temp-var)))))
+
+
+
+;;;; Loop Keyword Tables
+
+
+#|
+LOOP keyword tables are hash tables string keys and a test of EQUAL.
+
+The actual descriptive/dispatch structure used by LOOP is called a "loop
+universe" contains a few tables and parameterizations.  The basic idea is
+that we can provide a non-extensible ANSI-compatible loop environment,
+an extensible ANSI-superset loop environment, and (for such environments
+as CLOE) one which is "sufficiently close" to the old Genera-vintage
+LOOP for use by old user programs without requiring all of the old LOOP
+code to be loaded.
+|#
+
+
+;;;; Token Hackery
+
+
+;;;Compare two "tokens".  The first is the frob out of *LOOP-SOURCE-CODE*,
+;;; the second a symbol to check against.
+(defun loop-tequal (x1 x2)
+  (and (symbolp x1) (string= x1 x2)))
+
+
+(defun loop-tassoc (kwd alist)
+  (and (symbolp kwd) (assoc kwd alist :test #'string=)))
+
+
+(defun loop-tmember (kwd list)
+  (and (symbolp kwd) (member kwd list :test #'string=)))
+
+
+(defun loop-lookup-keyword (loop-token table)
+  (and (symbolp loop-token)
+       (values (gethash (symbol-name loop-token) table))))
+
+
+(defmacro loop-store-table-data (symbol table datum)
+  `(setf (gethash (symbol-name ,symbol) ,table) ,datum))
+
+
+(defstruct (loop-universe
+	     (:print-function print-loop-universe)
+	     (:copier nil)
+	     (:predicate nil))
+  keywords					;hash table, value = (fn-name . extra-data).
+  iteration-keywords				;hash table, value = (fn-name . extra-data).
+  for-keywords					;hash table, value = (fn-name . extra-data).
+  path-keywords					;hash table, value = (fn-name . extra-data).
+  type-symbols					;hash table of type SYMBOLS, test EQ, value = CL type specifier.
+  type-keywords					;hash table of type STRINGS, test EQUAL, value = CL type spec.
+  ansi						;NIL, T, or :EXTENDED.
+  implicit-for-required				;see loop-hack-iteration
+  )
+
+
+(defun print-loop-universe (u stream level)
+  (declare (ignore level))
+  (let ((str (case (loop-universe-ansi u)
+	       ((nil) "Non-ANSI")
+	       ((t) "ANSI")
+	       (:extended "Extended-ANSI")
+	       (t (loop-universe-ansi u)))))
+    ;;Cloe could be done with the above except for bootstrap lossage...
+    #+CLOE
+    (format stream "#<~S ~A ~X>" (type-of u) str (sys::address-of u))
+    #+Genera					;@@@@ This is reallly the ANSI definition.
+    (print-unreadable-object (u stream :type t :identity t)
+      (princ str stream))
+    #-(or Genera CLOE)
+    (format stream "#<~S ~A>" (type-of u) str)
+    ))
+
+
+;;;This is the "current" loop context in use when we are expanding a
+;;;loop.  It gets bound on each invocation of LOOP.
+(defvar *loop-universe*)
+
+
+(defun make-standard-loop-universe (&key keywords for-keywords iteration-keywords path-keywords
+				    type-keywords type-symbols ansi)
+  #-(and CLOE Source-Bootstrap) (check-type ansi (member nil t :extended))
+  (flet ((maketable (entries)
+	   (let* ((size (length entries))
+		  (ht (make-hash-table :size (if (< size 10) 10 size) :test #'equal)))
+	     (dolist (x entries) (setf (gethash (symbol-name (car x)) ht) (cadr x)))
+	     ht)))
+    (make-loop-universe
+      :keywords (maketable keywords)
+      :for-keywords (maketable for-keywords)
+      :iteration-keywords (maketable iteration-keywords)
+      :path-keywords (maketable path-keywords)
+      :ansi ansi
+      :implicit-for-required (not (null ansi))
+      :type-keywords (maketable type-keywords)
+      :type-symbols (let* ((size (length type-symbols))
+			   (ht (make-hash-table :size (if (< size 10) 10 size) :test #'eq)))
+		      (dolist (x type-symbols)
+			(if (atom x) (setf (gethash x ht) x) (setf (gethash (car x) ht) (cadr x))))
+		      ht)))) 
+
+
+;;;; Setq Hackery
+
+
+(defvar *loop-destructuring-hooks*
+	nil
+  "If not NIL, this must be a list of two things:
+a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.")
+
+
+(defun loop-make-psetq (frobs)
+  (and frobs
+       (loop-make-desetq
+	 (list (car frobs)
+	       (if (null (cddr frobs)) (cadr frobs)
+		   `(prog1 ,(cadr frobs)
+			   ,(loop-make-psetq (cddr frobs))))))))
+
+
+(defun loop-make-desetq (var-val-pairs)
+  (if (null var-val-pairs)
+      nil
+      (cons (if *loop-destructuring-hooks*
+		(cadr *loop-destructuring-hooks*)
+		'loop-really-desetq)
+	    var-val-pairs)))
+
+
+(defvar *loop-desetq-temporary*
+	(make-symbol "LOOP-DESETQ-TEMP"))
+
+
+(defmacro loop-really-desetq (&environment env &rest var-val-pairs)
+  (labels ((find-non-null (var)
+	     ;; see if there's any non-null thing here
+	     ;; recurse if the list element is itself a list
+	     (do ((tail var)) ((not (consp tail)) tail)
+	       (when (find-non-null (pop tail)) (return t))))
+	   (loop-desetq-internal (var val &optional temp)
+	     ;; returns a list of actions to be performed
+	     (typecase var
+	       (null
+		 (when (consp val)
+		   ;; don't lose possible side-effects
+		   (if (eq (car val) 'prog1)
+		       ;; these can come from psetq or desetq below.
+		       ;; throw away the value, keep the side-effects.
+		       ;;Special case is for handling an expanded POP.
+		       (mapcan #'(lambda (x)
+				   (and (consp x)
+					(or (not (eq (car x) 'car))
+					    (not (symbolp (cadr x)))
+					    (not (symbolp (setq x (macroexpand x env)))))
+					(cons x nil)))
+			       (cdr val))
+		       `(,val))))
+	       (cons
+		 (let* ((car (car var))
+			(cdr (cdr var))
+			(car-non-null (find-non-null car))
+			(cdr-non-null (find-non-null cdr)))
+		   (when (or car-non-null cdr-non-null)
+		     (if cdr-non-null
+			 (let* ((temp-p temp)
+				(temp (or temp *loop-desetq-temporary*))
+				(body #+LOOP-Prefer-POP `(,@(loop-desetq-internal
+							      car
+							      `(prog1 (car ,temp)
+								      (setq ,temp (cdr ,temp))))
+							  ,@(loop-desetq-internal cdr temp temp))
+				      #-LOOP-Prefer-POP `(,@(loop-desetq-internal car `(car ,temp))
+							  (setq ,temp (cdr ,temp))
+							  ,@(loop-desetq-internal cdr temp temp))))
+			   (if temp-p
+			       `(,@(unless (eq temp val)
+				     `((setq ,temp ,val)))
+				 ,@body)
+			       `((let ((,temp ,val))
+				   ,@body))))
+			 ;; no cdring to do
+			 (loop-desetq-internal car `(car ,val) temp)))))
+	       (otherwise
+		 (unless (eq var val)
+		   `((setq ,var ,val)))))))
+    (do ((actions))
+	((null var-val-pairs)
+	 (if (null (cdr actions)) (car actions) `(progn ,@(nreverse actions))))
+      (setq actions (revappend
+		      (loop-desetq-internal (pop var-val-pairs) (pop var-val-pairs))
+		      actions)))))
+
+
+;;;; LOOP-local variables
+
+;;;This is the "current" pointer into the LOOP source code.
+(defvar *loop-source-code*)
+
+
+;;;This is the pointer to the original, for things like NAMED that
+;;;insist on being in a particular position
+(defvar *loop-original-source-code*)
+
+
+;;;This is *loop-source-code* as of the "last" clause.  It is used
+;;;primarily for generating error messages (see loop-error, loop-warn).
+(defvar *loop-source-context*)
+
+
+;;;List of names for the LOOP, supplied by the NAMED clause.
+(defvar *loop-names*)
+
+;;;The macroexpansion environment given to the macro.
+(defvar *loop-macro-environment*)
+
+;;;This holds variable names specified with the USING clause.
+;;; See LOOP-NAMED-VARIABLE.
+(defvar *loop-named-variables*)
+
+;;; LETlist-like list being accumulated for one group of parallel bindings.
+(defvar *loop-variables*)
+
+;;;List of declarations being accumulated in parallel with
+;;;*loop-variables*.
+(defvar *loop-declarations*)
+
+;;;Used by LOOP for destructuring binding, if it is doing that itself.
+;;; See loop-make-variable.
+(defvar *loop-desetq-crocks*)
+
+;;; List of wrapping forms, innermost first, which go immediately inside
+;;; the current set of parallel bindings being accumulated in
+;;; *loop-variables*.  The wrappers are appended onto a body.  E.g.,
+;;; this list could conceivably has as its value ((with-open-file (g0001
+;;; g0002 ...))), with g0002 being one of the bindings in
+;;; *loop-variables* (this is why the wrappers go inside of the variable
+;;; bindings).
+(defvar *loop-wrappers*)
+
+;;;This accumulates lists of previous values of *loop-variables* and the
+;;;other lists  above, for each new nesting of bindings.  See
+;;;loop-bind-block.
+(defvar *loop-bind-stack*)
+
+;;;This is a LOOP-global variable for the (obsolete) NODECLARE clause
+;;;which inhibits  LOOP from actually outputting a type declaration for
+;;;an iteration (or any) variable.
+(defvar *loop-nodeclare*)
+
+;;;This is simply a list of LOOP iteration variables, used for checking
+;;;for duplications.
+(defvar *loop-iteration-variables*)
+
+
+;;;List of prologue forms of the loop, accumulated in reverse order.
+(defvar *loop-prologue*)
+
+(defvar *loop-before-loop*)
+(defvar *loop-body*)
+(defvar *loop-after-body*)
+
+;;;This is T if we have emitted any body code, so that iteration driving
+;;;clauses can be disallowed.   This is not strictly the same as
+;;;checking *loop-body*, because we permit some clauses  such as RETURN
+;;;to not be considered "real" body (so as to permit the user to "code"
+;;;an  abnormal return value "in loop").
+(defvar *loop-emitted-body*)
+
+
+;;;List of epilogue forms (supplied by FINALLY generally), accumulated
+;;; in reverse order.
+(defvar *loop-epilogue*)
+
+;;;List of epilogue forms which are supplied after the above "user"
+;;;epilogue.  "normal" termination return values are provide by putting
+;;;the return form in here.  Normally this is done using
+;;;loop-emit-final-value, q.v.
+(defvar *loop-after-epilogue*)
+
+;;;The "culprit" responsible for supplying a final value from the loop.
+;;;This  is so loop-emit-final-value can moan about multiple return
+;;;values being supplied.
+(defvar *loop-final-value-culprit*)
+
+;;;If not NIL, we are in some branch of a conditional.  Some clauses may
+;;;be disallowed.
+(defvar *loop-inside-conditional*)
+
+;;;If not NIL, this is a temporary bound around the loop for holding the
+;;;temporary  value for "it" in things like "when (f) collect it".  It
+;;;may be used as a supertemporary by some other things.
+(defvar *loop-when-it-variable*)
+
+;;;Sometimes we decide we need to fold together parts of the loop, but
+;;;some part of the generated iteration  code is different for the first
+;;;and remaining iterations.  This variable will be the temporary which 
+;;;is the flag used in the loop to tell whether we are in the first or
+;;;remaining iterations.
+(defvar *loop-never-stepped-variable*)
+
+;;;List of all the value-accumulation descriptor structures in the loop.
+;;; See loop-get-collection-info.
+(defvar *loop-collection-cruft*)		; for multiple COLLECTs (etc)
+
+
+;;;; Code Analysis Stuff
+
+
+(defun loop-constant-fold-if-possible (form &optional expected-type)
+  #+Genera (declare (values new-form constantp constant-value))
+  (let ((new-form form) (constantp nil) (constant-value nil))
+    #+Genera (setq new-form (compiler:optimize-form form *loop-macro-environment*
+						    :repeat t
+						    :do-macro-expansion t
+						    :do-named-constants t
+						    :do-inline-forms t
+						    :do-optimizers t
+						    :do-constant-folding t
+						    :do-function-args t)
+		   constantp (constantp new-form *loop-macro-environment*)
+		   constant-value (and constantp (lt:evaluate-constant new-form *loop-macro-environment*)))
+    #-Genera (when (setq constantp (constantp new-form))
+	       (setq constant-value (eval new-form)))
+    (when (and constantp expected-type)
+      (unless (typep constant-value expected-type)
+	(loop-warn "The form ~S evaluated to ~S, which was not of the anticipated type ~S."
+		   form constant-value expected-type)
+	(setq constantp nil constant-value nil)))
+    (values new-form constantp constant-value)))
+
+
+(defun loop-constantp (form)
+  #+Genera (constantp form *loop-macro-environment*)
+  #-Genera (constantp form))
+
+
+;;;; LOOP Iteration Optimization
+
+(defvar *loop-duplicate-code*
+	nil)
+
+
+(defvar *loop-iteration-flag-variable*
+	(make-symbol "LOOP-NOT-FIRST-TIME"))
+
+
+(defun loop-code-duplication-threshold (env)
+  (multiple-value-bind (speed space) (loop-optimization-quantities env)
+    (+ 40 (* (- speed space) 10))))
+
+
+(defmacro loop-body (&environment env
+		     prologue
+		     before-loop
+		     main-body
+		     after-loop
+		     epilogue
+		     &aux rbefore rafter flagvar)
+  (unless (= (length before-loop) (length after-loop))
+    (error "LOOP-BODY called with non-synched before- and after-loop lists."))
+  ;;All our work is done from these copies, working backwards from the end:
+  (setq rbefore (reverse before-loop) rafter (reverse after-loop))
+  (labels ((psimp (l)
+	     (let ((ans nil))
+	       (dolist (x l)
+		 (when x
+		   (push x ans)
+		   (when (and (consp x) (member (car x) '(go return return-from)))
+		     (return nil))))
+	       (nreverse ans)))
+	   (pify (l) (if (null (cdr l)) (car l) `(progn ,@l)))
+	   (makebody ()
+	     (let ((form `(tagbody
+			    ,@(psimp (append prologue (nreverse rbefore)))
+			 next-loop
+			    ,@(psimp (append main-body (nreconc rafter `((go next-loop)))))
+			 end-loop
+			    ,@(psimp epilogue))))
+	       (if flagvar `(let ((,flagvar nil)) ,form) form))))
+    (when (or *loop-duplicate-code* (not rbefore))
+      (return-from loop-body (makebody)))
+    ;; This outer loop iterates once for each not-first-time flag test generated
+    ;; plus once more for the forms that don't need a flag test
+    (do ((threshold (loop-code-duplication-threshold env))) (nil)
+      (declare (fixnum threshold))
+      ;; Go backwards from the ends of before-loop and after-loop merging all the equivalent
+      ;; forms into the body.
+      (do () ((or (null rbefore) (not (equal (car rbefore) (car rafter)))))
+	(push (pop rbefore) main-body)
+	(pop rafter))
+      (unless rbefore (return (makebody)))
+      ;; The first forms in rbefore & rafter (which are the chronologically
+      ;; last forms in the list) differ, therefore they cannot be moved
+      ;; into the main body.  If everything that chronologically precedes
+      ;; them either differs or is equal but is okay to duplicate, we can
+      ;; just put all of rbefore in the prologue and all of rafter after
+      ;; the body.  Otherwise, there is something that is not okay to
+      ;; duplicate, so it and everything chronologically after it in
+      ;; rbefore and rafter must go into the body, with a flag test to
+      ;; distinguish the first time around the loop from later times.
+      ;; What chronologically precedes the non-duplicatable form will
+      ;; be handled the next time around the outer loop.
+      (do ((bb rbefore (cdr bb)) (aa rafter (cdr aa)) (lastdiff nil) (count 0) (inc nil))
+	  ((null bb) (return-from loop-body (makebody)))	;Did it.
+	(cond ((not (equal (car bb) (car aa))) (setq lastdiff bb count 0))
+	      ((or (not (setq inc (estimate-code-size (car bb) env)))
+		   (> (incf count inc) threshold))
+	       ;; Ok, we have found a non-duplicatable piece of code.  Everything
+	       ;; chronologically after it must be in the central body.
+	       ;; Everything chronologically at and after lastdiff goes into the
+	       ;; central body under a flag test.
+	       (let ((then nil) (else nil))
+		 (do () (nil)
+		   (push (pop rbefore) else)
+		   (push (pop rafter) then)
+		   (when (eq rbefore (cdr lastdiff)) (return)))
+		 (unless flagvar
+		   (push `(setq ,(setq flagvar *loop-iteration-flag-variable*) t) else))
+		 (push `(if ,flagvar ,(pify (psimp then)) ,(pify (psimp else)))
+		       main-body))
+	       ;; Everything chronologically before lastdiff until the non-duplicatable form (car bb) 
+	       ;; is the same in rbefore and rafter so just copy it into the body
+	       (do () (nil)
+		 (pop rafter)
+		 (push (pop rbefore) main-body)
+		 (when (eq rbefore (cdr bb)) (return)))
+	       (return)))))))
+
+
+
+(defun duplicatable-code-p (expr env)
+  (if (null expr) 0
+      (let ((ans (estimate-code-size expr env)))
+	(declare (fixnum ans))
+	;;@@@@ Use (DECLARATION-INFORMATION 'OPTIMIZE ENV) here to get an alist of
+	;; optimize quantities back to help quantify how much code we are willing to
+	;; duplicate.
+	ans)))
+
+
+(defvar *special-code-sizes*
+	'((return 0) (progn 0)
+	  (null 1) (not 1) (eq 1) (car 1) (cdr 1)
+	  (when 1) (unless 1) (if 1)
+	  (caar 2) (cadr 2) (cdar 2) (cddr 2)
+	  (caaar 3) (caadr 3) (cadar 3) (caddr 3) (cdaar 3) (cdadr 3) (cddar 3) (cdddr 3)
+	  (caaaar 4) (caaadr 4) (caadar 4) (caaddr 4)
+	  (cadaar 4) (cadadr 4) (caddar 4) (cadddr 4)
+	  (cdaaar 4) (cdaadr 4) (cdadar 4) (cdaddr 4)
+	  (cddaar 4) (cddadr 4) (cdddar 4) (cddddr 4)))
+
+
+(defvar *estimate-code-size-punt*
+	'(block
+	   do do* dolist
+	   flet
+	   labels lambda let let* locally
+	   macrolet multiple-value-bind
+	   prog prog*
+	   symbol-macrolet
+	   tagbody
+	   unwind-protect
+	   with-open-file))
+
+
+(defun destructuring-size (x)
+  (do ((x x (cdr x)) (n 0 (+ (destructuring-size (car x)) n)))
+      ((atom x) (+ n (if (null x) 0 1)))))
+
+
+(defun estimate-code-size (x env)
+  (catch 'estimate-code-size
+    (estimate-code-size-1 x env)))
+
+
+(defun estimate-code-size-1 (x env)
+  (flet ((list-size (l)
+	   (let ((n 0))
+	     (declare (fixnum n))
+	     (dolist (x l n) (incf n (estimate-code-size-1 x env))))))
+    ;;@@@@ ???? (declare (function list-size (list) fixnum))
+    (cond ((constantp x #+Genera env) 1)
+	  ((symbolp x) (multiple-value-bind (new-form expanded-p) (macroexpand-1 x env)
+			 (if expanded-p (estimate-code-size-1 new-form env) 1)))
+	  ((atom x) 1)				;??? self-evaluating???
+	  ((symbolp (car x))
+	   (let ((fn (car x)) (tem nil) (n 0))
+	     (declare (symbol fn) (fixnum n))
+	     (macrolet ((f (overhead &optional (args nil args-p))
+			  `(the fixnum (+ (the fixnum ,overhead)
+					  (the fixnum (list-size ,(if args-p args '(cdr x))))))))
+	       (cond ((setq tem (get fn 'estimate-code-size))
+		      (typecase tem
+			(fixnum (f tem))
+			(t (funcall tem x env))))
+		     ((setq tem (assoc fn *special-code-sizes*)) (f (second tem)))
+		     #+Genera
+		     ((eq fn 'compiler:invisible-references) (list-size (cddr x)))
+		     ((eq fn 'cond)
+		      (dolist (clause (cdr x) n) (incf n (list-size clause)) (incf n)))
+		     ((eq fn 'desetq)
+		      (do ((l (cdr x) (cdr l))) ((null l) n)
+			(setq n (+ n (destructuring-size (car l)) (estimate-code-size-1 (cadr l) env)))))
+		     ((member fn '(setq psetq))
+		      (do ((l (cdr x) (cdr l))) ((null l) n)
+			(setq n (+ n (estimate-code-size-1 (cadr l) env) 1))))
+		     ((eq fn 'go) 1)
+		     ((eq fn 'function)
+		      ;;This skirts the issue of implementationally-defined lambda macros
+		      ;; by recognizing CL function names and nothing else.
+		      (if (or (symbolp (cadr x))
+			      (and (consp (cadr x)) (eq (caadr x) 'setf)))
+			  1
+			  (throw 'duplicatable-code-p nil)))
+		     ((eq fn 'multiple-value-setq) (f (length (second x)) (cddr x)))
+		     ((eq fn 'return-from) (1+ (estimate-code-size-1 (third x) env)))
+		     ((or (special-operator-p fn) (member fn *estimate-code-size-punt*))
+		      (throw 'estimate-code-size nil))
+		     (t (multiple-value-bind (new-form expanded-p) (macroexpand-1 x env)
+			  (if expanded-p
+			      (estimate-code-size-1 new-form env)
+			      (f 3))))))))
+	  (t (throw 'estimate-code-size nil)))))
+
+
+;;;; Loop Errors
+
+
+(defun loop-context ()
+  (do ((l *loop-source-context* (cdr l)) (new nil (cons (car l) new)))
+      ((eq l (cdr *loop-source-code*)) (nreverse new))))
+
+
+(defun loop-error (format-string &rest format-args)
+  #+(or Genera CLOE) (declare (dbg:error-reporter))
+  #+Genera (setq format-args (copy-list format-args))	;Don't ask.
+  (error "~?~%Current LOOP context:~{ ~S~}." format-string format-args (loop-context)))
+
+
+(defun loop-warn (format-string &rest format-args)
+  (warn "~?~%Current LOOP context:~{ ~S~}." format-string format-args (loop-context)))
+
+
+(defun loop-check-data-type (specified-type required-type
+			     &optional (default-type required-type))
+  (if (null specified-type)
+      default-type
+      (multiple-value-bind (a b) (subtypep specified-type required-type)
+	(cond ((not b)
+	       (loop-warn "LOOP couldn't verify that ~S is a subtype of the required type ~S."
+			  specified-type required-type))
+	      ((not a)
+	       (loop-error "Specified data type ~S is not a subtype of ~S."
+			   specified-type required-type)))
+	specified-type)))
+
+
+;;;INTERFACE: Traditional, ANSI, Lucid.
+(defmacro loop-finish () 
+  "Causes the iteration to terminate \"normally\", the same as implicit
+termination by an iteration driving clause, or by use of WHILE or
+UNTIL -- the epilogue code (if any) will be run, and any implicitly
+collected result will be returned as the value of the LOOP."
+  '(go end-loop))
+
+
+
+
+(defun loop-translate (*loop-source-code* *loop-macro-environment* *loop-universe*)
+  (let ((*loop-original-source-code* *loop-source-code*)
+	(*loop-source-context* nil)
+	(*loop-iteration-variables* nil)
+	(*loop-variables* nil)
+	(*loop-nodeclare* nil)
+	(*loop-named-variables* nil)
+	(*loop-declarations* nil)
+	(*loop-desetq-crocks* nil)
+	(*loop-bind-stack* nil)
+	(*loop-prologue* nil)
+	(*loop-wrappers* nil)
+	(*loop-before-loop* nil)
+	(*loop-body* nil)
+	(*loop-emitted-body* nil)
+	(*loop-after-body* nil)
+	(*loop-epilogue* nil)
+	(*loop-after-epilogue* nil)
+	(*loop-final-value-culprit* nil)
+	(*loop-inside-conditional* nil)
+	(*loop-when-it-variable* nil)
+	(*loop-never-stepped-variable* nil)
+	(*loop-names* nil)
+	(*loop-collection-cruft* nil))
+    (loop-iteration-driver)
+    (loop-bind-block)
+    (let ((answer `(loop-body
+		     ,(nreverse *loop-prologue*)
+		     ,(nreverse *loop-before-loop*)
+		     ,(nreverse *loop-body*)
+		     ,(nreverse *loop-after-body*)
+		     ,(nreconc *loop-epilogue* (nreverse *loop-after-epilogue*)))))
+      (do () (nil)
+	(setq answer `(block ,(pop *loop-names*) ,answer))
+	(unless *loop-names* (return nil)))
+      (dolist (entry *loop-bind-stack*)
+	(let ((vars (first entry))
+	      (dcls (second entry))
+	      (crocks (third entry))
+	      (wrappers (fourth entry)))
+	  (dolist (w wrappers)
+	    (setq answer (append w (list answer))))
+	  (when (or vars dcls crocks)
+	    (let ((forms (list answer)))
+	      ;;(when crocks (push crocks forms))
+	      (when dcls (push `(declare ,@dcls) forms))
+	      (setq answer `(,(cond ((not vars) 'locally)
+				    (*loop-destructuring-hooks* (first *loop-destructuring-hooks*))
+				    (t 'let))
+			     ,vars
+			     ,@(if crocks
+				   `((destructuring-bind ,@crocks
+					 ,@forms))
+				 forms)))))))
+      answer)))
+
+
+(defun loop-iteration-driver ()
+  (do () ((null *loop-source-code*))
+    (let ((keyword (car *loop-source-code*)) (tem nil))
+      (cond ((not (symbolp keyword))
+	     (loop-error "~S found where LOOP keyword expected." keyword))
+	    (t (setq *loop-source-context* *loop-source-code*)
+	       (loop-pop-source)
+	       (cond ((setq tem (loop-lookup-keyword keyword (loop-universe-keywords *loop-universe*)))
+		      ;;It's a "miscellaneous" toplevel LOOP keyword (do, collect, named, etc.)
+		      (apply (symbol-function (first tem)) (rest tem)))
+		     ((setq tem (loop-lookup-keyword keyword (loop-universe-iteration-keywords *loop-universe*)))
+		      (loop-hack-iteration tem))
+		     ((loop-tmember keyword '(and else))
+		      ;; Alternative is to ignore it, ie let it go around to the next keyword...
+		      (loop-error "Secondary clause misplaced at top level in LOOP macro: ~S ~S ~S ..."
+				  keyword (car *loop-source-code*) (cadr *loop-source-code*)))
+		     (t (loop-error "~S is an unknown keyword in LOOP macro." keyword))))))))
+
+
+
+(defun loop-pop-source ()
+  (if *loop-source-code*
+      (pop *loop-source-code*)
+      (loop-error "LOOP source code ran out when another token was expected.")))
+
+
+(defun loop-get-progn ()
+  (do ((forms (list (loop-pop-source)) (cons (loop-pop-source) forms))
+       (nextform (car *loop-source-code*) (car *loop-source-code*)))
+      ((atom nextform)
+       (if (null (cdr forms)) (car forms) (cons 'progn (nreverse forms))))))
+
+
+(defun loop-get-form ()
+  (if *loop-source-code*
+      (loop-pop-source)
+      (loop-error "LOOP code ran out where a form was expected.")))
+
+
+(defun loop-construct-return (form)
+  `(return-from ,(car *loop-names*) ,form))
+
+
+(defun loop-pseudo-body (form)
+  (cond ((or *loop-emitted-body* *loop-inside-conditional*) (push form *loop-body*))
+	(t (push form *loop-before-loop*) (push form *loop-after-body*))))
+
+(defun loop-emit-body (form)
+  (setq *loop-emitted-body* t)
+  (loop-pseudo-body form))
+
+(defun loop-emit-final-value (form)
+  (push (loop-construct-return form) *loop-after-epilogue*)
+  (when *loop-final-value-culprit*
+    (loop-warn "LOOP clause is providing a value for the iteration,~@
+	        however one was already established by a ~S clause."
+	       *loop-final-value-culprit*))
+  (setq *loop-final-value-culprit* (car *loop-source-context*)))
+
+
+(defun loop-disallow-conditional (&optional kwd)
+  #+(or Genera CLOE) (declare (dbg:error-reporter))
+  (when *loop-inside-conditional*
+    (loop-error "~:[This LOOP~;The LOOP ~:*~S~] clause is not permitted inside a conditional." kwd)))
+
+
+;;;; Loop Types
+
+
+(defun loop-typed-init (data-type)
+  (when (and data-type (subtypep data-type 'number))
+    (if (or (subtypep data-type 'float) (subtypep data-type '(complex float)))
+	(coerce 0 data-type)
+	0)))
+
+
+(defun loop-optional-type (&optional variable)
+  ;;No variable specified implies that no destructuring is permissible.
+  (and *loop-source-code*			;Don't get confused by NILs...
+       (let ((z (car *loop-source-code*)))
+	 (cond ((loop-tequal z 'of-type)
+		;;This is the syntactically unambigous form in that the form of the
+		;; type specifier does not matter.  Also, it is assumed that the
+		;; type specifier is unambiguously, and without need of translation,
+		;; a common lisp type specifier or pattern (matching the variable) thereof.
+		(loop-pop-source)
+		(loop-pop-source))
+	       ((symbolp z)
+		;;This is the (sort of) "old" syntax, even though we didn't used to support all of
+		;; these type symbols.
+		(let ((type-spec (or (gethash z (loop-universe-type-symbols *loop-universe*))
+				     (gethash (symbol-name z) (loop-universe-type-keywords *loop-universe*)))))
+		  (when type-spec
+		    (loop-pop-source)
+		    type-spec)))
+	       (t 
+		;;This is our sort-of old syntax.  But this is only valid for when we are destructuring,
+		;; so we will be compulsive (should we really be?) and require that we in fact be
+		;; doing variable destructuring here.  We must translate the old keyword pattern typespec
+		;; into a fully-specified pattern of real type specifiers here.
+		(if (consp variable)
+		    (unless (consp z)
+		     (loop-error
+			"~S found where a LOOP keyword, LOOP type keyword, or LOOP type pattern expected."
+			z))
+		    (loop-error "~S found where a LOOP keyword or LOOP type keyword expected." z))
+		(loop-pop-source)
+		(labels ((translate (k v)
+			   (cond ((null k) nil)
+				 ((atom k)
+				  (replicate
+				    (or (gethash k (loop-universe-type-symbols *loop-universe*))
+					(gethash (symbol-name k) (loop-universe-type-keywords *loop-universe*))
+					(loop-error
+					  "Destructuring type pattern ~S contains unrecognized type keyword ~S."
+					  z k))
+				    v))
+				 ((atom v)
+				  (loop-error
+				    "Destructuring type pattern ~S doesn't match variable pattern ~S."
+				    z variable))
+				 (t (cons (translate (car k) (car v)) (translate (cdr k) (cdr v))))))
+			 (replicate (typ v)
+			   (if (atom v) typ (cons (replicate typ (car v)) (replicate typ (cdr v))))))
+		  (translate z variable)))))))
+
+
+
+;;;; Loop Variables
+
+
+(defun loop-bind-block ()
+  (when (or *loop-variables* *loop-declarations* *loop-wrappers*)
+    (push (list (nreverse *loop-variables*) *loop-declarations* *loop-desetq-crocks* *loop-wrappers*)
+	  *loop-bind-stack*)
+    (setq *loop-variables* nil
+	  *loop-declarations* nil
+	  *loop-desetq-crocks* nil
+	  *loop-wrappers* nil)))
+
+
+(defun loop-make-variable (name initialization dtype &optional iteration-variable-p)
+  (cond ((null name)
+	 (cond ((not (null initialization))
+		(push (list (setq name (loop-gentemp 'loop-ignore-))
+			    initialization)
+		      *loop-variables*)
+		(push `(ignore ,name) *loop-declarations*))))
+	((atom name)
+	 (cond (iteration-variable-p
+		(if (member name *loop-iteration-variables*)
+		    (loop-error "Duplicated LOOP iteration variable ~S." name)
+		    (push name *loop-iteration-variables*)))
+	       ((assoc name *loop-variables*)
+		(loop-error "Duplicated variable ~S in LOOP parallel binding." name)))
+	 (unless (symbolp name)
+	   (loop-error "Bad variable ~S somewhere in LOOP." name))
+	 (loop-declare-variable name dtype)
+	 ;; We use ASSOC on this list to check for duplications (above),
+	 ;; so don't optimize out this list:
+	 (push (list name (or initialization (loop-typed-init dtype)))
+	       *loop-variables*))
+	(initialization
+	 (cond (*loop-destructuring-hooks*
+		(loop-declare-variable name dtype)
+		(push (list name initialization) *loop-variables*))
+	       (t (let ((newvar (loop-gentemp 'loop-destructure-)))
+		    (push (list newvar initialization) *loop-variables*)
+		    ;; *LOOP-DESETQ-CROCKS* gathered in reverse order.
+		    (setq *loop-desetq-crocks*
+		      (list* name newvar *loop-desetq-crocks*))
+		    #+ignore
+		    (loop-make-variable name nil dtype iteration-variable-p)))))
+	(t (let ((tcar nil) (tcdr nil))
+	     (if (atom dtype) (setq tcar (setq tcdr dtype))
+		 (setq tcar (car dtype) tcdr (cdr dtype)))
+	     (loop-make-variable (car name) nil tcar iteration-variable-p)
+	     (loop-make-variable (cdr name) nil tcdr iteration-variable-p))))
+  name)
+
+
+(defun loop-make-iteration-variable (name initialization dtype)
+  (loop-make-variable name initialization dtype t))
+
+
+(defun loop-declare-variable (name dtype)
+  (cond ((or (null name) (null dtype) (eq dtype t)) nil)
+	((symbolp name)
+	 (unless (or (eq dtype t) (member (the symbol name) *loop-nodeclare*))
+	   (push `(type ,dtype ,name) *loop-declarations*)))
+	((consp name)
+	 (cond ((consp dtype)
+		(loop-declare-variable (car name) (car dtype))
+		(loop-declare-variable (cdr name) (cdr dtype)))
+	       (t (loop-declare-variable (car name) dtype)
+		  (loop-declare-variable (cdr name) dtype))))
+	(t (error "Invalid LOOP variable passed in: ~S." name))))
+
+
+(defun loop-maybe-bind-form (form data-type)
+  (if (loop-constantp form)
+      form
+      (loop-make-variable (loop-gentemp 'loop-bind-) form data-type)))
+
+
+
+(defun loop-do-if (for negatep)
+  (let ((form (loop-get-form)) (*loop-inside-conditional* t) (it-p nil))
+    (flet ((get-clause (for)
+	     (do ((body nil)) (nil)
+	       (let ((key (car *loop-source-code*)) (*loop-body* nil) data)
+		 (cond ((not (symbolp key))
+			(loop-error
+			  "~S found where keyword expected getting LOOP clause after ~S."
+			  key for))
+		       (t (setq *loop-source-context* *loop-source-code*)
+			  (loop-pop-source)
+			  (when (loop-tequal (car *loop-source-code*) 'it)
+			    (setq *loop-source-code*
+				  (cons (or it-p (setq it-p (loop-when-it-variable)))
+					(cdr *loop-source-code*))))
+			  (cond ((or (not (setq data (loop-lookup-keyword
+						       key (loop-universe-keywords *loop-universe*))))
+				     (progn (apply (symbol-function (car data)) (cdr data))
+					    (null *loop-body*)))
+				 (loop-error
+				   "~S does not introduce a LOOP clause that can follow ~S."
+				   key for))
+				(t (setq body (nreconc *loop-body* body)))))))
+	       (if (loop-tequal (car *loop-source-code*) :and)
+		   (loop-pop-source)
+		   (return (if (cdr body) `(progn ,@(nreverse body)) (car body)))))))
+      (let ((then (get-clause for))
+	    (else (when (loop-tequal (car *loop-source-code*) :else)
+		    (loop-pop-source)
+		    (list (get-clause :else)))))
+	(when (loop-tequal (car *loop-source-code*) :end)
+	  (loop-pop-source))
+	(when it-p (setq form `(setq ,it-p ,form)))
+	(loop-pseudo-body
+	  `(if ,(if negatep `(not ,form) form)
+	       ,then
+	       ,@else))))))
+
+
+(defun loop-do-initially ()
+  (loop-disallow-conditional :initially)
+  (push (loop-get-progn) *loop-prologue*))
+
+(defun loop-do-finally ()
+  (loop-disallow-conditional :finally)
+  (push (loop-get-progn) *loop-epilogue*))
+
+(defun loop-do-do ()
+  (loop-emit-body (loop-get-progn)))
+
+(defun loop-do-named ()
+  (let ((name (loop-pop-source)))
+    (unless (symbolp name)
+      (loop-error "~S is an invalid name for your LOOP." name))
+    (when (or *loop-before-loop* *loop-body* *loop-after-epilogue* *loop-inside-conditional*)
+      (loop-error "The NAMED ~S clause occurs too late." name))
+    (when *loop-names*
+      (loop-error "You may only use one NAMED clause in your loop: NAMED ~S ... NAMED ~S."
+		  (car *loop-names*) name))
+    (setq *loop-names* (list name nil))))
+
+(defun loop-do-return ()
+  (loop-pseudo-body (loop-construct-return (loop-get-form))))
+
+
+;;;; Value Accumulation: List
+
+
+(defstruct (loop-collector
+	     (:copier nil)
+	     (:predicate nil))
+  name
+  class
+  (history nil)
+  (tempvars nil)
+  dtype
+  (data nil))						;collector-specific data
+
+
+(defun loop-get-collection-info (collector class default-type)
+  (let ((form (loop-get-form))
+	(dtype (and (not (loop-universe-ansi *loop-universe*)) (loop-optional-type)))
+	(name (when (loop-tequal (car *loop-source-code*) 'into)
+		(loop-pop-source)
+		(loop-pop-source))))
+    (when (not (symbolp name))
+      (loop-error "Value accumulation recipient name, ~S, is not a symbol." name))
+    (unless dtype
+      (setq dtype (or (loop-optional-type) default-type)))
+    (let ((cruft (find (the symbol name) *loop-collection-cruft*
+		       :key #'loop-collector-name)))
+      (cond ((not cruft)
+	     (push (setq cruft (make-loop-collector
+				 :name name :class class
+				 :history (list collector) :dtype dtype))
+		   *loop-collection-cruft*))
+	    (t (unless (eq (loop-collector-class cruft) class)
+		 (loop-error
+		   "Incompatible kinds of LOOP value accumulation specified for collecting~@
+		    ~:[as the value of the LOOP~;~:*INTO ~S~]: ~S and ~S."
+		   name (car (loop-collector-history cruft)) collector))
+	       (unless (equal dtype (loop-collector-dtype cruft))
+		 (loop-warn
+		   "Unequal datatypes specified in different LOOP value accumulations~@
+		   into ~S: ~S and ~S."
+		   name dtype (loop-collector-dtype cruft))
+		 (when (eq (loop-collector-dtype cruft) t)
+		   (setf (loop-collector-dtype cruft) dtype)))
+	       (push collector (loop-collector-history cruft))))
+      (values cruft form))))
+
+
+(defun loop-list-collection (specifically)	;NCONC, LIST, or APPEND
+  (multiple-value-bind (lc form) (loop-get-collection-info specifically 'list 'list)
+    (let ((tempvars (loop-collector-tempvars lc)))
+      (unless tempvars
+	(setf (loop-collector-tempvars lc)
+	      (setq tempvars (list* (loop-gentemp 'loop-list-head-)
+				    (loop-gentemp 'loop-list-tail-)
+				    (and (loop-collector-name lc)
+					 (list (loop-collector-name lc))))))
+	(push `(with-loop-list-collection-head ,tempvars) *loop-wrappers*)
+	(unless (loop-collector-name lc)
+	  (loop-emit-final-value `(loop-collect-answer ,(car tempvars) ,@(cddr tempvars)))))
+      (ecase specifically
+	(list (setq form `(list ,form)))
+	(nconc nil)
+	(append (unless (and (consp form) (eq (car form) 'list))
+		  (setq form `(loop-copylist* ,form)))))
+      (loop-emit-body `(loop-collect-rplacd ,tempvars ,form)))))
+
+
+;;;; Value Accumulation: max, min, sum, count.
+
+
+
+(defun loop-sum-collection (specifically required-type default-type)	;SUM, COUNT
+  (multiple-value-bind (lc form)
+      (loop-get-collection-info specifically 'sum default-type)
+    (loop-check-data-type (loop-collector-dtype lc) required-type)
+    (let ((tempvars (loop-collector-tempvars lc)))
+      (unless tempvars
+	(setf (loop-collector-tempvars lc)
+	      (setq tempvars (list (loop-make-variable
+				     (or (loop-collector-name lc)
+					 (loop-gentemp 'loop-sum-))
+				     nil (loop-collector-dtype lc)))))
+	(unless (loop-collector-name lc)
+	  (loop-emit-final-value (car (loop-collector-tempvars lc)))))
+      (loop-emit-body
+	(if (eq specifically 'count)
+	    `(when ,form
+	       (setq ,(car tempvars)
+		     ,(hide-variable-reference t (car tempvars) `(1+ ,(car tempvars)))))
+	    `(setq ,(car tempvars)
+		   (+ ,(hide-variable-reference t (car tempvars) (car tempvars))
+		      ,form)))))))
+
+
+
+(defun loop-maxmin-collection (specifically)
+  (multiple-value-bind (lc form)
+      (loop-get-collection-info specifically 'maxmin *loop-real-data-type*)
+    (loop-check-data-type (loop-collector-dtype lc) *loop-real-data-type*)
+    (let ((data (loop-collector-data lc)))
+      (unless data
+	(setf (loop-collector-data lc)
+	      (setq data (make-loop-minimax
+			   (or (loop-collector-name lc) (loop-gentemp 'loop-maxmin-))
+			   (loop-collector-dtype lc))))
+	(unless (loop-collector-name lc)
+	  (loop-emit-final-value (loop-minimax-answer-variable data))))
+      (loop-note-minimax-operation specifically data)
+      (push `(with-minimax-value ,data) *loop-wrappers*)
+      (loop-emit-body `(loop-accumulate-minimax-value ,data ,specifically ,form))
+      )))
+
+
+;;;; Value Accumulation:  Aggregate Booleans
+
+;;;ALWAYS and NEVER.
+;;; Under ANSI these are not permitted to appear under conditionalization.
+(defun loop-do-always (restrictive negate)
+  (let ((form (loop-get-form)))
+    (when restrictive (loop-disallow-conditional))
+    (loop-emit-body `(,(if negate 'when 'unless) ,form
+		      ,(loop-construct-return nil)))
+    (loop-emit-final-value t)))
+
+
+
+;;;THERIS.
+;;; Under ANSI this is not permitted to appear under conditionalization.
+(defun loop-do-thereis (restrictive)
+  (when restrictive (loop-disallow-conditional))
+  (loop-emit-body `(when (setq ,(loop-when-it-variable) ,(loop-get-form))
+		     ,(loop-construct-return *loop-when-it-variable*))))
+
+
+(defun loop-do-while (negate kwd &aux (form (loop-get-form)))
+  (loop-disallow-conditional kwd)
+  (loop-pseudo-body `(,(if negate 'when 'unless) ,form (go end-loop))))
+
+
+(defun loop-do-with ()
+  (loop-disallow-conditional :with)
+  (do ((var) (val) (dtype)) (nil)
+    (setq var (loop-pop-source)
+	  dtype (loop-optional-type var)
+	  val (cond ((loop-tequal (car *loop-source-code*) :=)
+		     (loop-pop-source)
+		     (loop-get-form))
+		    (t nil)))
+    (loop-make-variable var val dtype)
+    (if (loop-tequal (car *loop-source-code*) :and)
+	(loop-pop-source)
+	(return (loop-bind-block)))))
+
+
+;;;; The iteration driver
+
+(defun loop-hack-iteration (entry)
+  (flet ((make-endtest (list-of-forms)
+	   (cond ((null list-of-forms) nil)
+		 ((member t list-of-forms) '(go end-loop))
+		 (t `(when ,(if (null (cdr (setq list-of-forms (nreverse list-of-forms))))
+				(car list-of-forms)
+				(cons 'or list-of-forms))
+		       (go end-loop))))))
+    (do ((pre-step-tests nil)
+	 (steps nil)
+	 (post-step-tests nil)
+	 (pseudo-steps nil)
+	 (pre-loop-pre-step-tests nil)
+	 (pre-loop-steps nil)
+	 (pre-loop-post-step-tests nil)
+	 (pre-loop-pseudo-steps nil)
+	 (tem) (data))
+	(nil)
+      ;; Note we collect endtests in reverse order, but steps in correct
+      ;; order.  MAKE-ENDTEST does the nreverse for us.
+      (setq tem (setq data (apply (symbol-function (first entry)) (rest entry))))
+      (and (car tem) (push (car tem) pre-step-tests))
+      (setq steps (nconc steps (loop-copylist* (car (setq tem (cdr tem))))))
+      (and (car (setq tem (cdr tem))) (push (car tem) post-step-tests))
+      (setq pseudo-steps (nconc pseudo-steps (loop-copylist* (car (setq tem (cdr tem))))))
+      (setq tem (cdr tem))
+      (when *loop-emitted-body*
+	(loop-error "Iteration in LOOP follows body code."))
+      (unless tem (setq tem data))
+      (when (car tem) (push (car tem) pre-loop-pre-step-tests))
+      (setq pre-loop-steps (nconc pre-loop-steps (loop-copylist* (car (setq tem (cdr tem))))))
+      (when (car (setq tem (cdr tem))) (push (car tem) pre-loop-post-step-tests))
+      (setq pre-loop-pseudo-steps (nconc pre-loop-pseudo-steps (loop-copylist* (cadr tem))))
+      (unless (loop-tequal (car *loop-source-code*) :and)
+	(setq *loop-before-loop* (list* (loop-make-desetq pre-loop-pseudo-steps)
+					(make-endtest pre-loop-post-step-tests)
+					(loop-make-psetq pre-loop-steps)
+					(make-endtest pre-loop-pre-step-tests)
+					*loop-before-loop*)
+	      *loop-after-body* (list* (loop-make-desetq pseudo-steps)
+				       (make-endtest post-step-tests)
+				       (loop-make-psetq steps)
+				       (make-endtest pre-step-tests)
+				       *loop-after-body*))
+	(loop-bind-block)
+	(return nil))
+      (loop-pop-source)				; flush the "AND"
+      (when (and (not (loop-universe-implicit-for-required *loop-universe*))
+		 (setq tem (loop-lookup-keyword
+			     (car *loop-source-code*)
+			     (loop-universe-iteration-keywords *loop-universe*))))
+	;;Latest ANSI clarification is that the FOR/AS after the AND must NOT be supplied.
+	(loop-pop-source)
+	(setq entry tem)))))
+
+
+;;;; Main Iteration Drivers
+
+
+;FOR variable keyword ..args..
+(defun loop-do-for ()
+  (let* ((var (loop-pop-source))
+	 (data-type (loop-optional-type var))
+	 (keyword (loop-pop-source))
+	 (first-arg nil)
+	 (tem nil))
+    (setq first-arg (loop-get-form))
+    (unless (and (symbolp keyword)
+		 (setq tem (loop-lookup-keyword
+			     keyword
+			     (loop-universe-for-keywords *loop-universe*))))
+      (loop-error "~S is an unknown keyword in FOR or AS clause in LOOP." keyword))
+    (apply (car tem) var first-arg data-type (cdr tem))))
+
+
+(defun loop-do-repeat ()
+  (let ((form (loop-get-form))
+	(type (loop-check-data-type (loop-optional-type) *loop-real-data-type*)))
+    (when (and (consp form) (eq (car form) 'the) (subtypep (second form) type))
+      (setq type (second form)))
+    (multiple-value-bind (number constantp value)
+	(loop-constant-fold-if-possible form type)
+      (cond ((and constantp (<= value 1)) `(t () () () ,(<= value 0) () () ()))
+	    (t (let ((var (loop-make-variable (loop-gentemp 'loop-repeat-) number type)))
+		 (if constantp
+		     `((not (plusp (setq ,var (1- ,var)))) () () () () () () ())
+		     `((minusp (setq ,var (1- ,var))) () () ()))))))))
+
+
+(defun loop-when-it-variable ()
+  (or *loop-when-it-variable*
+      (setq *loop-when-it-variable*
+	    (loop-make-variable (loop-gentemp 'loop-it-) nil nil))))
+
+
+;;;; Various FOR/AS Subdispatches
+
+
+;;;ANSI "FOR x = y [THEN z]" is sort of like the old Genera one when the THEN
+;;; is omitted (other than being more stringent in its placement), and like
+;;; the old "FOR x FIRST y THEN z" when the THEN is present.  I.e., the first
+;;; initialization occurs in the loop body (first-step), not in the variable binding
+;;; phase.
+(defun loop-ansi-for-equals (var val data-type)
+  (loop-make-iteration-variable var nil data-type)
+  (cond ((loop-tequal (car *loop-source-code*) :then)
+	 ;;Then we are the same as "FOR x FIRST y THEN z".
+	 (loop-pop-source)
+	 `(() (,var ,(loop-get-form)) () ()
+	   () (,var ,val) () ()))
+	(t ;;We are the same as "FOR x = y".
+	 `(() (,var ,val) () ()))))
+
+
+(defun loop-for-across (var val data-type)
+  (loop-make-iteration-variable var nil data-type)
+  (let ((vector-var (loop-gentemp 'loop-across-vector-))
+	(index-var (loop-gentemp 'loop-across-index-)))
+    (multiple-value-bind (vector-form constantp vector-value)
+	(loop-constant-fold-if-possible val 'vector)
+      (loop-make-variable
+	vector-var vector-form
+	(if (and (consp vector-form) (eq (car vector-form) 'the))
+	    (cadr vector-form)
+	    'vector))
+      #+Genera (push `(system:array-register ,vector-var) *loop-declarations*)
+      (loop-make-variable index-var 0 'fixnum)
+      (let* ((length 0)
+	     (length-form (cond ((not constantp)
+				 (let ((v (loop-gentemp 'loop-across-limit-)))
+				   (push `(setq ,v (length ,vector-var)) *loop-prologue*)
+				   (loop-make-variable v 0 'fixnum)))
+				(t (setq length (length vector-value)))))
+	     (first-test `(>= ,index-var ,length-form))
+	     (other-test first-test)
+	     (step `(,var (aref ,vector-var ,index-var)))
+	     (pstep `(,index-var (1+ ,index-var))))
+	(declare (fixnum length))
+	(when constantp
+	  (setq first-test (= length 0))
+	  (when (<= length 1)
+	    (setq other-test t)))
+	`(,other-test ,step () ,pstep
+	  ,@(and (not (eq first-test other-test)) `(,first-test ,step () ,pstep)))))))
+
+
+
+;;;; List Iteration
+
+
+(defun loop-list-step (listvar)
+  ;;We are not equipped to analyze whether 'FOO is the same as #'FOO here in any
+  ;; sensible fashion, so let's give an obnoxious warning whenever 'FOO is used
+  ;; as the stepping function.
+  ;;While a Discerning Compiler may deal intelligently with (funcall 'foo ...), not
+  ;; recognizing FOO may defeat some LOOP optimizations.
+  (let ((stepper (cond ((loop-tequal (car *loop-source-code*) :by)
+			(loop-pop-source)
+			(loop-get-form))
+		       (t '(function cdr)))))
+    (cond ((and (consp stepper) (eq (car stepper) 'quote))
+	   (loop-warn "Use of QUOTE around stepping function in LOOP will be left verbatim.")
+	   (values `(funcall ,stepper ,listvar) nil))
+	  ((and (consp stepper) (eq (car stepper) 'function))
+	   (values (list (cadr stepper) listvar) (cadr stepper)))
+	  (t (values `(funcall ,(loop-make-variable (loop-gentemp 'loop-fn-) stepper 'function)
+			       ,listvar)
+		     nil)))))
+
+
+(defun loop-for-on (var val data-type)
+  (multiple-value-bind (list constantp list-value) (loop-constant-fold-if-possible val)
+    (let ((listvar var))
+      (cond ((and var (symbolp var)) (loop-make-iteration-variable var list data-type))
+	    (t (loop-make-variable (setq listvar (loop-gentemp)) list 'list)
+	       (loop-make-iteration-variable var nil data-type)))
+      (multiple-value-bind (list-step step-function) (loop-list-step listvar)
+	(declare #+(and (not LOOP-Prefer-POP) (not CLOE)) (ignore step-function))
+	;;@@@@ The CLOE problem above has to do with bug in macroexpansion of multiple-value-bind.
+	(let* ((first-endtest
+		(hide-variable-reference
+		 (eq var listvar)
+		 listvar
+		 ;; the following should use `atom' instead of `endp', per
+		 ;; [bug2428]
+		 `(atom ,listvar)))
+	       (other-endtest first-endtest))
+	  (when (and constantp (listp list-value))
+	    (setq first-endtest (null list-value)))
+	  (cond ((eq var listvar)
+		 ;;Contour of the loop is different because we use the user's variable...
+		 `(() (,listvar ,(hide-variable-reference t listvar list-step)) ,other-endtest
+		   () () () ,first-endtest ()))
+		#+LOOP-Prefer-POP
+		((and step-function
+		      (let ((n (cdr (assoc step-function '((cdr . 1) (cddr . 2)
+							   (cdddr . 3) (cddddr . 4))))))
+			(and n (do ((l var (cdr l)) (i 0 (1+ i)))
+				   ((atom l) (and (null l) (= i n)))
+				 (declare (fixnum i))))))
+		 (let ((step (mapcan #'(lambda (x) (list x `(pop ,listvar))) var)))
+		   `(,other-endtest () () ,step ,first-endtest () () ,step)))
+		(t (let ((step `(,var ,listvar)) (pseudo `(,listvar ,list-step)))
+		     `(,other-endtest ,step () ,pseudo
+		       ,@(and (not (eq first-endtest other-endtest))
+			      `(,first-endtest ,step () ,pseudo)))))))))))
+
+
+(defun loop-for-in (var val data-type)
+  (multiple-value-bind (list constantp list-value) (loop-constant-fold-if-possible val)
+    (let ((listvar (loop-gentemp 'loop-list-)))
+      (loop-make-iteration-variable var nil data-type)
+      (loop-make-variable listvar list 'list)
+      (multiple-value-bind (list-step step-function) (loop-list-step listvar)
+	#-LOOP-Prefer-POP (declare (ignore step-function))
+	(let* ((first-endtest `(endp ,listvar))
+	       (other-endtest first-endtest)
+	       (step `(,var (car ,listvar)))
+	       (pseudo-step `(,listvar ,list-step)))
+	  (when (and constantp (listp list-value))
+	    (setq first-endtest (null list-value)))
+	  #+LOOP-Prefer-POP (when (eq step-function 'cdr)
+			      (setq step `(,var (pop ,listvar)) pseudo-step nil))
+	  `(,other-endtest ,step () ,pseudo-step
+	    ,@(and (not (eq first-endtest other-endtest))
+		   `(,first-endtest ,step () ,pseudo-step))))))))
+
+
+;;;; Iteration Paths
+
+
+(defstruct (loop-path
+	     (:copier nil)
+	     (:predicate nil))
+  names
+  preposition-groups
+  inclusive-permitted
+  function
+  user-data)
+
+
+(defun add-loop-path (names function universe &key preposition-groups inclusive-permitted user-data)
+  (unless (listp names) (setq names (list names)))
+  ;; Can't do this due to CLOS bootstrapping problems.
+  #-(or Genera (and CLOE Source-Bootstrap)) (check-type universe loop-universe)
+  (let ((ht (loop-universe-path-keywords universe))
+	(lp (make-loop-path
+	      :names (mapcar #'symbol-name names)
+	      :function function
+	      :user-data user-data
+	      :preposition-groups (mapcar #'(lambda (x) (if (listp x) x (list x))) preposition-groups)
+	      :inclusive-permitted inclusive-permitted)))
+    (dolist (name names) (setf (gethash (symbol-name name) ht) lp))
+    lp))
+
+
+;;; Note:  path functions are allowed to use loop-make-variable, hack
+;;; the prologue, etc.
+(defun loop-for-being (var val data-type)
+  ;; FOR var BEING each/the pathname prep-phrases using-stuff...
+  ;; each/the = EACH or THE.  Not clear if it is optional, so I guess we'll warn.
+  (let ((path nil)
+	(data nil)
+	(inclusive nil)
+	(stuff nil)
+	(initial-prepositions nil))
+    (cond ((loop-tmember val '(:each :the)) (setq path (loop-pop-source)))
+	  ((loop-tequal (car *loop-source-code*) :and)
+	   (loop-pop-source)
+	   (setq inclusive t)
+	   (unless (loop-tmember (car *loop-source-code*) '(:its :each :his :her))
+	     (loop-error "~S found where ITS or EACH expected in LOOP iteration path syntax."
+			 (car *loop-source-code*)))
+	   (loop-pop-source)
+	   (setq path (loop-pop-source))
+	   (setq initial-prepositions `((:in ,val))))
+	  (t (loop-error "Unrecognizable LOOP iteration path syntax.  Missing EACH or THE?")))
+    (cond ((not (symbolp path))
+	   (loop-error "~S found where a LOOP iteration path name was expected." path))
+	  ((not (setq data (loop-lookup-keyword path (loop-universe-path-keywords *loop-universe*))))
+	   (loop-error "~S is not the name of a LOOP iteration path." path))
+	  ((and inclusive (not (loop-path-inclusive-permitted data)))
+	   (loop-error "\"Inclusive\" iteration is not possible with the ~S LOOP iteration path." path)))
+    (let ((fun (loop-path-function data))
+	  (preps (nconc initial-prepositions
+			(loop-collect-prepositional-phrases (loop-path-preposition-groups data) t)))
+	  (user-data (loop-path-user-data data)))
+      (when (symbolp fun) (setq fun (symbol-function fun)))
+      (setq stuff (if inclusive
+		      (apply fun var data-type preps :inclusive t user-data)
+		      (apply fun var data-type preps user-data))))
+    (when *loop-named-variables*
+      (loop-error "Unused USING variables: ~S." *loop-named-variables*))
+    ;; STUFF is now (bindings prologue-forms . stuff-to-pass-back).  Protect the system from the user
+    ;; and the user from himself.
+    (unless (member (length stuff) '(6 10))
+      (loop-error "Value passed back by LOOP iteration path function for path ~S has invalid length."
+		  path))
+    (do ((l (car stuff) (cdr l)) (x)) ((null l))
+      (if (atom (setq x (car l)))
+	  (loop-make-iteration-variable x nil nil)
+	  (loop-make-iteration-variable (car x) (cadr x) (caddr x))))
+    (setq *loop-prologue* (nconc (reverse (cadr stuff)) *loop-prologue*))
+    (cddr stuff)))
+
+
+
+;;;INTERFACE:  Lucid, exported.
+;;; i.e., this is part of our extended ansi-loop interface.
+(defun named-variable (name)
+  (let ((tem (loop-tassoc name *loop-named-variables*)))
+    (declare (list tem))
+    (cond ((null tem) (values (loop-gentemp) nil))
+	  (t (setq *loop-named-variables* (delete tem *loop-named-variables*))
+	     (values (cdr tem) t)))))
+
+
+(defun loop-collect-prepositional-phrases (preposition-groups &optional USING-allowed initial-phrases)
+  (flet ((in-group-p (x group) (car (loop-tmember x group))))
+    (do ((token nil)
+	 (prepositional-phrases initial-phrases)
+	 (this-group nil nil)
+	 (this-prep nil nil)
+	 (disallowed-prepositions
+	   (mapcan #'(lambda (x)
+		       (loop-copylist*
+			 (find (car x) preposition-groups :test #'in-group-p)))
+		   initial-phrases))
+	 (used-prepositions (mapcar #'car initial-phrases)))
+	((null *loop-source-code*) (nreverse prepositional-phrases))
+      (declare (symbol this-prep))
+      (setq token (car *loop-source-code*))
+      (dolist (group preposition-groups)
+	(when (setq this-prep (in-group-p token group))
+	  (return (setq this-group group))))
+      (cond (this-group
+	     (when (member this-prep disallowed-prepositions)
+	       (loop-error
+		 (if (member this-prep used-prepositions)
+		     "A ~S prepositional phrase occurs multiply for some LOOP clause."
+		     "Preposition ~S used when some other preposition has subsumed it.")
+		 token))
+	     (setq used-prepositions (if (listp this-group)
+					 (append this-group used-prepositions)
+					 (cons this-group used-prepositions)))
+	     (loop-pop-source)
+	     (push (list this-prep (loop-get-form)) prepositional-phrases))
+	    ((and USING-allowed (loop-tequal token 'using))
+	     (loop-pop-source)
+	     (do ((z (loop-pop-source) (loop-pop-source)) (tem)) (nil)
+	       (when (or (atom z)
+			 (atom (cdr z))
+			 (not (null (cddr z)))
+			 (not (symbolp (car z)))
+			 (and (cadr z) (not (symbolp (cadr z)))))
+		 (loop-error "~S bad variable pair in path USING phrase." z))
+	       (when (cadr z)
+		 (if (setq tem (loop-tassoc (car z) *loop-named-variables*))
+		     (loop-error
+		       "The variable substitution for ~S occurs twice in a USING phrase,~@
+		        with ~S and ~S."
+		       (car z) (cadr z) (cadr tem))
+		     (push (cons (car z) (cadr z)) *loop-named-variables*)))
+	       (when (or (null *loop-source-code*) (symbolp (car *loop-source-code*)))
+		 (return nil))))
+	    (t (return (nreverse prepositional-phrases)))))))
+
+
+;;;; Master Sequencer Function
+
+
+(defun loop-sequencer (indexv indexv-type indexv-user-specified-p
+			  variable variable-type
+			  sequence-variable sequence-type
+			  step-hack default-top
+			  prep-phrases)
+   (let ((endform nil)				;Form (constant or variable) with limit value.
+	 (sequencep nil)			;T if sequence arg has been provided.
+	 (testfn nil)				;endtest function
+	 (test nil)				;endtest form.
+	 (stepby (1+ (or (loop-typed-init indexv-type) 0)))	;Our increment.
+	 (stepby-constantp t)
+	 (step nil)				;step form.
+	 (dir nil)				;Direction of stepping: NIL, :UP, :DOWN.
+	 (inclusive-iteration nil)		;T if include last index.
+	 (start-given nil)			;T when prep phrase has specified start
+	 (start-value nil)
+	 (start-constantp nil)
+	 (limit-given nil)			;T when prep phrase has specified end
+	 (limit-constantp nil)
+	 (limit-value nil)
+	 )
+     (when variable (loop-make-iteration-variable variable nil variable-type))
+     (do ((l prep-phrases (cdr l)) (prep) (form) (odir)) ((null l))
+       (setq prep (caar l) form (cadar l))
+       (case prep
+	 ((:of :in)
+	  (setq sequencep t)
+	  (loop-make-variable sequence-variable form sequence-type))
+	 ((:from :downfrom :upfrom)
+	  (setq start-given t)
+	  (cond ((eq prep :downfrom) (setq dir ':down))
+		((eq prep :upfrom) (setq dir ':up)))
+	  (multiple-value-setq (form start-constantp start-value)
+	    (loop-constant-fold-if-possible form indexv-type))
+	  (loop-make-iteration-variable indexv form indexv-type))
+	 ((:upto :to :downto :above :below)
+	  (cond ((loop-tequal prep :upto) (setq inclusive-iteration (setq dir ':up)))
+		((loop-tequal prep :to) (setq inclusive-iteration t))
+		((loop-tequal prep :downto) (setq inclusive-iteration (setq dir ':down)))
+		((loop-tequal prep :above) (setq dir ':down))
+		((loop-tequal prep :below) (setq dir ':up)))
+	  (setq limit-given t)
+	  (multiple-value-setq (form limit-constantp limit-value)
+	    (loop-constant-fold-if-possible form indexv-type))
+	  (setq endform (if limit-constantp
+			    `',limit-value
+			    (loop-make-variable
+			      (loop-gentemp 'loop-limit-) form indexv-type))))
+	 (:by
+	   (multiple-value-setq (form stepby-constantp stepby)
+	     (loop-constant-fold-if-possible form indexv-type))
+	   (unless stepby-constantp
+	     (loop-make-variable (setq stepby (loop-gentemp 'loop-step-by-)) form indexv-type)))
+	 (t (loop-error
+	      "~S invalid preposition in sequencing or sequence path.~@
+	       Invalid prepositions specified in iteration path descriptor or something?"
+	      prep)))
+       (when (and odir dir (not (eq dir odir)))
+	 (loop-error "Conflicting stepping directions in LOOP sequencing path"))
+       (setq odir dir))
+     (when (and sequence-variable (not sequencep))
+       (loop-error "Missing OF or IN phrase in sequence path"))
+     ;; Now fill in the defaults.
+     (unless start-given
+       (loop-make-iteration-variable
+	 indexv
+	 (setq start-constantp t start-value (or (loop-typed-init indexv-type) 0))
+	 indexv-type))
+     (cond ((member dir '(nil :up))
+	    (when (or limit-given default-top)
+	      (unless limit-given
+		(loop-make-variable (setq endform (loop-gentemp 'loop-seq-limit-))
+				    nil indexv-type)
+		(push `(setq ,endform ,default-top) *loop-prologue*))
+	      (setq testfn (if inclusive-iteration '> '>=)))
+	    (setq step (if (eql stepby 1) `(1+ ,indexv) `(+ ,indexv ,stepby))))
+	   (t (unless start-given
+		(unless default-top
+		  (loop-error "Don't know where to start stepping."))
+		(push `(setq ,indexv (1- ,default-top)) *loop-prologue*))
+	      (when (and default-top (not endform))
+		(setq endform (loop-typed-init indexv-type) inclusive-iteration t))
+	      (when endform (setq testfn (if inclusive-iteration  '< '<=)))
+	      (setq step (if (eql stepby 1) `(1- ,indexv) `(- ,indexv ,stepby)))))
+     (when testfn (setq test (hide-variable-reference t indexv `(,testfn ,indexv ,endform))))
+     (when step-hack
+       (setq step-hack `(,variable ,(hide-variable-reference indexv-user-specified-p indexv step-hack))))
+     (let ((first-test test) (remaining-tests test))
+       (when (and stepby-constantp start-constantp limit-constantp)
+	 (when (setq first-test (funcall (symbol-function testfn) start-value limit-value))
+	   (setq remaining-tests t)))
+       `(() (,indexv ,(hide-variable-reference t indexv step)) ,remaining-tests ,step-hack
+	 () () ,first-test ,step-hack))))
+
+
+;;;; Interfaces to the Master Sequencer
+
+
+
+(defun loop-for-arithmetic (var val data-type kwd)
+  (loop-sequencer
+    var (loop-check-data-type data-type *loop-real-data-type*) t
+    nil nil nil nil nil nil
+    (loop-collect-prepositional-phrases
+      '((:from :upfrom :downfrom) (:to :upto :downto :above :below) (:by))
+      nil (list (list kwd val)))))
+
+
+(defun loop-sequence-elements-path (variable data-type prep-phrases
+				    &key fetch-function size-function sequence-type element-type)
+  (multiple-value-bind (indexv indexv-user-specified-p) (named-variable 'index)
+    (let ((sequencev (named-variable 'sequence)))
+      #+Genera (when (and sequencev
+			  (symbolp sequencev)
+			  sequence-type
+			  (subtypep sequence-type 'vector)
+			  (not (member (the symbol sequencev) *loop-nodeclare*)))
+		 (push `(sys:array-register ,sequencev) *loop-declarations*))
+      (list* nil nil				; dummy bindings and prologue
+	     (loop-sequencer
+	       indexv 'fixnum indexv-user-specified-p
+	       variable (or data-type element-type)
+	       sequencev sequence-type
+	       `(,fetch-function ,sequencev ,indexv) `(,size-function ,sequencev)
+	       prep-phrases)))))
+
+
+;;;; Builtin LOOP Iteration Paths
+
+
+#||
+(loop for v being the hash-values of ht do (print v))
+(loop for k being the hash-keys of ht do (print k))
+(loop for v being the hash-values of ht using (hash-key k) do (print (list k v)))
+(loop for k being the hash-keys of ht using (hash-value v) do (print (list k v)))
+||#
+
+(defun loop-hash-table-iteration-path (variable data-type prep-phrases &key which)
+  (check-type which (member hash-key hash-value))
+  (cond ((or (cdr prep-phrases) (not (member (caar prep-phrases) '(:in :of))))
+	 (loop-error "Too many prepositions!"))
+	((null prep-phrases) (loop-error "Missing OF or IN in ~S iteration path.")))
+  (let ((ht-var (loop-gentemp 'loop-hashtab-))
+	(next-fn (loop-gentemp 'loop-hashtab-next-))
+	(dummy-predicate-var nil)
+	(post-steps nil))
+    (multiple-value-bind (other-var other-p)
+	(named-variable (if (eq which 'hash-key) 'hash-value 'hash-key))
+      ;;@@@@ named-variable returns a second value of T if the name was actually
+      ;; specified, so clever code can throw away the gensym'ed up variable if
+      ;; it isn't really needed.
+      ;;The following is for those implementations in which we cannot put dummy NILs
+      ;; into multiple-value-setq variable lists.
+      #-Genera (setq other-p t
+		     dummy-predicate-var (loop-when-it-variable))
+      (let ((key-var nil)
+	    (val-var nil)
+	    (bindings `((,variable nil ,data-type)
+			(,ht-var ,(cadar prep-phrases))
+			,@(and other-p other-var `((,other-var nil))))))
+	(if (eq which 'hash-key)
+	    (setq key-var variable val-var (and other-p other-var))
+	    (setq key-var (and other-p other-var) val-var variable))
+	(push `(with-hash-table-iterator (,next-fn ,ht-var)) *loop-wrappers*)
+	(when (consp key-var)
+	  (setq post-steps `(,key-var ,(setq key-var (loop-gentemp 'loop-hash-key-temp-))
+			     ,@post-steps))
+	  (push `(,key-var nil) bindings))
+	(when (consp val-var)
+	  (setq post-steps `(,val-var ,(setq val-var (loop-gentemp 'loop-hash-val-temp-))
+			     ,@post-steps))
+	  (push `(,val-var nil) bindings))
+	`(,bindings				;bindings
+	  ()					;prologue
+	  ()					;pre-test
+	  ()					;parallel steps
+	  (not (multiple-value-setq (,dummy-predicate-var ,key-var ,val-var) (,next-fn)))	;post-test
+	  ,post-steps)))))
+
+
+(defun loop-package-symbols-iteration-path (variable data-type prep-phrases &key symbol-types)
+  (cond ((or (cdr prep-phrases) (not (member (caar prep-phrases) '(:in :of))))
+	 (loop-error "Too many prepositions!"))
+	((null prep-phrases) (loop-error "Missing OF or IN in ~S iteration path.")))
+  (unless (symbolp variable)
+    (loop-error "Destructuring is not valid for package symbol iteration."))
+  (let ((pkg-var (loop-gentemp 'loop-pkgsym-))
+	(next-fn (loop-gentemp 'loop-pkgsym-next-)))
+    (push `(with-package-iterator (,next-fn ,pkg-var ,@symbol-types)) *loop-wrappers*)
+    `(((,variable nil ,data-type) (,pkg-var ,(cadar prep-phrases)))
+      ()
+      ()
+      ()
+      (not (multiple-value-setq (,(progn
+				    ;;@@@@ If an implementation can get away without actually
+				    ;; using a variable here, so much the better.
+				    #+Genera NIL
+				    #-Genera (loop-when-it-variable))
+				 ,variable)
+	     (,next-fn)))
+      ())))
+
+;;;; ANSI Loop
+
+(defun make-ansi-loop-universe (extended-p)
+  (let ((w (make-standard-loop-universe
+	     :keywords `((named (loop-do-named))
+			 (initially (loop-do-initially))
+			 (finally (loop-do-finally))
+			 (do (loop-do-do))
+			 (doing (loop-do-do))
+			 (return (loop-do-return))
+			 (collect (loop-list-collection list))
+			 (collecting (loop-list-collection list))
+			 (append (loop-list-collection append))
+			 (appending (loop-list-collection append))
+			 (nconc (loop-list-collection nconc))
+			 (nconcing (loop-list-collection nconc))
+			 (count (loop-sum-collection count ,*loop-real-data-type* fixnum))
+			 (counting (loop-sum-collection count ,*loop-real-data-type* fixnum))
+			 (sum (loop-sum-collection sum number number))
+			 (summing (loop-sum-collection sum number number))
+			 (maximize (loop-maxmin-collection max))
+			 (minimize (loop-maxmin-collection min))
+			 (maximizing (loop-maxmin-collection max))
+			 (minimizing (loop-maxmin-collection min))
+			 (always (loop-do-always t nil))	; Normal, do always
+			 (never (loop-do-always t t))	; Negate the test on always.
+			 (thereis (loop-do-thereis t))
+			 (while (loop-do-while nil :while))	; Normal, do while
+			 (until (loop-do-while t :until))	; Negate the test on while
+			 (when (loop-do-if when nil))	; Normal, do when
+			 (if (loop-do-if if nil))	; synonymous
+			 (unless (loop-do-if unless t))	; Negate the test on when
+			 (with (loop-do-with)))
+	     :for-keywords '((= (loop-ansi-for-equals))
+			     (across (loop-for-across))
+			     (in (loop-for-in))
+			     (on (loop-for-on))
+			     (from (loop-for-arithmetic :from))
+			     (downfrom (loop-for-arithmetic :downfrom))
+			     (upfrom (loop-for-arithmetic :upfrom))
+			     (below (loop-for-arithmetic :below))
+			     (to (loop-for-arithmetic :to))
+			     (upto (loop-for-arithmetic :upto))
+			     (being (loop-for-being)))
+	     :iteration-keywords '((for (loop-do-for))
+				   (as (loop-do-for))
+				   (repeat (loop-do-repeat)))
+	     :type-symbols '(array atom bignum bit bit-vector character #| common |# compiled-function
+				   complex cons double-float fixnum float
+				   function hash-table integer keyword list long-float
+				   nil null number package pathname random-state
+				   ratio rational readtable sequence short-float
+				   simple-array simple-bit-vector simple-string
+				   simple-vector single-float standard-char
+				   stream string string-char
+				   symbol t vector)
+	     :type-keywords nil
+	     :ansi (if extended-p :extended t))))
+    (add-loop-path '(hash-key hash-keys) 'loop-hash-table-iteration-path w
+		   :preposition-groups '((:of :in))
+		   :inclusive-permitted nil
+		   :user-data '(:which hash-key))
+    (add-loop-path '(hash-value hash-values) 'loop-hash-table-iteration-path w
+		   :preposition-groups '((:of :in))
+		   :inclusive-permitted nil
+		   :user-data '(:which hash-value))
+    (add-loop-path '(symbol symbols) 'loop-package-symbols-iteration-path w
+		   :preposition-groups '((:of :in))
+		   :inclusive-permitted nil
+		   :user-data '(:symbol-types (:internal :external :inherited)))
+    (add-loop-path '(external-symbol external-symbols) 'loop-package-symbols-iteration-path w
+		   :preposition-groups '((:of :in))
+		   :inclusive-permitted nil
+		   :user-data '(:symbol-types (:external)))
+    (add-loop-path '(present-symbol present-symbols) 'loop-package-symbols-iteration-path w
+		   :preposition-groups '((:of :in))
+		   :inclusive-permitted nil
+		   :user-data '(:symbol-types (:internal)))
+    w))
+
+
+(defparameter *loop-ansi-universe*
+	      (make-ansi-loop-universe nil))
+
+
+(defun loop-standard-expansion (keywords-and-forms environment universe)
+  (if (and keywords-and-forms (symbolp (car keywords-and-forms)))
+      (loop-translate keywords-and-forms environment universe)
+      (let ((tag (gensym)))
+	`(block nil (tagbody ,tag (progn ,@keywords-and-forms) (go ,tag))))))
+
+
+;;;INTERFACE: ANSI
+(defmacro loop (&environment env &rest keywords-and-forms)
+  #+Genera (declare (compiler:do-not-record-macroexpansions)
+		    (zwei:indentation . zwei:indent-loop))
+  (loop-standard-expansion keywords-and-forms env *loop-ansi-universe*))
+
+#+allegro
+(defun excl::complex-loop-expander (body env)
+  (loop-standard-expansion body env *loop-ansi-universe*))

--- a/src/ansiloop/ansi-loop.lisp
+++ b/src/ansiloop/ansi-loop.lisp
@@ -214,53 +214,53 @@
        ,@body)))
 
 
-(defmacro loop-collect-rplacd (&environment env
-			       (head-var tail-var &optional user-head-var) form)
+(defmacro loop-collect-rplacd ((head-var tail-var &optional user-head-var) form)
   (declare
-    #+LISPM (ignore head-var user-head-var)	;use locatives, unconditionally update through the tail.
-    )
-  (setq form (macroexpand form env))
-  (flet ((cdr-wrap (form n)
-       #+nil (declare (fixnum n))
-	   (do () ((<= n 4) (setq form `(,(case n
-					    (1 'cdr)
-					    (2 'cddr)
-					    (3 'cdddr)
-					    (4 'cddddr))
-					 ,form)))
-	     (setq form `(cddddr ,form) n (- n 4)))))
-    (let ((tail-form form) (ncdrs nil))
-      ;;Determine if the form being constructed is a list of known length.
-      (when (consp form)
-	(cond ((eq (car form) 'list)
-	       (setq ncdrs (1- (length (cdr form))))
-	       ;;@@@@ Because the last element is going to be RPLACDed,
-	       ;; we don't want the cdr-coded implementations to use
-	       ;; cdr-nil at the end (which would just force copying
-	       ;; the whole list again).
-	       #+LISPM (setq tail-form `(list* ,@(cdr form) nil)))
-	      ((member (car form) '(list* cons))
-	       (when (and (cddr form) (member (car (last form)) '(nil 'nil)))
-		 (setq ncdrs (- (length (cdr form)) 2))))))
-      (let ((answer
-	      (cond ((null ncdrs)
-		     `(when (setf (cdr ,tail-var) ,tail-form)
-			(setq ,tail-var (last (cdr ,tail-var)))))
-		    ((< ncdrs 0) (return-from loop-collect-rplacd nil))
-		    ((= ncdrs 0)
-		     ;;@@@@ Here we have a choice of two idioms:
-		     ;; (rplacd tail (setq tail tail-form))
-		     ;; (setq tail (setf (cdr tail) tail-form)).
-		     ;;Genera and most others I have seen do better with the former.
-		     `(rplacd ,tail-var (setq ,tail-var ,tail-form)))
-		    (t `(setq ,tail-var ,(cdr-wrap `(setf (cdr ,tail-var) ,tail-form)
-						   ncdrs))))))
-	;;If not using locatives or something similar to update the user's
-	;; head variable, we've got to set it...  It's harmless to repeatedly set it
-	;; unconditionally, and probably faster than checking.
-	#-LISPM (when user-head-var
-		  (setq answer `(progn ,answer (setq ,user-head-var (cdr ,head-var)))))
-	answer))))
+   #+LISPM (ignore head-var user-head-var) ;use locatives, unconditionally update through the tail.
+   )
+  (let ((env jscl::*environment*))
+    (setq form (macroexpand form env))
+    (flet ((cdr-wrap (form n)
+             #+nil (declare (fixnum n))
+             (do () ((<= n 4) (setq form `(,(case n
+                                              (1 'cdr)
+                                              (2 'cddr)
+                                              (3 'cdddr)
+                                              (4 'cddddr))
+                                            ,form)))
+               (setq form `(cddddr ,form) n (- n 4)))))
+      (let ((tail-form form) (ncdrs nil))
+        ;;Determine if the form being constructed is a list of known length.
+        (when (consp form)
+          (cond ((eq (car form) 'list)
+                 (setq ncdrs (1- (length (cdr form))))
+                 ;;@@@@ Because the last element is going to be RPLACDed,
+                 ;; we don't want the cdr-coded implementations to use
+                 ;; cdr-nil at the end (which would just force copying
+                 ;; the whole list again).
+                 #+LISPM (setq tail-form `(list* ,@(cdr form) nil)))
+                ((member (car form) '(list* cons))
+                 (when (and (cddr form) (member (car (last form)) '(nil 'nil)))
+                   (setq ncdrs (- (length (cdr form)) 2))))))
+        (let ((answer
+               (cond ((null ncdrs)
+                      `(when (setf (cdr ,tail-var) ,tail-form)
+                         (setq ,tail-var (last (cdr ,tail-var)))))
+                     ((< ncdrs 0) (return-from loop-collect-rplacd nil))
+                     ((= ncdrs 0)
+                      ;;@@@@ Here we have a choice of two idioms:
+                      ;; (rplacd tail (setq tail tail-form))
+                      ;; (setq tail (setf (cdr tail) tail-form)).
+                      ;;Genera and most others I have seen do better with the former.
+                      `(rplacd ,tail-var (setq ,tail-var ,tail-form)))
+                     (t `(setq ,tail-var ,(cdr-wrap `(setf (cdr ,tail-var) ,tail-form)
+                                                    ncdrs))))))
+          ;;If not using locatives or something similar to update the user's
+          ;; head variable, we've got to set it...  It's harmless to repeatedly set it
+          ;; unconditionally, and probably faster than checking.
+          #-LISPM (when user-head-var
+                    (setq answer `(progn ,answer (setq ,user-head-var (cdr ,head-var)))))
+          answer)))))
 
 
 (defmacro loop-collect-answer (head-var &optional user-head-var)
@@ -512,64 +512,65 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
   (make-symbol "LOOP-DESETQ-TEMP"))
 
 
-(defmacro loop-really-desetq (&environment env &rest var-val-pairs)
-  (labels ((find-non-null (var)
-	     ;; see if there's any non-null thing here
-	     ;; recurse if the list element is itself a list
-	     (do ((tail var)) ((not (consp tail)) tail)
-	       (when (find-non-null (pop tail)) (return t))))
-	   (loop-desetq-internal (var val &optional temp)
-	     ;; returns a list of actions to be performed
-	     (typecase var
-	       (null
-		 (when (consp val)
-		   ;; don't lose possible side-effects
-		   (if (eq (car val) 'prog1)
-		       ;; these can come from psetq or desetq below.
-		       ;; throw away the value, keep the side-effects.
-		       ;;Special case is for handling an expanded POP.
-		       (mapcan #'(lambda (x)
-				   (and (consp x)
-					(or (not (eq (car x) 'car))
-					    (not (symbolp (cadr x)))
-					    (not (symbolp (setq x (macroexpand x env)))))
-					(cons x nil)))
-			       (cdr val))
-		       `(,val))))
-	       (cons
-		 (let* ((car (car var))
-			(cdr (cdr var))
-			(car-non-null (find-non-null car))
-			(cdr-non-null (find-non-null cdr)))
-		   (when (or car-non-null cdr-non-null)
-		     (if cdr-non-null
-			 (let* ((temp-p temp)
-				(temp (or temp *loop-desetq-temporary*))
-				(body #+LOOP-Prefer-POP `(,@(loop-desetq-internal
-							      car
-							      `(prog1 (car ,temp)
-								      (setq ,temp (cdr ,temp))))
-							  ,@(loop-desetq-internal cdr temp temp))
-				      #-LOOP-Prefer-POP `(,@(loop-desetq-internal car `(car ,temp))
-							  (setq ,temp (cdr ,temp))
-							  ,@(loop-desetq-internal cdr temp temp))))
-			   (if temp-p
-			       `(,@(unless (eq temp val)
-				     `((setq ,temp ,val)))
-				 ,@body)
-			       `((let ((,temp ,val))
-				   ,@body))))
-			 ;; no cdring to do
-			 (loop-desetq-internal car `(car ,val) temp)))))
-	       (otherwise
-		 (unless (eq var val)
-		   `((setq ,var ,val)))))))
-    (do ((actions))
-	((null var-val-pairs)
-	 (if (null (cdr actions)) (car actions) `(progn ,@(nreverse actions))))
-      (setq actions (revappend
-		      (loop-desetq-internal (pop var-val-pairs) (pop var-val-pairs))
-		      actions)))))
+(defmacro loop-really-desetq (&rest var-val-pairs)
+  (let ((env jscl::*environment*))
+    (labels ((find-non-null (var)
+               ;; see if there's any non-null thing here
+               ;; recurse if the list element is itself a list
+               (do ((tail var)) ((not (consp tail)) tail)
+                 (when (find-non-null (pop tail)) (return t))))
+             (loop-desetq-internal (var val &optional temp)
+                ;; returns a list of actions to be performed
+                (typecase var
+                  (null
+                   (when (consp val)
+                     ;; don't lose possible side-effects
+                     (if (eq (car val) 'prog1)
+                         ;; these can come from psetq or desetq below.
+                         ;; throw away the value, keep the side-effects.
+                         ;;Special case is for handling an expanded POP.
+                         (mapcan #'(lambda (x)
+                                     (and (consp x)
+                                          (or (not (eq (car x) 'car))
+                                              (not (symbolp (cadr x)))
+                                              (not (symbolp (setq x (macroexpand x env)))))
+                                          (cons x nil)))
+                                 (cdr val))
+                         `(,val))))
+                  (cons
+                   (let* ((car (car var))
+                          (cdr (cdr var))
+                          (car-non-null (find-non-null car))
+                          (cdr-non-null (find-non-null cdr)))
+                     (when (or car-non-null cdr-non-null)
+                       (if cdr-non-null
+                           (let* ((temp-p temp)
+                                  (temp (or temp *loop-desetq-temporary*))
+                                  (body #+LOOP-Prefer-POP `(,@(loop-desetq-internal
+                                                                 car
+                                                                   `(prog1 (car ,temp)
+                                                                      (setq ,temp (cdr ,temp))))
+                                                              ,@(loop-desetq-internal cdr temp temp))
+                                        #-LOOP-Prefer-POP `(,@(loop-desetq-internal car `(car ,temp))
+                                                              (setq ,temp (cdr ,temp))
+                                                              ,@(loop-desetq-internal cdr temp temp))))
+                             (if temp-p
+                                 `(,@(unless (eq temp val)
+                                       `((setq ,temp ,val)))
+                                     ,@body)
+                                 `((let ((,temp ,val))
+                                     ,@body))))
+                           ;; no cdring to do
+                           (loop-desetq-internal car `(car ,val) temp)))))
+                  (otherwise
+                   (unless (eq var val)
+                     `((setq ,var ,val)))))))
+      (do ((actions))
+          ((null var-val-pairs)
+           (if (null (cdr actions)) (car actions) `(progn ,@(nreverse actions))))
+        (setq actions (revappend
+                       (loop-desetq-internal (pop var-val-pairs) (pop var-val-pairs))
+                       actions))))))
 
 
 ;;;; LOOP-local variables

--- a/src/ansiloop/ansi-loop.lisp
+++ b/src/ansiloop/ansi-loop.lisp
@@ -207,23 +207,11 @@
 ;;;; List Collection Macrology
 
 
-;; (defmacro with-loop-list-collection-head ((head-var tail-var &optional user-head-var)
-;; 					  &body body)
-;;   ;;@@@@ TI? Exploder?
-;;   #+LISPM (let ((head-place (or user-head-var head-var)))
-;; 	    `(let* ((,head-place nil)
-;; 		    (,tail-var
-;; 		      ,(hide-variable-reference
-;; 			 user-head-var user-head-var
-;; 			 `(progn #+Genera (scl:locf ,head-place)
-;; 				 #-Genera (system:variable-location ,head-place)))))
-;; 	       ,@body))
-;;   #-LISPM (let ((l (and user-head-var (list (list user-head-var nil)))))
-;; 	    #+CLOE `(sys::with-stack-list* (,head-var nil nil)
-;; 		      (let ((,tail-var ,head-var) ,@l)
-;; 			,@body))
-;; 	    #-CLOE `(let* ((,head-var (list nil)) (,tail-var ,head-var) ,@l)
-;; 		      ,@body)))
+(defmacro with-loop-list-collection-head ((head-var tail-var &optional user-head-var)
+					  &body body)
+  (let ((l (and user-head-var (list (list user-head-var nil)))))
+    `(let* ((,head-var (list nil)) (,tail-var ,head-var) ,@l)
+       ,@body)))
 
 
 ;; (defmacro loop-collect-rplacd (&environment env

--- a/src/ansiloop/ansi-loop.lisp
+++ b/src/ansiloop/ansi-loop.lisp
@@ -49,15 +49,10 @@
 
 ;;;; LOOP Iteration Macro
 
-#+allegro
-(in-package :excl)
-#-allegro
+(defpackage :ansi-loop
+  (:use :common-lisp))
+
 (in-package :ansi-loop)
-
-(provide :loop)
-
-#+Cloe-Runtime					;Don't ask.
-(car (push "%Z% %M% %I% %E% %U%" system::*module-identifications*))
 
 ;;; Technology.
 ;;;
@@ -117,7 +112,7 @@
 ;;; shifting fenceposts in an iteration or series of carcdr operations.  This is
 ;;; primarily recognized in the list iterators (FOR .. {IN,ON}), and LOOP's
 ;;; destructuring setq code.
-(eval-when (compile load eval)
+(eval-when (:compile-toplevel :load-toplevel :execute)
   #+(or Genera Minima) (pushnew :LOOP-Prefer-POP *features*)
   )
 
@@ -212,1923 +207,1929 @@
 ;;;; List Collection Macrology
 
 
-(defmacro with-loop-list-collection-head ((head-var tail-var &optional user-head-var)
-					  &body body)
-  ;;@@@@ TI? Exploder?
-  #+LISPM (let ((head-place (or user-head-var head-var)))
-	    `(let* ((,head-place nil)
-		    (,tail-var
-		      ,(hide-variable-reference
-			 user-head-var user-head-var
-			 `(progn #+Genera (scl:locf ,head-place)
-				 #-Genera (system:variable-location ,head-place)))))
-	       ,@body))
-  #-LISPM (let ((l (and user-head-var (list (list user-head-var nil)))))
-	    #+CLOE `(sys::with-stack-list* (,head-var nil nil)
-		      (let ((,tail-var ,head-var) ,@l)
-			,@body))
-	    #-CLOE `(let* ((,head-var (list nil)) (,tail-var ,head-var) ,@l)
-		      ,@body)))
-
-
-(defmacro loop-collect-rplacd (&environment env
-			       (head-var tail-var &optional user-head-var) form)
-  (declare
-    #+LISPM (ignore head-var user-head-var)	;use locatives, unconditionally update through the tail.
-    )
-  (setq form (macroexpand form env))
-  (flet ((cdr-wrap (form n)
-	   (declare (fixnum n))
-	   (do () ((<= n 4) (setq form `(,(case n
-					    (1 'cdr)
-					    (2 'cddr)
-					    (3 'cdddr)
-					    (4 'cddddr))
-					 ,form)))
-	     (setq form `(cddddr ,form) n (- n 4)))))
-    (let ((tail-form form) (ncdrs nil))
-      ;;Determine if the form being constructed is a list of known length.
-      (when (consp form)
-	(cond ((eq (car form) 'list)
-	       (setq ncdrs (1- (length (cdr form))))
-	       ;;@@@@ Because the last element is going to be RPLACDed,
-	       ;; we don't want the cdr-coded implementations to use
-	       ;; cdr-nil at the end (which would just force copying
-	       ;; the whole list again).
-	       #+LISPM (setq tail-form `(list* ,@(cdr form) nil)))
-	      ((member (car form) '(list* cons))
-	       (when (and (cddr form) (member (car (last form)) '(nil 'nil)))
-		 (setq ncdrs (- (length (cdr form)) 2))))))
-      (let ((answer
-	      (cond ((null ncdrs)
-		     `(when (setf (cdr ,tail-var) ,tail-form)
-			(setq ,tail-var (last (cdr ,tail-var)))))
-		    ((< ncdrs 0) (return-from loop-collect-rplacd nil))
-		    ((= ncdrs 0)
-		     ;;@@@@ Here we have a choice of two idioms:
-		     ;; (rplacd tail (setq tail tail-form))
-		     ;; (setq tail (setf (cdr tail) tail-form)).
-		     ;;Genera and most others I have seen do better with the former.
-		     `(rplacd ,tail-var (setq ,tail-var ,tail-form)))
-		    (t `(setq ,tail-var ,(cdr-wrap `(setf (cdr ,tail-var) ,tail-form)
-						   ncdrs))))))
-	;;If not using locatives or something similar to update the user's
-	;; head variable, we've got to set it...  It's harmless to repeatedly set it
-	;; unconditionally, and probably faster than checking.
-	#-LISPM (when user-head-var
-		  (setq answer `(progn ,answer (setq ,user-head-var (cdr ,head-var)))))
-	answer))))
-
-
-(defmacro loop-collect-answer (head-var &optional user-head-var)
-  (or user-head-var
-      (progn
-	;;If we use locatives to get tail-updating to update the head var,
-	;; then the head var itself contains the answer.  Otherwise we
-	;; have to cdr it.
-	#+LISPM head-var
-	#-LISPM `(cdr ,head-var))))
-
-
-;;;; Maximization Technology
-
-
-#|
-The basic idea of all this minimax randomness here is that we have to
-have constructed all uses of maximize and minimize to a particular
-"destination" before we can decide how to code them.  The goal is to not
-have to have any kinds of flags, by knowing both that (1) the type is
-something which we can provide an initial minimum or maximum value for
-and (2) know that a MAXIMIZE and MINIMIZE are not being combined.
-
-SO, we have a datastructure which we annotate with all sorts of things,
-incrementally updating it as we generate loop body code, and then use
-a wrapper and internal macros to do the coding when the loop has been
-constructed.
-|#
-
-
-(defstruct (loop-minimax
-	     (:constructor make-loop-minimax-internal)
-	     (:copier nil)
-	     (:predicate nil))
-  answer-variable
-  type
-  temp-variable
-  flag-variable
-  operations
-  infinity-data)
-
-
-(defvar *loop-minimax-type-infinities-alist*
-	;;@@@@ This is the sort of value this should take on for a Lisp that has
-	;; "eminently usable" infinities.  n.b. there are neither constants nor
-	;; printed representations for infinities defined by CL.
-	;;@@@@ This grotesque read-from-string below is to help implementations
-	;; which croak on the infinity character when it appears in a token, even
-	;; conditionalized out.
-	#+Genera
-	  '#.(read-from-string
-	      "((fixnum 	most-positive-fixnum	 most-negative-fixnum)
-		(short-float 	+1s			 -1s)
-		(single-float	+1f			 -1f)
-		(double-float	+1d			 -1d)
-		(long-float	+1l			 -1l))")
-	;;This is how the alist should look for a lisp that has no infinities.  In
-	;; that case, MOST-POSITIVE-x-FLOAT really IS the most positive.
-	#+(or CLOE-Runtime Minima)
-	  '((fixnum   		most-positive-fixnum		most-negative-fixnum)
-	    (short-float	most-positive-short-float	most-negative-short-float)
-	    (single-float	most-positive-single-float	most-negative-single-float)
-	    (double-float	most-positive-double-float	most-negative-double-float)
-	    (long-float		most-positive-long-float	most-negative-long-float))
-	;;If we don't know, then we cannot provide "infinite" initial values for any of the
-	;; types but FIXNUM:
-	#-(or Genera CLOE-Runtime Minima)
-	  '((fixnum   		most-positive-fixnum		most-negative-fixnum))
-	  )
-
-
-(defun make-loop-minimax (answer-variable type)
-  (let ((infinity-data (cdr (assoc type *loop-minimax-type-infinities-alist* :test #'subtypep))))
-    (make-loop-minimax-internal
-      :answer-variable answer-variable
-      :type type
-      :temp-variable (loop-gentemp 'loop-maxmin-temp-)
-      :flag-variable (and (not infinity-data) (loop-gentemp 'loop-maxmin-flag-))
-      :operations nil
-      :infinity-data infinity-data)))
-
-
-(defun loop-note-minimax-operation (operation minimax)
-  (pushnew (the symbol operation) (loop-minimax-operations minimax))
-  (when (and (cdr (loop-minimax-operations minimax))
-	     (not (loop-minimax-flag-variable minimax)))
-    (setf (loop-minimax-flag-variable minimax) (loop-gentemp 'loop-maxmin-flag-)))
-  operation)
-
-
-(defmacro with-minimax-value (lm &body body)
-  (let ((init (loop-typed-init (loop-minimax-type lm)))
-	(which (car (loop-minimax-operations lm)))
-	(infinity-data (loop-minimax-infinity-data lm))
-	(answer-var (loop-minimax-answer-variable lm))
-	(temp-var (loop-minimax-temp-variable lm))
-	(flag-var (loop-minimax-flag-variable lm))
-	(type (loop-minimax-type lm)))
-    (if flag-var
-	`(let ((,answer-var ,init) (,temp-var ,init) (,flag-var nil))
-	   (declare (type ,type ,answer-var ,temp-var))
-	   ,@body)
-	`(let ((,answer-var ,(if (eq which 'min) (first infinity-data) (second infinity-data)))
-	       (,temp-var ,init))
-	   (declare (type ,type ,answer-var ,temp-var))
-	   ,@body))))
-
-
-(defmacro loop-accumulate-minimax-value (lm operation form)
-  (let* ((answer-var (loop-minimax-answer-variable lm))
-	 (temp-var (loop-minimax-temp-variable lm))
-	 (flag-var (loop-minimax-flag-variable lm))
-	 (test
-	   (hide-variable-reference
-	     t (loop-minimax-answer-variable lm)
-	     `(,(ecase operation
-		  (min '<)
-		  (max '>))
-	       ,temp-var ,answer-var))))
-    `(progn
-       (setq ,temp-var ,form)
-       (when ,(if flag-var `(or (not ,flag-var) ,test) test)
-	 (setq ,@(and flag-var `(,flag-var t))
-	       ,answer-var ,temp-var)))))
-
-
-
-;;;; Loop Keyword Tables
-
-
-#|
-LOOP keyword tables are hash tables string keys and a test of EQUAL.
-
-The actual descriptive/dispatch structure used by LOOP is called a "loop
-universe" contains a few tables and parameterizations.  The basic idea is
-that we can provide a non-extensible ANSI-compatible loop environment,
-an extensible ANSI-superset loop environment, and (for such environments
-as CLOE) one which is "sufficiently close" to the old Genera-vintage
-LOOP for use by old user programs without requiring all of the old LOOP
-code to be loaded.
-|#
-
-
-;;;; Token Hackery
-
-
-;;;Compare two "tokens".  The first is the frob out of *LOOP-SOURCE-CODE*,
-;;; the second a symbol to check against.
-(defun loop-tequal (x1 x2)
-  (and (symbolp x1) (string= x1 x2)))
-
-
-(defun loop-tassoc (kwd alist)
-  (and (symbolp kwd) (assoc kwd alist :test #'string=)))
-
-
-(defun loop-tmember (kwd list)
-  (and (symbolp kwd) (member kwd list :test #'string=)))
-
-
-(defun loop-lookup-keyword (loop-token table)
-  (and (symbolp loop-token)
-       (values (gethash (symbol-name loop-token) table))))
-
-
-(defmacro loop-store-table-data (symbol table datum)
-  `(setf (gethash (symbol-name ,symbol) ,table) ,datum))
-
-
-(defstruct (loop-universe
-	     (:print-function print-loop-universe)
-	     (:copier nil)
-	     (:predicate nil))
-  keywords					;hash table, value = (fn-name . extra-data).
-  iteration-keywords				;hash table, value = (fn-name . extra-data).
-  for-keywords					;hash table, value = (fn-name . extra-data).
-  path-keywords					;hash table, value = (fn-name . extra-data).
-  type-symbols					;hash table of type SYMBOLS, test EQ, value = CL type specifier.
-  type-keywords					;hash table of type STRINGS, test EQUAL, value = CL type spec.
-  ansi						;NIL, T, or :EXTENDED.
-  implicit-for-required				;see loop-hack-iteration
-  )
-
-
-(defun print-loop-universe (u stream level)
-  (declare (ignore level))
-  (let ((str (case (loop-universe-ansi u)
-	       ((nil) "Non-ANSI")
-	       ((t) "ANSI")
-	       (:extended "Extended-ANSI")
-	       (t (loop-universe-ansi u)))))
-    ;;Cloe could be done with the above except for bootstrap lossage...
-    #+CLOE
-    (format stream "#<~S ~A ~X>" (type-of u) str (sys::address-of u))
-    #+Genera					;@@@@ This is reallly the ANSI definition.
-    (print-unreadable-object (u stream :type t :identity t)
-      (princ str stream))
-    #-(or Genera CLOE)
-    (format stream "#<~S ~A>" (type-of u) str)
-    ))
-
-
-;;;This is the "current" loop context in use when we are expanding a
-;;;loop.  It gets bound on each invocation of LOOP.
-(defvar *loop-universe*)
-
-
-(defun make-standard-loop-universe (&key keywords for-keywords iteration-keywords path-keywords
-				    type-keywords type-symbols ansi)
-  #-(and CLOE Source-Bootstrap) (check-type ansi (member nil t :extended))
-  (flet ((maketable (entries)
-	   (let* ((size (length entries))
-		  (ht (make-hash-table :size (if (< size 10) 10 size) :test #'equal)))
-	     (dolist (x entries) (setf (gethash (symbol-name (car x)) ht) (cadr x)))
-	     ht)))
-    (make-loop-universe
-      :keywords (maketable keywords)
-      :for-keywords (maketable for-keywords)
-      :iteration-keywords (maketable iteration-keywords)
-      :path-keywords (maketable path-keywords)
-      :ansi ansi
-      :implicit-for-required (not (null ansi))
-      :type-keywords (maketable type-keywords)
-      :type-symbols (let* ((size (length type-symbols))
-			   (ht (make-hash-table :size (if (< size 10) 10 size) :test #'eq)))
-		      (dolist (x type-symbols)
-			(if (atom x) (setf (gethash x ht) x) (setf (gethash (car x) ht) (cadr x))))
-		      ht)))) 
-
-
-;;;; Setq Hackery
-
-
-(defvar *loop-destructuring-hooks*
-	nil
-  "If not NIL, this must be a list of two things:
-a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.")
-
-
-(defun loop-make-psetq (frobs)
-  (and frobs
-       (loop-make-desetq
-	 (list (car frobs)
-	       (if (null (cddr frobs)) (cadr frobs)
-		   `(prog1 ,(cadr frobs)
-			   ,(loop-make-psetq (cddr frobs))))))))
-
-
-(defun loop-make-desetq (var-val-pairs)
-  (if (null var-val-pairs)
-      nil
-      (cons (if *loop-destructuring-hooks*
-		(cadr *loop-destructuring-hooks*)
-		'loop-really-desetq)
-	    var-val-pairs)))
-
-
-(defvar *loop-desetq-temporary*
-	(make-symbol "LOOP-DESETQ-TEMP"))
-
-
-(defmacro loop-really-desetq (&environment env &rest var-val-pairs)
-  (labels ((find-non-null (var)
-	     ;; see if there's any non-null thing here
-	     ;; recurse if the list element is itself a list
-	     (do ((tail var)) ((not (consp tail)) tail)
-	       (when (find-non-null (pop tail)) (return t))))
-	   (loop-desetq-internal (var val &optional temp)
-	     ;; returns a list of actions to be performed
-	     (typecase var
-	       (null
-		 (when (consp val)
-		   ;; don't lose possible side-effects
-		   (if (eq (car val) 'prog1)
-		       ;; these can come from psetq or desetq below.
-		       ;; throw away the value, keep the side-effects.
-		       ;;Special case is for handling an expanded POP.
-		       (mapcan #'(lambda (x)
-				   (and (consp x)
-					(or (not (eq (car x) 'car))
-					    (not (symbolp (cadr x)))
-					    (not (symbolp (setq x (macroexpand x env)))))
-					(cons x nil)))
-			       (cdr val))
-		       `(,val))))
-	       (cons
-		 (let* ((car (car var))
-			(cdr (cdr var))
-			(car-non-null (find-non-null car))
-			(cdr-non-null (find-non-null cdr)))
-		   (when (or car-non-null cdr-non-null)
-		     (if cdr-non-null
-			 (let* ((temp-p temp)
-				(temp (or temp *loop-desetq-temporary*))
-				(body #+LOOP-Prefer-POP `(,@(loop-desetq-internal
-							      car
-							      `(prog1 (car ,temp)
-								      (setq ,temp (cdr ,temp))))
-							  ,@(loop-desetq-internal cdr temp temp))
-				      #-LOOP-Prefer-POP `(,@(loop-desetq-internal car `(car ,temp))
-							  (setq ,temp (cdr ,temp))
-							  ,@(loop-desetq-internal cdr temp temp))))
-			   (if temp-p
-			       `(,@(unless (eq temp val)
-				     `((setq ,temp ,val)))
-				 ,@body)
-			       `((let ((,temp ,val))
-				   ,@body))))
-			 ;; no cdring to do
-			 (loop-desetq-internal car `(car ,val) temp)))))
-	       (otherwise
-		 (unless (eq var val)
-		   `((setq ,var ,val)))))))
-    (do ((actions))
-	((null var-val-pairs)
-	 (if (null (cdr actions)) (car actions) `(progn ,@(nreverse actions))))
-      (setq actions (revappend
-		      (loop-desetq-internal (pop var-val-pairs) (pop var-val-pairs))
-		      actions)))))
-
-
-;;;; LOOP-local variables
-
-;;;This is the "current" pointer into the LOOP source code.
-(defvar *loop-source-code*)
-
-
-;;;This is the pointer to the original, for things like NAMED that
-;;;insist on being in a particular position
-(defvar *loop-original-source-code*)
-
-
-;;;This is *loop-source-code* as of the "last" clause.  It is used
-;;;primarily for generating error messages (see loop-error, loop-warn).
-(defvar *loop-source-context*)
-
-
-;;;List of names for the LOOP, supplied by the NAMED clause.
-(defvar *loop-names*)
-
-;;;The macroexpansion environment given to the macro.
-(defvar *loop-macro-environment*)
-
-;;;This holds variable names specified with the USING clause.
-;;; See LOOP-NAMED-VARIABLE.
-(defvar *loop-named-variables*)
-
-;;; LETlist-like list being accumulated for one group of parallel bindings.
-(defvar *loop-variables*)
-
-;;;List of declarations being accumulated in parallel with
-;;;*loop-variables*.
-(defvar *loop-declarations*)
-
-;;;Used by LOOP for destructuring binding, if it is doing that itself.
-;;; See loop-make-variable.
-(defvar *loop-desetq-crocks*)
-
-;;; List of wrapping forms, innermost first, which go immediately inside
-;;; the current set of parallel bindings being accumulated in
-;;; *loop-variables*.  The wrappers are appended onto a body.  E.g.,
-;;; this list could conceivably has as its value ((with-open-file (g0001
-;;; g0002 ...))), with g0002 being one of the bindings in
-;;; *loop-variables* (this is why the wrappers go inside of the variable
-;;; bindings).
-(defvar *loop-wrappers*)
-
-;;;This accumulates lists of previous values of *loop-variables* and the
-;;;other lists  above, for each new nesting of bindings.  See
-;;;loop-bind-block.
-(defvar *loop-bind-stack*)
-
-;;;This is a LOOP-global variable for the (obsolete) NODECLARE clause
-;;;which inhibits  LOOP from actually outputting a type declaration for
-;;;an iteration (or any) variable.
-(defvar *loop-nodeclare*)
-
-;;;This is simply a list of LOOP iteration variables, used for checking
-;;;for duplications.
-(defvar *loop-iteration-variables*)
-
-
-;;;List of prologue forms of the loop, accumulated in reverse order.
-(defvar *loop-prologue*)
-
-(defvar *loop-before-loop*)
-(defvar *loop-body*)
-(defvar *loop-after-body*)
-
-;;;This is T if we have emitted any body code, so that iteration driving
-;;;clauses can be disallowed.   This is not strictly the same as
-;;;checking *loop-body*, because we permit some clauses  such as RETURN
-;;;to not be considered "real" body (so as to permit the user to "code"
-;;;an  abnormal return value "in loop").
-(defvar *loop-emitted-body*)
-
-
-;;;List of epilogue forms (supplied by FINALLY generally), accumulated
-;;; in reverse order.
-(defvar *loop-epilogue*)
-
-;;;List of epilogue forms which are supplied after the above "user"
-;;;epilogue.  "normal" termination return values are provide by putting
-;;;the return form in here.  Normally this is done using
-;;;loop-emit-final-value, q.v.
-(defvar *loop-after-epilogue*)
-
-;;;The "culprit" responsible for supplying a final value from the loop.
-;;;This  is so loop-emit-final-value can moan about multiple return
-;;;values being supplied.
-(defvar *loop-final-value-culprit*)
-
-;;;If not NIL, we are in some branch of a conditional.  Some clauses may
-;;;be disallowed.
-(defvar *loop-inside-conditional*)
-
-;;;If not NIL, this is a temporary bound around the loop for holding the
-;;;temporary  value for "it" in things like "when (f) collect it".  It
-;;;may be used as a supertemporary by some other things.
-(defvar *loop-when-it-variable*)
-
-;;;Sometimes we decide we need to fold together parts of the loop, but
-;;;some part of the generated iteration  code is different for the first
-;;;and remaining iterations.  This variable will be the temporary which 
-;;;is the flag used in the loop to tell whether we are in the first or
-;;;remaining iterations.
-(defvar *loop-never-stepped-variable*)
-
-;;;List of all the value-accumulation descriptor structures in the loop.
-;;; See loop-get-collection-info.
-(defvar *loop-collection-cruft*)		; for multiple COLLECTs (etc)
-
-
-;;;; Code Analysis Stuff
-
-
-(defun loop-constant-fold-if-possible (form &optional expected-type)
-  #+Genera (declare (values new-form constantp constant-value))
-  (let ((new-form form) (constantp nil) (constant-value nil))
-    #+Genera (setq new-form (compiler:optimize-form form *loop-macro-environment*
-						    :repeat t
-						    :do-macro-expansion t
-						    :do-named-constants t
-						    :do-inline-forms t
-						    :do-optimizers t
-						    :do-constant-folding t
-						    :do-function-args t)
-		   constantp (constantp new-form *loop-macro-environment*)
-		   constant-value (and constantp (lt:evaluate-constant new-form *loop-macro-environment*)))
-    #-Genera (when (setq constantp (constantp new-form))
-	       (setq constant-value (eval new-form)))
-    (when (and constantp expected-type)
-      (unless (typep constant-value expected-type)
-	(loop-warn "The form ~S evaluated to ~S, which was not of the anticipated type ~S."
-		   form constant-value expected-type)
-	(setq constantp nil constant-value nil)))
-    (values new-form constantp constant-value)))
-
-
-(defun loop-constantp (form)
-  #+Genera (constantp form *loop-macro-environment*)
-  #-Genera (constantp form))
-
-
-;;;; LOOP Iteration Optimization
-
-(defvar *loop-duplicate-code*
-	nil)
-
-
-(defvar *loop-iteration-flag-variable*
-	(make-symbol "LOOP-NOT-FIRST-TIME"))
-
-
-(defun loop-code-duplication-threshold (env)
-  (multiple-value-bind (speed space) (loop-optimization-quantities env)
-    (+ 40 (* (- speed space) 10))))
-
-
-(defmacro loop-body (&environment env
-		     prologue
-		     before-loop
-		     main-body
-		     after-loop
-		     epilogue
-		     &aux rbefore rafter flagvar)
-  (unless (= (length before-loop) (length after-loop))
-    (error "LOOP-BODY called with non-synched before- and after-loop lists."))
-  ;;All our work is done from these copies, working backwards from the end:
-  (setq rbefore (reverse before-loop) rafter (reverse after-loop))
-  (labels ((psimp (l)
-	     (let ((ans nil))
-	       (dolist (x l)
-		 (when x
-		   (push x ans)
-		   (when (and (consp x) (member (car x) '(go return return-from)))
-		     (return nil))))
-	       (nreverse ans)))
-	   (pify (l) (if (null (cdr l)) (car l) `(progn ,@l)))
-	   (makebody ()
-	     (let ((form `(tagbody
-			    ,@(psimp (append prologue (nreverse rbefore)))
-			 next-loop
-			    ,@(psimp (append main-body (nreconc rafter `((go next-loop)))))
-			 end-loop
-			    ,@(psimp epilogue))))
-	       (if flagvar `(let ((,flagvar nil)) ,form) form))))
-    (when (or *loop-duplicate-code* (not rbefore))
-      (return-from loop-body (makebody)))
-    ;; This outer loop iterates once for each not-first-time flag test generated
-    ;; plus once more for the forms that don't need a flag test
-    (do ((threshold (loop-code-duplication-threshold env))) (nil)
-      (declare (fixnum threshold))
-      ;; Go backwards from the ends of before-loop and after-loop merging all the equivalent
-      ;; forms into the body.
-      (do () ((or (null rbefore) (not (equal (car rbefore) (car rafter)))))
-	(push (pop rbefore) main-body)
-	(pop rafter))
-      (unless rbefore (return (makebody)))
-      ;; The first forms in rbefore & rafter (which are the chronologically
-      ;; last forms in the list) differ, therefore they cannot be moved
-      ;; into the main body.  If everything that chronologically precedes
-      ;; them either differs or is equal but is okay to duplicate, we can
-      ;; just put all of rbefore in the prologue and all of rafter after
-      ;; the body.  Otherwise, there is something that is not okay to
-      ;; duplicate, so it and everything chronologically after it in
-      ;; rbefore and rafter must go into the body, with a flag test to
-      ;; distinguish the first time around the loop from later times.
-      ;; What chronologically precedes the non-duplicatable form will
-      ;; be handled the next time around the outer loop.
-      (do ((bb rbefore (cdr bb)) (aa rafter (cdr aa)) (lastdiff nil) (count 0) (inc nil))
-	  ((null bb) (return-from loop-body (makebody)))	;Did it.
-	(cond ((not (equal (car bb) (car aa))) (setq lastdiff bb count 0))
-	      ((or (not (setq inc (estimate-code-size (car bb) env)))
-		   (> (incf count inc) threshold))
-	       ;; Ok, we have found a non-duplicatable piece of code.  Everything
-	       ;; chronologically after it must be in the central body.
-	       ;; Everything chronologically at and after lastdiff goes into the
-	       ;; central body under a flag test.
-	       (let ((then nil) (else nil))
-		 (do () (nil)
-		   (push (pop rbefore) else)
-		   (push (pop rafter) then)
-		   (when (eq rbefore (cdr lastdiff)) (return)))
-		 (unless flagvar
-		   (push `(setq ,(setq flagvar *loop-iteration-flag-variable*) t) else))
-		 (push `(if ,flagvar ,(pify (psimp then)) ,(pify (psimp else)))
-		       main-body))
-	       ;; Everything chronologically before lastdiff until the non-duplicatable form (car bb) 
-	       ;; is the same in rbefore and rafter so just copy it into the body
-	       (do () (nil)
-		 (pop rafter)
-		 (push (pop rbefore) main-body)
-		 (when (eq rbefore (cdr bb)) (return)))
-	       (return)))))))
-
-
-
-(defun duplicatable-code-p (expr env)
-  (if (null expr) 0
-      (let ((ans (estimate-code-size expr env)))
-	(declare (fixnum ans))
-	;;@@@@ Use (DECLARATION-INFORMATION 'OPTIMIZE ENV) here to get an alist of
-	;; optimize quantities back to help quantify how much code we are willing to
-	;; duplicate.
-	ans)))
-
-
-(defvar *special-code-sizes*
-	'((return 0) (progn 0)
-	  (null 1) (not 1) (eq 1) (car 1) (cdr 1)
-	  (when 1) (unless 1) (if 1)
-	  (caar 2) (cadr 2) (cdar 2) (cddr 2)
-	  (caaar 3) (caadr 3) (cadar 3) (caddr 3) (cdaar 3) (cdadr 3) (cddar 3) (cdddr 3)
-	  (caaaar 4) (caaadr 4) (caadar 4) (caaddr 4)
-	  (cadaar 4) (cadadr 4) (caddar 4) (cadddr 4)
-	  (cdaaar 4) (cdaadr 4) (cdadar 4) (cdaddr 4)
-	  (cddaar 4) (cddadr 4) (cdddar 4) (cddddr 4)))
-
-
-(defvar *estimate-code-size-punt*
-	'(block
-	   do do* dolist
-	   flet
-	   labels lambda let let* locally
-	   macrolet multiple-value-bind
-	   prog prog*
-	   symbol-macrolet
-	   tagbody
-	   unwind-protect
-	   with-open-file))
-
-
-(defun destructuring-size (x)
-  (do ((x x (cdr x)) (n 0 (+ (destructuring-size (car x)) n)))
-      ((atom x) (+ n (if (null x) 0 1)))))
-
-
-(defun estimate-code-size (x env)
-  (catch 'estimate-code-size
-    (estimate-code-size-1 x env)))
-
-
-(defun estimate-code-size-1 (x env)
-  (flet ((list-size (l)
-	   (let ((n 0))
-	     (declare (fixnum n))
-	     (dolist (x l n) (incf n (estimate-code-size-1 x env))))))
-    ;;@@@@ ???? (declare (function list-size (list) fixnum))
-    (cond ((constantp x #+Genera env) 1)
-	  ((symbolp x) (multiple-value-bind (new-form expanded-p) (macroexpand-1 x env)
-			 (if expanded-p (estimate-code-size-1 new-form env) 1)))
-	  ((atom x) 1)				;??? self-evaluating???
-	  ((symbolp (car x))
-	   (let ((fn (car x)) (tem nil) (n 0))
-	     (declare (symbol fn) (fixnum n))
-	     (macrolet ((f (overhead &optional (args nil args-p))
-			  `(the fixnum (+ (the fixnum ,overhead)
-					  (the fixnum (list-size ,(if args-p args '(cdr x))))))))
-	       (cond ((setq tem (get fn 'estimate-code-size))
-		      (typecase tem
-			(fixnum (f tem))
-			(t (funcall tem x env))))
-		     ((setq tem (assoc fn *special-code-sizes*)) (f (second tem)))
-		     #+Genera
-		     ((eq fn 'compiler:invisible-references) (list-size (cddr x)))
-		     ((eq fn 'cond)
-		      (dolist (clause (cdr x) n) (incf n (list-size clause)) (incf n)))
-		     ((eq fn 'desetq)
-		      (do ((l (cdr x) (cdr l))) ((null l) n)
-			(setq n (+ n (destructuring-size (car l)) (estimate-code-size-1 (cadr l) env)))))
-		     ((member fn '(setq psetq))
-		      (do ((l (cdr x) (cdr l))) ((null l) n)
-			(setq n (+ n (estimate-code-size-1 (cadr l) env) 1))))
-		     ((eq fn 'go) 1)
-		     ((eq fn 'function)
-		      ;;This skirts the issue of implementationally-defined lambda macros
-		      ;; by recognizing CL function names and nothing else.
-		      (if (or (symbolp (cadr x))
-			      (and (consp (cadr x)) (eq (caadr x) 'setf)))
-			  1
-			  (throw 'duplicatable-code-p nil)))
-		     ((eq fn 'multiple-value-setq) (f (length (second x)) (cddr x)))
-		     ((eq fn 'return-from) (1+ (estimate-code-size-1 (third x) env)))
-		     ((or (special-operator-p fn) (member fn *estimate-code-size-punt*))
-		      (throw 'estimate-code-size nil))
-		     (t (multiple-value-bind (new-form expanded-p) (macroexpand-1 x env)
-			  (if expanded-p
-			      (estimate-code-size-1 new-form env)
-			      (f 3))))))))
-	  (t (throw 'estimate-code-size nil)))))
-
-
-;;;; Loop Errors
-
-
-(defun loop-context ()
-  (do ((l *loop-source-context* (cdr l)) (new nil (cons (car l) new)))
-      ((eq l (cdr *loop-source-code*)) (nreverse new))))
-
-
-(defun loop-error (format-string &rest format-args)
-  #+(or Genera CLOE) (declare (dbg:error-reporter))
-  #+Genera (setq format-args (copy-list format-args))	;Don't ask.
-  (error "~?~%Current LOOP context:~{ ~S~}." format-string format-args (loop-context)))
-
-
-(defun loop-warn (format-string &rest format-args)
-  (warn "~?~%Current LOOP context:~{ ~S~}." format-string format-args (loop-context)))
-
-
-(defun loop-check-data-type (specified-type required-type
-			     &optional (default-type required-type))
-  (if (null specified-type)
-      default-type
-      (multiple-value-bind (a b) (subtypep specified-type required-type)
-	(cond ((not b)
-	       (loop-warn "LOOP couldn't verify that ~S is a subtype of the required type ~S."
-			  specified-type required-type))
-	      ((not a)
-	       (loop-error "Specified data type ~S is not a subtype of ~S."
-			   specified-type required-type)))
-	specified-type)))
-
-
-;;;INTERFACE: Traditional, ANSI, Lucid.
-(defmacro loop-finish () 
-  "Causes the iteration to terminate \"normally\", the same as implicit
-termination by an iteration driving clause, or by use of WHILE or
-UNTIL -- the epilogue code (if any) will be run, and any implicitly
-collected result will be returned as the value of the LOOP."
-  '(go end-loop))
-
-
-
-
-(defun loop-translate (*loop-source-code* *loop-macro-environment* *loop-universe*)
-  (let ((*loop-original-source-code* *loop-source-code*)
-	(*loop-source-context* nil)
-	(*loop-iteration-variables* nil)
-	(*loop-variables* nil)
-	(*loop-nodeclare* nil)
-	(*loop-named-variables* nil)
-	(*loop-declarations* nil)
-	(*loop-desetq-crocks* nil)
-	(*loop-bind-stack* nil)
-	(*loop-prologue* nil)
-	(*loop-wrappers* nil)
-	(*loop-before-loop* nil)
-	(*loop-body* nil)
-	(*loop-emitted-body* nil)
-	(*loop-after-body* nil)
-	(*loop-epilogue* nil)
-	(*loop-after-epilogue* nil)
-	(*loop-final-value-culprit* nil)
-	(*loop-inside-conditional* nil)
-	(*loop-when-it-variable* nil)
-	(*loop-never-stepped-variable* nil)
-	(*loop-names* nil)
-	(*loop-collection-cruft* nil))
-    (loop-iteration-driver)
-    (loop-bind-block)
-    (let ((answer `(loop-body
-		     ,(nreverse *loop-prologue*)
-		     ,(nreverse *loop-before-loop*)
-		     ,(nreverse *loop-body*)
-		     ,(nreverse *loop-after-body*)
-		     ,(nreconc *loop-epilogue* (nreverse *loop-after-epilogue*)))))
-      (do () (nil)
-	(setq answer `(block ,(pop *loop-names*) ,answer))
-	(unless *loop-names* (return nil)))
-      (dolist (entry *loop-bind-stack*)
-	(let ((vars (first entry))
-	      (dcls (second entry))
-	      (crocks (third entry))
-	      (wrappers (fourth entry)))
-	  (dolist (w wrappers)
-	    (setq answer (append w (list answer))))
-	  (when (or vars dcls crocks)
-	    (let ((forms (list answer)))
-	      ;;(when crocks (push crocks forms))
-	      (when dcls (push `(declare ,@dcls) forms))
-	      (setq answer `(,(cond ((not vars) 'locally)
-				    (*loop-destructuring-hooks* (first *loop-destructuring-hooks*))
-				    (t 'let))
-			     ,vars
-			     ,@(if crocks
-				   `((destructuring-bind ,@crocks
-					 ,@forms))
-				 forms)))))))
-      answer)))
-
-
-(defun loop-iteration-driver ()
-  (do () ((null *loop-source-code*))
-    (let ((keyword (car *loop-source-code*)) (tem nil))
-      (cond ((not (symbolp keyword))
-	     (loop-error "~S found where LOOP keyword expected." keyword))
-	    (t (setq *loop-source-context* *loop-source-code*)
-	       (loop-pop-source)
-	       (cond ((setq tem (loop-lookup-keyword keyword (loop-universe-keywords *loop-universe*)))
-		      ;;It's a "miscellaneous" toplevel LOOP keyword (do, collect, named, etc.)
-		      (apply (symbol-function (first tem)) (rest tem)))
-		     ((setq tem (loop-lookup-keyword keyword (loop-universe-iteration-keywords *loop-universe*)))
-		      (loop-hack-iteration tem))
-		     ((loop-tmember keyword '(and else))
-		      ;; Alternative is to ignore it, ie let it go around to the next keyword...
-		      (loop-error "Secondary clause misplaced at top level in LOOP macro: ~S ~S ~S ..."
-				  keyword (car *loop-source-code*) (cadr *loop-source-code*)))
-		     (t (loop-error "~S is an unknown keyword in LOOP macro." keyword))))))))
-
-
-
-(defun loop-pop-source ()
-  (if *loop-source-code*
-      (pop *loop-source-code*)
-      (loop-error "LOOP source code ran out when another token was expected.")))
-
-
-(defun loop-get-progn ()
-  (do ((forms (list (loop-pop-source)) (cons (loop-pop-source) forms))
-       (nextform (car *loop-source-code*) (car *loop-source-code*)))
-      ((atom nextform)
-       (if (null (cdr forms)) (car forms) (cons 'progn (nreverse forms))))))
-
-
-(defun loop-get-form ()
-  (if *loop-source-code*
-      (loop-pop-source)
-      (loop-error "LOOP code ran out where a form was expected.")))
-
-
-(defun loop-construct-return (form)
-  `(return-from ,(car *loop-names*) ,form))
-
-
-(defun loop-pseudo-body (form)
-  (cond ((or *loop-emitted-body* *loop-inside-conditional*) (push form *loop-body*))
-	(t (push form *loop-before-loop*) (push form *loop-after-body*))))
-
-(defun loop-emit-body (form)
-  (setq *loop-emitted-body* t)
-  (loop-pseudo-body form))
-
-(defun loop-emit-final-value (form)
-  (push (loop-construct-return form) *loop-after-epilogue*)
-  (when *loop-final-value-culprit*
-    (loop-warn "LOOP clause is providing a value for the iteration,~@
-	        however one was already established by a ~S clause."
-	       *loop-final-value-culprit*))
-  (setq *loop-final-value-culprit* (car *loop-source-context*)))
-
-
-(defun loop-disallow-conditional (&optional kwd)
-  #+(or Genera CLOE) (declare (dbg:error-reporter))
-  (when *loop-inside-conditional*
-    (loop-error "~:[This LOOP~;The LOOP ~:*~S~] clause is not permitted inside a conditional." kwd)))
-
-
-;;;; Loop Types
-
-
-(defun loop-typed-init (data-type)
-  (when (and data-type (subtypep data-type 'number))
-    (if (or (subtypep data-type 'float) (subtypep data-type '(complex float)))
-	(coerce 0 data-type)
-	0)))
-
-
-(defun loop-optional-type (&optional variable)
-  ;;No variable specified implies that no destructuring is permissible.
-  (and *loop-source-code*			;Don't get confused by NILs...
-       (let ((z (car *loop-source-code*)))
-	 (cond ((loop-tequal z 'of-type)
-		;;This is the syntactically unambigous form in that the form of the
-		;; type specifier does not matter.  Also, it is assumed that the
-		;; type specifier is unambiguously, and without need of translation,
-		;; a common lisp type specifier or pattern (matching the variable) thereof.
-		(loop-pop-source)
-		(loop-pop-source))
-	       ((symbolp z)
-		;;This is the (sort of) "old" syntax, even though we didn't used to support all of
-		;; these type symbols.
-		(let ((type-spec (or (gethash z (loop-universe-type-symbols *loop-universe*))
-				     (gethash (symbol-name z) (loop-universe-type-keywords *loop-universe*)))))
-		  (when type-spec
-		    (loop-pop-source)
-		    type-spec)))
-	       (t 
-		;;This is our sort-of old syntax.  But this is only valid for when we are destructuring,
-		;; so we will be compulsive (should we really be?) and require that we in fact be
-		;; doing variable destructuring here.  We must translate the old keyword pattern typespec
-		;; into a fully-specified pattern of real type specifiers here.
-		(if (consp variable)
-		    (unless (consp z)
-		     (loop-error
-			"~S found where a LOOP keyword, LOOP type keyword, or LOOP type pattern expected."
-			z))
-		    (loop-error "~S found where a LOOP keyword or LOOP type keyword expected." z))
-		(loop-pop-source)
-		(labels ((translate (k v)
-			   (cond ((null k) nil)
-				 ((atom k)
-				  (replicate
-				    (or (gethash k (loop-universe-type-symbols *loop-universe*))
-					(gethash (symbol-name k) (loop-universe-type-keywords *loop-universe*))
-					(loop-error
-					  "Destructuring type pattern ~S contains unrecognized type keyword ~S."
-					  z k))
-				    v))
-				 ((atom v)
-				  (loop-error
-				    "Destructuring type pattern ~S doesn't match variable pattern ~S."
-				    z variable))
-				 (t (cons (translate (car k) (car v)) (translate (cdr k) (cdr v))))))
-			 (replicate (typ v)
-			   (if (atom v) typ (cons (replicate typ (car v)) (replicate typ (cdr v))))))
-		  (translate z variable)))))))
-
-
-
-;;;; Loop Variables
-
-
-(defun loop-bind-block ()
-  (when (or *loop-variables* *loop-declarations* *loop-wrappers*)
-    (push (list (nreverse *loop-variables*) *loop-declarations* *loop-desetq-crocks* *loop-wrappers*)
-	  *loop-bind-stack*)
-    (setq *loop-variables* nil
-	  *loop-declarations* nil
-	  *loop-desetq-crocks* nil
-	  *loop-wrappers* nil)))
-
-
-(defun loop-make-variable (name initialization dtype &optional iteration-variable-p)
-  (cond ((null name)
-	 (cond ((not (null initialization))
-		(push (list (setq name (loop-gentemp 'loop-ignore-))
-			    initialization)
-		      *loop-variables*)
-		(push `(ignore ,name) *loop-declarations*))))
-	((atom name)
-	 (cond (iteration-variable-p
-		(if (member name *loop-iteration-variables*)
-		    (loop-error "Duplicated LOOP iteration variable ~S." name)
-		    (push name *loop-iteration-variables*)))
-	       ((assoc name *loop-variables*)
-		(loop-error "Duplicated variable ~S in LOOP parallel binding." name)))
-	 (unless (symbolp name)
-	   (loop-error "Bad variable ~S somewhere in LOOP." name))
-	 (loop-declare-variable name dtype)
-	 ;; We use ASSOC on this list to check for duplications (above),
-	 ;; so don't optimize out this list:
-	 (push (list name (or initialization (loop-typed-init dtype)))
-	       *loop-variables*))
-	(initialization
-	 (cond (*loop-destructuring-hooks*
-		(loop-declare-variable name dtype)
-		(push (list name initialization) *loop-variables*))
-	       (t (let ((newvar (loop-gentemp 'loop-destructure-)))
-		    (push (list newvar initialization) *loop-variables*)
-		    ;; *LOOP-DESETQ-CROCKS* gathered in reverse order.
-		    (setq *loop-desetq-crocks*
-		      (list* name newvar *loop-desetq-crocks*))
-		    #+ignore
-		    (loop-make-variable name nil dtype iteration-variable-p)))))
-	(t (let ((tcar nil) (tcdr nil))
-	     (if (atom dtype) (setq tcar (setq tcdr dtype))
-		 (setq tcar (car dtype) tcdr (cdr dtype)))
-	     (loop-make-variable (car name) nil tcar iteration-variable-p)
-	     (loop-make-variable (cdr name) nil tcdr iteration-variable-p))))
-  name)
-
-
-(defun loop-make-iteration-variable (name initialization dtype)
-  (loop-make-variable name initialization dtype t))
-
-
-(defun loop-declare-variable (name dtype)
-  (cond ((or (null name) (null dtype) (eq dtype t)) nil)
-	((symbolp name)
-	 (unless (or (eq dtype t) (member (the symbol name) *loop-nodeclare*))
-	   (push `(type ,dtype ,name) *loop-declarations*)))
-	((consp name)
-	 (cond ((consp dtype)
-		(loop-declare-variable (car name) (car dtype))
-		(loop-declare-variable (cdr name) (cdr dtype)))
-	       (t (loop-declare-variable (car name) dtype)
-		  (loop-declare-variable (cdr name) dtype))))
-	(t (error "Invalid LOOP variable passed in: ~S." name))))
-
-
-(defun loop-maybe-bind-form (form data-type)
-  (if (loop-constantp form)
-      form
-      (loop-make-variable (loop-gentemp 'loop-bind-) form data-type)))
-
-
-
-(defun loop-do-if (for negatep)
-  (let ((form (loop-get-form)) (*loop-inside-conditional* t) (it-p nil))
-    (flet ((get-clause (for)
-	     (do ((body nil)) (nil)
-	       (let ((key (car *loop-source-code*)) (*loop-body* nil) data)
-		 (cond ((not (symbolp key))
-			(loop-error
-			  "~S found where keyword expected getting LOOP clause after ~S."
-			  key for))
-		       (t (setq *loop-source-context* *loop-source-code*)
-			  (loop-pop-source)
-			  (when (loop-tequal (car *loop-source-code*) 'it)
-			    (setq *loop-source-code*
-				  (cons (or it-p (setq it-p (loop-when-it-variable)))
-					(cdr *loop-source-code*))))
-			  (cond ((or (not (setq data (loop-lookup-keyword
-						       key (loop-universe-keywords *loop-universe*))))
-				     (progn (apply (symbol-function (car data)) (cdr data))
-					    (null *loop-body*)))
-				 (loop-error
-				   "~S does not introduce a LOOP clause that can follow ~S."
-				   key for))
-				(t (setq body (nreconc *loop-body* body)))))))
-	       (if (loop-tequal (car *loop-source-code*) :and)
-		   (loop-pop-source)
-		   (return (if (cdr body) `(progn ,@(nreverse body)) (car body)))))))
-      (let ((then (get-clause for))
-	    (else (when (loop-tequal (car *loop-source-code*) :else)
-		    (loop-pop-source)
-		    (list (get-clause :else)))))
-	(when (loop-tequal (car *loop-source-code*) :end)
-	  (loop-pop-source))
-	(when it-p (setq form `(setq ,it-p ,form)))
-	(loop-pseudo-body
-	  `(if ,(if negatep `(not ,form) form)
-	       ,then
-	       ,@else))))))
-
-
-(defun loop-do-initially ()
-  (loop-disallow-conditional :initially)
-  (push (loop-get-progn) *loop-prologue*))
-
-(defun loop-do-finally ()
-  (loop-disallow-conditional :finally)
-  (push (loop-get-progn) *loop-epilogue*))
-
-(defun loop-do-do ()
-  (loop-emit-body (loop-get-progn)))
-
-(defun loop-do-named ()
-  (let ((name (loop-pop-source)))
-    (unless (symbolp name)
-      (loop-error "~S is an invalid name for your LOOP." name))
-    (when (or *loop-before-loop* *loop-body* *loop-after-epilogue* *loop-inside-conditional*)
-      (loop-error "The NAMED ~S clause occurs too late." name))
-    (when *loop-names*
-      (loop-error "You may only use one NAMED clause in your loop: NAMED ~S ... NAMED ~S."
-		  (car *loop-names*) name))
-    (setq *loop-names* (list name nil))))
-
-(defun loop-do-return ()
-  (loop-pseudo-body (loop-construct-return (loop-get-form))))
-
-
-;;;; Value Accumulation: List
-
-
-(defstruct (loop-collector
-	     (:copier nil)
-	     (:predicate nil))
-  name
-  class
-  (history nil)
-  (tempvars nil)
-  dtype
-  (data nil))						;collector-specific data
-
-
-(defun loop-get-collection-info (collector class default-type)
-  (let ((form (loop-get-form))
-	(dtype (and (not (loop-universe-ansi *loop-universe*)) (loop-optional-type)))
-	(name (when (loop-tequal (car *loop-source-code*) 'into)
-		(loop-pop-source)
-		(loop-pop-source))))
-    (when (not (symbolp name))
-      (loop-error "Value accumulation recipient name, ~S, is not a symbol." name))
-    (unless dtype
-      (setq dtype (or (loop-optional-type) default-type)))
-    (let ((cruft (find (the symbol name) *loop-collection-cruft*
-		       :key #'loop-collector-name)))
-      (cond ((not cruft)
-	     (push (setq cruft (make-loop-collector
-				 :name name :class class
-				 :history (list collector) :dtype dtype))
-		   *loop-collection-cruft*))
-	    (t (unless (eq (loop-collector-class cruft) class)
-		 (loop-error
-		   "Incompatible kinds of LOOP value accumulation specified for collecting~@
-		    ~:[as the value of the LOOP~;~:*INTO ~S~]: ~S and ~S."
-		   name (car (loop-collector-history cruft)) collector))
-	       (unless (equal dtype (loop-collector-dtype cruft))
-		 (loop-warn
-		   "Unequal datatypes specified in different LOOP value accumulations~@
-		   into ~S: ~S and ~S."
-		   name dtype (loop-collector-dtype cruft))
-		 (when (eq (loop-collector-dtype cruft) t)
-		   (setf (loop-collector-dtype cruft) dtype)))
-	       (push collector (loop-collector-history cruft))))
-      (values cruft form))))
-
-
-(defun loop-list-collection (specifically)	;NCONC, LIST, or APPEND
-  (multiple-value-bind (lc form) (loop-get-collection-info specifically 'list 'list)
-    (let ((tempvars (loop-collector-tempvars lc)))
-      (unless tempvars
-	(setf (loop-collector-tempvars lc)
-	      (setq tempvars (list* (loop-gentemp 'loop-list-head-)
-				    (loop-gentemp 'loop-list-tail-)
-				    (and (loop-collector-name lc)
-					 (list (loop-collector-name lc))))))
-	(push `(with-loop-list-collection-head ,tempvars) *loop-wrappers*)
-	(unless (loop-collector-name lc)
-	  (loop-emit-final-value `(loop-collect-answer ,(car tempvars) ,@(cddr tempvars)))))
-      (ecase specifically
-	(list (setq form `(list ,form)))
-	(nconc nil)
-	(append (unless (and (consp form) (eq (car form) 'list))
-		  (setq form `(loop-copylist* ,form)))))
-      (loop-emit-body `(loop-collect-rplacd ,tempvars ,form)))))
-
-
-;;;; Value Accumulation: max, min, sum, count.
-
-
-
-(defun loop-sum-collection (specifically required-type default-type)	;SUM, COUNT
-  (multiple-value-bind (lc form)
-      (loop-get-collection-info specifically 'sum default-type)
-    (loop-check-data-type (loop-collector-dtype lc) required-type)
-    (let ((tempvars (loop-collector-tempvars lc)))
-      (unless tempvars
-	(setf (loop-collector-tempvars lc)
-	      (setq tempvars (list (loop-make-variable
-				     (or (loop-collector-name lc)
-					 (loop-gentemp 'loop-sum-))
-				     nil (loop-collector-dtype lc)))))
-	(unless (loop-collector-name lc)
-	  (loop-emit-final-value (car (loop-collector-tempvars lc)))))
-      (loop-emit-body
-	(if (eq specifically 'count)
-	    `(when ,form
-	       (setq ,(car tempvars)
-		     ,(hide-variable-reference t (car tempvars) `(1+ ,(car tempvars)))))
-	    `(setq ,(car tempvars)
-		   (+ ,(hide-variable-reference t (car tempvars) (car tempvars))
-		      ,form)))))))
-
-
-
-(defun loop-maxmin-collection (specifically)
-  (multiple-value-bind (lc form)
-      (loop-get-collection-info specifically 'maxmin *loop-real-data-type*)
-    (loop-check-data-type (loop-collector-dtype lc) *loop-real-data-type*)
-    (let ((data (loop-collector-data lc)))
-      (unless data
-	(setf (loop-collector-data lc)
-	      (setq data (make-loop-minimax
-			   (or (loop-collector-name lc) (loop-gentemp 'loop-maxmin-))
-			   (loop-collector-dtype lc))))
-	(unless (loop-collector-name lc)
-	  (loop-emit-final-value (loop-minimax-answer-variable data))))
-      (loop-note-minimax-operation specifically data)
-      (push `(with-minimax-value ,data) *loop-wrappers*)
-      (loop-emit-body `(loop-accumulate-minimax-value ,data ,specifically ,form))
-      )))
-
-
-;;;; Value Accumulation:  Aggregate Booleans
-
-;;;ALWAYS and NEVER.
-;;; Under ANSI these are not permitted to appear under conditionalization.
-(defun loop-do-always (restrictive negate)
-  (let ((form (loop-get-form)))
-    (when restrictive (loop-disallow-conditional))
-    (loop-emit-body `(,(if negate 'when 'unless) ,form
-		      ,(loop-construct-return nil)))
-    (loop-emit-final-value t)))
-
-
-
-;;;THERIS.
-;;; Under ANSI this is not permitted to appear under conditionalization.
-(defun loop-do-thereis (restrictive)
-  (when restrictive (loop-disallow-conditional))
-  (loop-emit-body `(when (setq ,(loop-when-it-variable) ,(loop-get-form))
-		     ,(loop-construct-return *loop-when-it-variable*))))
-
-
-(defun loop-do-while (negate kwd &aux (form (loop-get-form)))
-  (loop-disallow-conditional kwd)
-  (loop-pseudo-body `(,(if negate 'when 'unless) ,form (go end-loop))))
-
-
-(defun loop-do-with ()
-  (loop-disallow-conditional :with)
-  (do ((var) (val) (dtype)) (nil)
-    (setq var (loop-pop-source)
-	  dtype (loop-optional-type var)
-	  val (cond ((loop-tequal (car *loop-source-code*) :=)
-		     (loop-pop-source)
-		     (loop-get-form))
-		    (t nil)))
-    (loop-make-variable var val dtype)
-    (if (loop-tequal (car *loop-source-code*) :and)
-	(loop-pop-source)
-	(return (loop-bind-block)))))
-
-
-;;;; The iteration driver
-
-(defun loop-hack-iteration (entry)
-  (flet ((make-endtest (list-of-forms)
-	   (cond ((null list-of-forms) nil)
-		 ((member t list-of-forms) '(go end-loop))
-		 (t `(when ,(if (null (cdr (setq list-of-forms (nreverse list-of-forms))))
-				(car list-of-forms)
-				(cons 'or list-of-forms))
-		       (go end-loop))))))
-    (do ((pre-step-tests nil)
-	 (steps nil)
-	 (post-step-tests nil)
-	 (pseudo-steps nil)
-	 (pre-loop-pre-step-tests nil)
-	 (pre-loop-steps nil)
-	 (pre-loop-post-step-tests nil)
-	 (pre-loop-pseudo-steps nil)
-	 (tem) (data))
-	(nil)
-      ;; Note we collect endtests in reverse order, but steps in correct
-      ;; order.  MAKE-ENDTEST does the nreverse for us.
-      (setq tem (setq data (apply (symbol-function (first entry)) (rest entry))))
-      (and (car tem) (push (car tem) pre-step-tests))
-      (setq steps (nconc steps (loop-copylist* (car (setq tem (cdr tem))))))
-      (and (car (setq tem (cdr tem))) (push (car tem) post-step-tests))
-      (setq pseudo-steps (nconc pseudo-steps (loop-copylist* (car (setq tem (cdr tem))))))
-      (setq tem (cdr tem))
-      (when *loop-emitted-body*
-	(loop-error "Iteration in LOOP follows body code."))
-      (unless tem (setq tem data))
-      (when (car tem) (push (car tem) pre-loop-pre-step-tests))
-      (setq pre-loop-steps (nconc pre-loop-steps (loop-copylist* (car (setq tem (cdr tem))))))
-      (when (car (setq tem (cdr tem))) (push (car tem) pre-loop-post-step-tests))
-      (setq pre-loop-pseudo-steps (nconc pre-loop-pseudo-steps (loop-copylist* (cadr tem))))
-      (unless (loop-tequal (car *loop-source-code*) :and)
-	(setq *loop-before-loop* (list* (loop-make-desetq pre-loop-pseudo-steps)
-					(make-endtest pre-loop-post-step-tests)
-					(loop-make-psetq pre-loop-steps)
-					(make-endtest pre-loop-pre-step-tests)
-					*loop-before-loop*)
-	      *loop-after-body* (list* (loop-make-desetq pseudo-steps)
-				       (make-endtest post-step-tests)
-				       (loop-make-psetq steps)
-				       (make-endtest pre-step-tests)
-				       *loop-after-body*))
-	(loop-bind-block)
-	(return nil))
-      (loop-pop-source)				; flush the "AND"
-      (when (and (not (loop-universe-implicit-for-required *loop-universe*))
-		 (setq tem (loop-lookup-keyword
-			     (car *loop-source-code*)
-			     (loop-universe-iteration-keywords *loop-universe*))))
-	;;Latest ANSI clarification is that the FOR/AS after the AND must NOT be supplied.
-	(loop-pop-source)
-	(setq entry tem)))))
-
-
-;;;; Main Iteration Drivers
-
-
-;FOR variable keyword ..args..
-(defun loop-do-for ()
-  (let* ((var (loop-pop-source))
-	 (data-type (loop-optional-type var))
-	 (keyword (loop-pop-source))
-	 (first-arg nil)
-	 (tem nil))
-    (setq first-arg (loop-get-form))
-    (unless (and (symbolp keyword)
-		 (setq tem (loop-lookup-keyword
-			     keyword
-			     (loop-universe-for-keywords *loop-universe*))))
-      (loop-error "~S is an unknown keyword in FOR or AS clause in LOOP." keyword))
-    (apply (car tem) var first-arg data-type (cdr tem))))
-
-
-(defun loop-do-repeat ()
-  (let ((form (loop-get-form))
-	(type (loop-check-data-type (loop-optional-type) *loop-real-data-type*)))
-    (when (and (consp form) (eq (car form) 'the) (subtypep (second form) type))
-      (setq type (second form)))
-    (multiple-value-bind (number constantp value)
-	(loop-constant-fold-if-possible form type)
-      (cond ((and constantp (<= value 1)) `(t () () () ,(<= value 0) () () ()))
-	    (t (let ((var (loop-make-variable (loop-gentemp 'loop-repeat-) number type)))
-		 (if constantp
-		     `((not (plusp (setq ,var (1- ,var)))) () () () () () () ())
-		     `((minusp (setq ,var (1- ,var))) () () ()))))))))
-
-
-(defun loop-when-it-variable ()
-  (or *loop-when-it-variable*
-      (setq *loop-when-it-variable*
-	    (loop-make-variable (loop-gentemp 'loop-it-) nil nil))))
-
-
-;;;; Various FOR/AS Subdispatches
-
-
-;;;ANSI "FOR x = y [THEN z]" is sort of like the old Genera one when the THEN
-;;; is omitted (other than being more stringent in its placement), and like
-;;; the old "FOR x FIRST y THEN z" when the THEN is present.  I.e., the first
-;;; initialization occurs in the loop body (first-step), not in the variable binding
-;;; phase.
-(defun loop-ansi-for-equals (var val data-type)
-  (loop-make-iteration-variable var nil data-type)
-  (cond ((loop-tequal (car *loop-source-code*) :then)
-	 ;;Then we are the same as "FOR x FIRST y THEN z".
-	 (loop-pop-source)
-	 `(() (,var ,(loop-get-form)) () ()
-	   () (,var ,val) () ()))
-	(t ;;We are the same as "FOR x = y".
-	 `(() (,var ,val) () ()))))
-
-
-(defun loop-for-across (var val data-type)
-  (loop-make-iteration-variable var nil data-type)
-  (let ((vector-var (loop-gentemp 'loop-across-vector-))
-	(index-var (loop-gentemp 'loop-across-index-)))
-    (multiple-value-bind (vector-form constantp vector-value)
-	(loop-constant-fold-if-possible val 'vector)
-      (loop-make-variable
-	vector-var vector-form
-	(if (and (consp vector-form) (eq (car vector-form) 'the))
-	    (cadr vector-form)
-	    'vector))
-      #+Genera (push `(system:array-register ,vector-var) *loop-declarations*)
-      (loop-make-variable index-var 0 'fixnum)
-      (let* ((length 0)
-	     (length-form (cond ((not constantp)
-				 (let ((v (loop-gentemp 'loop-across-limit-)))
-				   (push `(setq ,v (length ,vector-var)) *loop-prologue*)
-				   (loop-make-variable v 0 'fixnum)))
-				(t (setq length (length vector-value)))))
-	     (first-test `(>= ,index-var ,length-form))
-	     (other-test first-test)
-	     (step `(,var (aref ,vector-var ,index-var)))
-	     (pstep `(,index-var (1+ ,index-var))))
-	(declare (fixnum length))
-	(when constantp
-	  (setq first-test (= length 0))
-	  (when (<= length 1)
-	    (setq other-test t)))
-	`(,other-test ,step () ,pstep
-	  ,@(and (not (eq first-test other-test)) `(,first-test ,step () ,pstep)))))))
-
-
-
-;;;; List Iteration
-
-
-(defun loop-list-step (listvar)
-  ;;We are not equipped to analyze whether 'FOO is the same as #'FOO here in any
-  ;; sensible fashion, so let's give an obnoxious warning whenever 'FOO is used
-  ;; as the stepping function.
-  ;;While a Discerning Compiler may deal intelligently with (funcall 'foo ...), not
-  ;; recognizing FOO may defeat some LOOP optimizations.
-  (let ((stepper (cond ((loop-tequal (car *loop-source-code*) :by)
-			(loop-pop-source)
-			(loop-get-form))
-		       (t '(function cdr)))))
-    (cond ((and (consp stepper) (eq (car stepper) 'quote))
-	   (loop-warn "Use of QUOTE around stepping function in LOOP will be left verbatim.")
-	   (values `(funcall ,stepper ,listvar) nil))
-	  ((and (consp stepper) (eq (car stepper) 'function))
-	   (values (list (cadr stepper) listvar) (cadr stepper)))
-	  (t (values `(funcall ,(loop-make-variable (loop-gentemp 'loop-fn-) stepper 'function)
-			       ,listvar)
-		     nil)))))
-
-
-(defun loop-for-on (var val data-type)
-  (multiple-value-bind (list constantp list-value) (loop-constant-fold-if-possible val)
-    (let ((listvar var))
-      (cond ((and var (symbolp var)) (loop-make-iteration-variable var list data-type))
-	    (t (loop-make-variable (setq listvar (loop-gentemp)) list 'list)
-	       (loop-make-iteration-variable var nil data-type)))
-      (multiple-value-bind (list-step step-function) (loop-list-step listvar)
-	(declare #+(and (not LOOP-Prefer-POP) (not CLOE)) (ignore step-function))
-	;;@@@@ The CLOE problem above has to do with bug in macroexpansion of multiple-value-bind.
-	(let* ((first-endtest
-		(hide-variable-reference
-		 (eq var listvar)
-		 listvar
-		 ;; the following should use `atom' instead of `endp', per
-		 ;; [bug2428]
-		 `(atom ,listvar)))
-	       (other-endtest first-endtest))
-	  (when (and constantp (listp list-value))
-	    (setq first-endtest (null list-value)))
-	  (cond ((eq var listvar)
-		 ;;Contour of the loop is different because we use the user's variable...
-		 `(() (,listvar ,(hide-variable-reference t listvar list-step)) ,other-endtest
-		   () () () ,first-endtest ()))
-		#+LOOP-Prefer-POP
-		((and step-function
-		      (let ((n (cdr (assoc step-function '((cdr . 1) (cddr . 2)
-							   (cdddr . 3) (cddddr . 4))))))
-			(and n (do ((l var (cdr l)) (i 0 (1+ i)))
-				   ((atom l) (and (null l) (= i n)))
-				 (declare (fixnum i))))))
-		 (let ((step (mapcan #'(lambda (x) (list x `(pop ,listvar))) var)))
-		   `(,other-endtest () () ,step ,first-endtest () () ,step)))
-		(t (let ((step `(,var ,listvar)) (pseudo `(,listvar ,list-step)))
-		     `(,other-endtest ,step () ,pseudo
-		       ,@(and (not (eq first-endtest other-endtest))
-			      `(,first-endtest ,step () ,pseudo)))))))))))
-
-
-(defun loop-for-in (var val data-type)
-  (multiple-value-bind (list constantp list-value) (loop-constant-fold-if-possible val)
-    (let ((listvar (loop-gentemp 'loop-list-)))
-      (loop-make-iteration-variable var nil data-type)
-      (loop-make-variable listvar list 'list)
-      (multiple-value-bind (list-step step-function) (loop-list-step listvar)
-	#-LOOP-Prefer-POP (declare (ignore step-function))
-	(let* ((first-endtest `(endp ,listvar))
-	       (other-endtest first-endtest)
-	       (step `(,var (car ,listvar)))
-	       (pseudo-step `(,listvar ,list-step)))
-	  (when (and constantp (listp list-value))
-	    (setq first-endtest (null list-value)))
-	  #+LOOP-Prefer-POP (when (eq step-function 'cdr)
-			      (setq step `(,var (pop ,listvar)) pseudo-step nil))
-	  `(,other-endtest ,step () ,pseudo-step
-	    ,@(and (not (eq first-endtest other-endtest))
-		   `(,first-endtest ,step () ,pseudo-step))))))))
-
-
-;;;; Iteration Paths
-
-
-(defstruct (loop-path
-	     (:copier nil)
-	     (:predicate nil))
-  names
-  preposition-groups
-  inclusive-permitted
-  function
-  user-data)
-
-
-(defun add-loop-path (names function universe &key preposition-groups inclusive-permitted user-data)
-  (unless (listp names) (setq names (list names)))
-  ;; Can't do this due to CLOS bootstrapping problems.
-  #-(or Genera (and CLOE Source-Bootstrap)) (check-type universe loop-universe)
-  (let ((ht (loop-universe-path-keywords universe))
-	(lp (make-loop-path
-	      :names (mapcar #'symbol-name names)
-	      :function function
-	      :user-data user-data
-	      :preposition-groups (mapcar #'(lambda (x) (if (listp x) x (list x))) preposition-groups)
-	      :inclusive-permitted inclusive-permitted)))
-    (dolist (name names) (setf (gethash (symbol-name name) ht) lp))
-    lp))
-
-
-;;; Note:  path functions are allowed to use loop-make-variable, hack
-;;; the prologue, etc.
-(defun loop-for-being (var val data-type)
-  ;; FOR var BEING each/the pathname prep-phrases using-stuff...
-  ;; each/the = EACH or THE.  Not clear if it is optional, so I guess we'll warn.
-  (let ((path nil)
-	(data nil)
-	(inclusive nil)
-	(stuff nil)
-	(initial-prepositions nil))
-    (cond ((loop-tmember val '(:each :the)) (setq path (loop-pop-source)))
-	  ((loop-tequal (car *loop-source-code*) :and)
-	   (loop-pop-source)
-	   (setq inclusive t)
-	   (unless (loop-tmember (car *loop-source-code*) '(:its :each :his :her))
-	     (loop-error "~S found where ITS or EACH expected in LOOP iteration path syntax."
-			 (car *loop-source-code*)))
-	   (loop-pop-source)
-	   (setq path (loop-pop-source))
-	   (setq initial-prepositions `((:in ,val))))
-	  (t (loop-error "Unrecognizable LOOP iteration path syntax.  Missing EACH or THE?")))
-    (cond ((not (symbolp path))
-	   (loop-error "~S found where a LOOP iteration path name was expected." path))
-	  ((not (setq data (loop-lookup-keyword path (loop-universe-path-keywords *loop-universe*))))
-	   (loop-error "~S is not the name of a LOOP iteration path." path))
-	  ((and inclusive (not (loop-path-inclusive-permitted data)))
-	   (loop-error "\"Inclusive\" iteration is not possible with the ~S LOOP iteration path." path)))
-    (let ((fun (loop-path-function data))
-	  (preps (nconc initial-prepositions
-			(loop-collect-prepositional-phrases (loop-path-preposition-groups data) t)))
-	  (user-data (loop-path-user-data data)))
-      (when (symbolp fun) (setq fun (symbol-function fun)))
-      (setq stuff (if inclusive
-		      (apply fun var data-type preps :inclusive t user-data)
-		      (apply fun var data-type preps user-data))))
-    (when *loop-named-variables*
-      (loop-error "Unused USING variables: ~S." *loop-named-variables*))
-    ;; STUFF is now (bindings prologue-forms . stuff-to-pass-back).  Protect the system from the user
-    ;; and the user from himself.
-    (unless (member (length stuff) '(6 10))
-      (loop-error "Value passed back by LOOP iteration path function for path ~S has invalid length."
-		  path))
-    (do ((l (car stuff) (cdr l)) (x)) ((null l))
-      (if (atom (setq x (car l)))
-	  (loop-make-iteration-variable x nil nil)
-	  (loop-make-iteration-variable (car x) (cadr x) (caddr x))))
-    (setq *loop-prologue* (nconc (reverse (cadr stuff)) *loop-prologue*))
-    (cddr stuff)))
-
-
-
-;;;INTERFACE:  Lucid, exported.
-;;; i.e., this is part of our extended ansi-loop interface.
-(defun named-variable (name)
-  (let ((tem (loop-tassoc name *loop-named-variables*)))
-    (declare (list tem))
-    (cond ((null tem) (values (loop-gentemp) nil))
-	  (t (setq *loop-named-variables* (delete tem *loop-named-variables*))
-	     (values (cdr tem) t)))))
-
-
-(defun loop-collect-prepositional-phrases (preposition-groups &optional USING-allowed initial-phrases)
-  (flet ((in-group-p (x group) (car (loop-tmember x group))))
-    (do ((token nil)
-	 (prepositional-phrases initial-phrases)
-	 (this-group nil nil)
-	 (this-prep nil nil)
-	 (disallowed-prepositions
-	   (mapcan #'(lambda (x)
-		       (loop-copylist*
-			 (find (car x) preposition-groups :test #'in-group-p)))
-		   initial-phrases))
-	 (used-prepositions (mapcar #'car initial-phrases)))
-	((null *loop-source-code*) (nreverse prepositional-phrases))
-      (declare (symbol this-prep))
-      (setq token (car *loop-source-code*))
-      (dolist (group preposition-groups)
-	(when (setq this-prep (in-group-p token group))
-	  (return (setq this-group group))))
-      (cond (this-group
-	     (when (member this-prep disallowed-prepositions)
-	       (loop-error
-		 (if (member this-prep used-prepositions)
-		     "A ~S prepositional phrase occurs multiply for some LOOP clause."
-		     "Preposition ~S used when some other preposition has subsumed it.")
-		 token))
-	     (setq used-prepositions (if (listp this-group)
-					 (append this-group used-prepositions)
-					 (cons this-group used-prepositions)))
-	     (loop-pop-source)
-	     (push (list this-prep (loop-get-form)) prepositional-phrases))
-	    ((and USING-allowed (loop-tequal token 'using))
-	     (loop-pop-source)
-	     (do ((z (loop-pop-source) (loop-pop-source)) (tem)) (nil)
-	       (when (or (atom z)
-			 (atom (cdr z))
-			 (not (null (cddr z)))
-			 (not (symbolp (car z)))
-			 (and (cadr z) (not (symbolp (cadr z)))))
-		 (loop-error "~S bad variable pair in path USING phrase." z))
-	       (when (cadr z)
-		 (if (setq tem (loop-tassoc (car z) *loop-named-variables*))
-		     (loop-error
-		       "The variable substitution for ~S occurs twice in a USING phrase,~@
-		        with ~S and ~S."
-		       (car z) (cadr z) (cadr tem))
-		     (push (cons (car z) (cadr z)) *loop-named-variables*)))
-	       (when (or (null *loop-source-code*) (symbolp (car *loop-source-code*)))
-		 (return nil))))
-	    (t (return (nreverse prepositional-phrases)))))))
-
-
-;;;; Master Sequencer Function
-
-
-(defun loop-sequencer (indexv indexv-type indexv-user-specified-p
-			  variable variable-type
-			  sequence-variable sequence-type
-			  step-hack default-top
-			  prep-phrases)
-   (let ((endform nil)				;Form (constant or variable) with limit value.
-	 (sequencep nil)			;T if sequence arg has been provided.
-	 (testfn nil)				;endtest function
-	 (test nil)				;endtest form.
-	 (stepby (1+ (or (loop-typed-init indexv-type) 0)))	;Our increment.
-	 (stepby-constantp t)
-	 (step nil)				;step form.
-	 (dir nil)				;Direction of stepping: NIL, :UP, :DOWN.
-	 (inclusive-iteration nil)		;T if include last index.
-	 (start-given nil)			;T when prep phrase has specified start
-	 (start-value nil)
-	 (start-constantp nil)
-	 (limit-given nil)			;T when prep phrase has specified end
-	 (limit-constantp nil)
-	 (limit-value nil)
-	 )
-     (when variable (loop-make-iteration-variable variable nil variable-type))
-     (do ((l prep-phrases (cdr l)) (prep) (form) (odir)) ((null l))
-       (setq prep (caar l) form (cadar l))
-       (case prep
-	 ((:of :in)
-	  (setq sequencep t)
-	  (loop-make-variable sequence-variable form sequence-type))
-	 ((:from :downfrom :upfrom)
-	  (setq start-given t)
-	  (cond ((eq prep :downfrom) (setq dir ':down))
-		((eq prep :upfrom) (setq dir ':up)))
-	  (multiple-value-setq (form start-constantp start-value)
-	    (loop-constant-fold-if-possible form indexv-type))
-	  (loop-make-iteration-variable indexv form indexv-type))
-	 ((:upto :to :downto :above :below)
-	  (cond ((loop-tequal prep :upto) (setq inclusive-iteration (setq dir ':up)))
-		((loop-tequal prep :to) (setq inclusive-iteration t))
-		((loop-tequal prep :downto) (setq inclusive-iteration (setq dir ':down)))
-		((loop-tequal prep :above) (setq dir ':down))
-		((loop-tequal prep :below) (setq dir ':up)))
-	  (setq limit-given t)
-	  (multiple-value-setq (form limit-constantp limit-value)
-	    (loop-constant-fold-if-possible form indexv-type))
-	  (setq endform (if limit-constantp
-			    `',limit-value
-			    (loop-make-variable
-			      (loop-gentemp 'loop-limit-) form indexv-type))))
-	 (:by
-	   (multiple-value-setq (form stepby-constantp stepby)
-	     (loop-constant-fold-if-possible form indexv-type))
-	   (unless stepby-constantp
-	     (loop-make-variable (setq stepby (loop-gentemp 'loop-step-by-)) form indexv-type)))
-	 (t (loop-error
-	      "~S invalid preposition in sequencing or sequence path.~@
-	       Invalid prepositions specified in iteration path descriptor or something?"
-	      prep)))
-       (when (and odir dir (not (eq dir odir)))
-	 (loop-error "Conflicting stepping directions in LOOP sequencing path"))
-       (setq odir dir))
-     (when (and sequence-variable (not sequencep))
-       (loop-error "Missing OF or IN phrase in sequence path"))
-     ;; Now fill in the defaults.
-     (unless start-given
-       (loop-make-iteration-variable
-	 indexv
-	 (setq start-constantp t start-value (or (loop-typed-init indexv-type) 0))
-	 indexv-type))
-     (cond ((member dir '(nil :up))
-	    (when (or limit-given default-top)
-	      (unless limit-given
-		(loop-make-variable (setq endform (loop-gentemp 'loop-seq-limit-))
-				    nil indexv-type)
-		(push `(setq ,endform ,default-top) *loop-prologue*))
-	      (setq testfn (if inclusive-iteration '> '>=)))
-	    (setq step (if (eql stepby 1) `(1+ ,indexv) `(+ ,indexv ,stepby))))
-	   (t (unless start-given
-		(unless default-top
-		  (loop-error "Don't know where to start stepping."))
-		(push `(setq ,indexv (1- ,default-top)) *loop-prologue*))
-	      (when (and default-top (not endform))
-		(setq endform (loop-typed-init indexv-type) inclusive-iteration t))
-	      (when endform (setq testfn (if inclusive-iteration  '< '<=)))
-	      (setq step (if (eql stepby 1) `(1- ,indexv) `(- ,indexv ,stepby)))))
-     (when testfn (setq test (hide-variable-reference t indexv `(,testfn ,indexv ,endform))))
-     (when step-hack
-       (setq step-hack `(,variable ,(hide-variable-reference indexv-user-specified-p indexv step-hack))))
-     (let ((first-test test) (remaining-tests test))
-       (when (and stepby-constantp start-constantp limit-constantp)
-	 (when (setq first-test (funcall (symbol-function testfn) start-value limit-value))
-	   (setq remaining-tests t)))
-       `(() (,indexv ,(hide-variable-reference t indexv step)) ,remaining-tests ,step-hack
-	 () () ,first-test ,step-hack))))
-
-
-;;;; Interfaces to the Master Sequencer
-
-
-
-(defun loop-for-arithmetic (var val data-type kwd)
-  (loop-sequencer
-    var (loop-check-data-type data-type *loop-real-data-type*) t
-    nil nil nil nil nil nil
-    (loop-collect-prepositional-phrases
-      '((:from :upfrom :downfrom) (:to :upto :downto :above :below) (:by))
-      nil (list (list kwd val)))))
-
-
-(defun loop-sequence-elements-path (variable data-type prep-phrases
-				    &key fetch-function size-function sequence-type element-type)
-  (multiple-value-bind (indexv indexv-user-specified-p) (named-variable 'index)
-    (let ((sequencev (named-variable 'sequence)))
-      #+Genera (when (and sequencev
-			  (symbolp sequencev)
-			  sequence-type
-			  (subtypep sequence-type 'vector)
-			  (not (member (the symbol sequencev) *loop-nodeclare*)))
-		 (push `(sys:array-register ,sequencev) *loop-declarations*))
-      (list* nil nil				; dummy bindings and prologue
-	     (loop-sequencer
-	       indexv 'fixnum indexv-user-specified-p
-	       variable (or data-type element-type)
-	       sequencev sequence-type
-	       `(,fetch-function ,sequencev ,indexv) `(,size-function ,sequencev)
-	       prep-phrases)))))
-
-
-;;;; Builtin LOOP Iteration Paths
-
-
-#||
-(loop for v being the hash-values of ht do (print v))
-(loop for k being the hash-keys of ht do (print k))
-(loop for v being the hash-values of ht using (hash-key k) do (print (list k v)))
-(loop for k being the hash-keys of ht using (hash-value v) do (print (list k v)))
-||#
-
-(defun loop-hash-table-iteration-path (variable data-type prep-phrases &key which)
-  (check-type which (member hash-key hash-value))
-  (cond ((or (cdr prep-phrases) (not (member (caar prep-phrases) '(:in :of))))
-	 (loop-error "Too many prepositions!"))
-	((null prep-phrases) (loop-error "Missing OF or IN in ~S iteration path.")))
-  (let ((ht-var (loop-gentemp 'loop-hashtab-))
-	(next-fn (loop-gentemp 'loop-hashtab-next-))
-	(dummy-predicate-var nil)
-	(post-steps nil))
-    (multiple-value-bind (other-var other-p)
-	(named-variable (if (eq which 'hash-key) 'hash-value 'hash-key))
-      ;;@@@@ named-variable returns a second value of T if the name was actually
-      ;; specified, so clever code can throw away the gensym'ed up variable if
-      ;; it isn't really needed.
-      ;;The following is for those implementations in which we cannot put dummy NILs
-      ;; into multiple-value-setq variable lists.
-      #-Genera (setq other-p t
-		     dummy-predicate-var (loop-when-it-variable))
-      (let ((key-var nil)
-	    (val-var nil)
-	    (bindings `((,variable nil ,data-type)
-			(,ht-var ,(cadar prep-phrases))
-			,@(and other-p other-var `((,other-var nil))))))
-	(if (eq which 'hash-key)
-	    (setq key-var variable val-var (and other-p other-var))
-	    (setq key-var (and other-p other-var) val-var variable))
-	(push `(with-hash-table-iterator (,next-fn ,ht-var)) *loop-wrappers*)
-	(when (consp key-var)
-	  (setq post-steps `(,key-var ,(setq key-var (loop-gentemp 'loop-hash-key-temp-))
-			     ,@post-steps))
-	  (push `(,key-var nil) bindings))
-	(when (consp val-var)
-	  (setq post-steps `(,val-var ,(setq val-var (loop-gentemp 'loop-hash-val-temp-))
-			     ,@post-steps))
-	  (push `(,val-var nil) bindings))
-	`(,bindings				;bindings
-	  ()					;prologue
-	  ()					;pre-test
-	  ()					;parallel steps
-	  (not (multiple-value-setq (,dummy-predicate-var ,key-var ,val-var) (,next-fn)))	;post-test
-	  ,post-steps)))))
-
-
-(defun loop-package-symbols-iteration-path (variable data-type prep-phrases &key symbol-types)
-  (cond ((or (cdr prep-phrases) (not (member (caar prep-phrases) '(:in :of))))
-	 (loop-error "Too many prepositions!"))
-	((null prep-phrases) (loop-error "Missing OF or IN in ~S iteration path.")))
-  (unless (symbolp variable)
-    (loop-error "Destructuring is not valid for package symbol iteration."))
-  (let ((pkg-var (loop-gentemp 'loop-pkgsym-))
-	(next-fn (loop-gentemp 'loop-pkgsym-next-)))
-    (push `(with-package-iterator (,next-fn ,pkg-var ,@symbol-types)) *loop-wrappers*)
-    `(((,variable nil ,data-type) (,pkg-var ,(cadar prep-phrases)))
-      ()
-      ()
-      ()
-      (not (multiple-value-setq (,(progn
-				    ;;@@@@ If an implementation can get away without actually
-				    ;; using a variable here, so much the better.
-				    #+Genera NIL
-				    #-Genera (loop-when-it-variable))
-				 ,variable)
-	     (,next-fn)))
-      ())))
-
-;;;; ANSI Loop
-
-(defun make-ansi-loop-universe (extended-p)
-  (let ((w (make-standard-loop-universe
-	     :keywords `((named (loop-do-named))
-			 (initially (loop-do-initially))
-			 (finally (loop-do-finally))
-			 (do (loop-do-do))
-			 (doing (loop-do-do))
-			 (return (loop-do-return))
-			 (collect (loop-list-collection list))
-			 (collecting (loop-list-collection list))
-			 (append (loop-list-collection append))
-			 (appending (loop-list-collection append))
-			 (nconc (loop-list-collection nconc))
-			 (nconcing (loop-list-collection nconc))
-			 (count (loop-sum-collection count ,*loop-real-data-type* fixnum))
-			 (counting (loop-sum-collection count ,*loop-real-data-type* fixnum))
-			 (sum (loop-sum-collection sum number number))
-			 (summing (loop-sum-collection sum number number))
-			 (maximize (loop-maxmin-collection max))
-			 (minimize (loop-maxmin-collection min))
-			 (maximizing (loop-maxmin-collection max))
-			 (minimizing (loop-maxmin-collection min))
-			 (always (loop-do-always t nil))	; Normal, do always
-			 (never (loop-do-always t t))	; Negate the test on always.
-			 (thereis (loop-do-thereis t))
-			 (while (loop-do-while nil :while))	; Normal, do while
-			 (until (loop-do-while t :until))	; Negate the test on while
-			 (when (loop-do-if when nil))	; Normal, do when
-			 (if (loop-do-if if nil))	; synonymous
-			 (unless (loop-do-if unless t))	; Negate the test on when
-			 (with (loop-do-with)))
-	     :for-keywords '((= (loop-ansi-for-equals))
-			     (across (loop-for-across))
-			     (in (loop-for-in))
-			     (on (loop-for-on))
-			     (from (loop-for-arithmetic :from))
-			     (downfrom (loop-for-arithmetic :downfrom))
-			     (upfrom (loop-for-arithmetic :upfrom))
-			     (below (loop-for-arithmetic :below))
-			     (to (loop-for-arithmetic :to))
-			     (upto (loop-for-arithmetic :upto))
-			     (being (loop-for-being)))
-	     :iteration-keywords '((for (loop-do-for))
-				   (as (loop-do-for))
-				   (repeat (loop-do-repeat)))
-	     :type-symbols '(array atom bignum bit bit-vector character #| common |# compiled-function
-				   complex cons double-float fixnum float
-				   function hash-table integer keyword list long-float
-				   nil null number package pathname random-state
-				   ratio rational readtable sequence short-float
-				   simple-array simple-bit-vector simple-string
-				   simple-vector single-float standard-char
-				   stream string string-char
-				   symbol t vector)
-	     :type-keywords nil
-	     :ansi (if extended-p :extended t))))
-    (add-loop-path '(hash-key hash-keys) 'loop-hash-table-iteration-path w
-		   :preposition-groups '((:of :in))
-		   :inclusive-permitted nil
-		   :user-data '(:which hash-key))
-    (add-loop-path '(hash-value hash-values) 'loop-hash-table-iteration-path w
-		   :preposition-groups '((:of :in))
-		   :inclusive-permitted nil
-		   :user-data '(:which hash-value))
-    (add-loop-path '(symbol symbols) 'loop-package-symbols-iteration-path w
-		   :preposition-groups '((:of :in))
-		   :inclusive-permitted nil
-		   :user-data '(:symbol-types (:internal :external :inherited)))
-    (add-loop-path '(external-symbol external-symbols) 'loop-package-symbols-iteration-path w
-		   :preposition-groups '((:of :in))
-		   :inclusive-permitted nil
-		   :user-data '(:symbol-types (:external)))
-    (add-loop-path '(present-symbol present-symbols) 'loop-package-symbols-iteration-path w
-		   :preposition-groups '((:of :in))
-		   :inclusive-permitted nil
-		   :user-data '(:symbol-types (:internal)))
-    w))
-
-
-(defparameter *loop-ansi-universe*
-	      (make-ansi-loop-universe nil))
-
-
-(defun loop-standard-expansion (keywords-and-forms environment universe)
-  (if (and keywords-and-forms (symbolp (car keywords-and-forms)))
-      (loop-translate keywords-and-forms environment universe)
-      (let ((tag (gensym)))
-	`(block nil (tagbody ,tag (progn ,@keywords-and-forms) (go ,tag))))))
-
-
-;;;INTERFACE: ANSI
-(defmacro loop (&environment env &rest keywords-and-forms)
-  #+Genera (declare (compiler:do-not-record-macroexpansions)
-		    (zwei:indentation . zwei:indent-loop))
-  (loop-standard-expansion keywords-and-forms env *loop-ansi-universe*))
-
-#+allegro
-(defun excl::complex-loop-expander (body env)
-  (loop-standard-expansion body env *loop-ansi-universe*))
+;; (defmacro with-loop-list-collection-head ((head-var tail-var &optional user-head-var)
+;; 					  &body body)
+;;   ;;@@@@ TI? Exploder?
+;;   #+LISPM (let ((head-place (or user-head-var head-var)))
+;; 	    `(let* ((,head-place nil)
+;; 		    (,tail-var
+;; 		      ,(hide-variable-reference
+;; 			 user-head-var user-head-var
+;; 			 `(progn #+Genera (scl:locf ,head-place)
+;; 				 #-Genera (system:variable-location ,head-place)))))
+;; 	       ,@body))
+;;   #-LISPM (let ((l (and user-head-var (list (list user-head-var nil)))))
+;; 	    #+CLOE `(sys::with-stack-list* (,head-var nil nil)
+;; 		      (let ((,tail-var ,head-var) ,@l)
+;; 			,@body))
+;; 	    #-CLOE `(let* ((,head-var (list nil)) (,tail-var ,head-var) ,@l)
+;; 		      ,@body)))
+
+
+;; (defmacro loop-collect-rplacd (&environment env
+;; 			       (head-var tail-var &optional user-head-var) form)
+;;   (declare
+;;     #+LISPM (ignore head-var user-head-var)	;use locatives, unconditionally update through the tail.
+;;     )
+;;   (setq form (macroexpand form env))
+;;   (flet ((cdr-wrap (form n)
+;; 	   (declare (fixnum n))
+;; 	   (do () ((<= n 4) (setq form `(,(case n
+;; 					    (1 'cdr)
+;; 					    (2 'cddr)
+;; 					    (3 'cdddr)
+;; 					    (4 'cddddr))
+;; 					 ,form)))
+;; 	     (setq form `(cddddr ,form) n (- n 4)))))
+;;     (let ((tail-form form) (ncdrs nil))
+;;       ;;Determine if the form being constructed is a list of known length.
+;;       (when (consp form)
+;; 	(cond ((eq (car form) 'list)
+;; 	       (setq ncdrs (1- (length (cdr form))))
+;; 	       ;;@@@@ Because the last element is going to be RPLACDed,
+;; 	       ;; we don't want the cdr-coded implementations to use
+;; 	       ;; cdr-nil at the end (which would just force copying
+;; 	       ;; the whole list again).
+;; 	       #+LISPM (setq tail-form `(list* ,@(cdr form) nil)))
+;; 	      ((member (car form) '(list* cons))
+;; 	       (when (and (cddr form) (member (car (last form)) '(nil 'nil)))
+;; 		 (setq ncdrs (- (length (cdr form)) 2))))))
+;;       (let ((answer
+;; 	      (cond ((null ncdrs)
+;; 		     `(when (setf (cdr ,tail-var) ,tail-form)
+;; 			(setq ,tail-var (last (cdr ,tail-var)))))
+;; 		    ((< ncdrs 0) (return-from loop-collect-rplacd nil))
+;; 		    ((= ncdrs 0)
+;; 		     ;;@@@@ Here we have a choice of two idioms:
+;; 		     ;; (rplacd tail (setq tail tail-form))
+;; 		     ;; (setq tail (setf (cdr tail) tail-form)).
+;; 		     ;;Genera and most others I have seen do better with the former.
+;; 		     `(rplacd ,tail-var (setq ,tail-var ,tail-form)))
+;; 		    (t `(setq ,tail-var ,(cdr-wrap `(setf (cdr ,tail-var) ,tail-form)
+;; 						   ncdrs))))))
+;; 	;;If not using locatives or something similar to update the user's
+;; 	;; head variable, we've got to set it...  It's harmless to repeatedly set it
+;; 	;; unconditionally, and probably faster than checking.
+;; 	#-LISPM (when user-head-var
+;; 		  (setq answer `(progn ,answer (setq ,user-head-var (cdr ,head-var)))))
+;; 	answer))))
+
+
+;; (defmacro loop-collect-answer (head-var &optional user-head-var)
+;;   (or user-head-var
+;;       (progn
+;; 	;;If we use locatives to get tail-updating to update the head var,
+;; 	;; then the head var itself contains the answer.  Otherwise we
+;; 	;; have to cdr it.
+;; 	#+LISPM head-var
+;; 	#-LISPM `(cdr ,head-var))))
+;; 
+
+;; ;;;; Maximization Technology
+
+
+;; #|
+;; The basic idea of all this minimax randomness here is that we have to
+;; have constructed all uses of maximize and minimize to a particular
+;; "destination" before we can decide how to code them.  The goal is to not
+;; have to have any kinds of flags, by knowing both that (1) the type is
+;; something which we can provide an initial minimum or maximum value for
+;; and (2) know that a MAXIMIZE and MINIMIZE are not being combined.
+
+;; SO, we have a datastructure which we annotate with all sorts of things,
+;; incrementally updating it as we generate loop body code, and then use
+;; a wrapper and internal macros to do the coding when the loop has been
+;; constructed.
+;; |#
+
+
+;; (defstruct (loop-minimax
+;; 	     (:constructor make-loop-minimax-internal)
+;; 	     (:copier nil)
+;; 	     (:predicate nil))
+;;   answer-variable
+;;   type
+;;   temp-variable
+;;   flag-variable
+;;   operations
+;;   infinity-data)
+
+
+;; (defvar *loop-minimax-type-infinities-alist*
+;; 	;;@@@@ This is the sort of value this should take on for a Lisp that has
+;; 	;; "eminently usable" infinities.  n.b. there are neither constants nor
+;; 	;; printed representations for infinities defined by CL.
+;; 	;;@@@@ This grotesque read-from-string below is to help implementations
+;; 	;; which croak on the infinity character when it appears in a token, even
+;; 	;; conditionalized out.
+;; 	#+Genera
+;; 	  '#.(read-from-string
+;; 	      "((fixnum 	most-positive-fixnum	 most-negative-fixnum)
+;; 		(short-float 	+1s			 -1s)
+;; 		(single-float	+1f			 -1f)
+;; 		(double-float	+1d			 -1d)
+;; 		(long-float	+1l			 -1l))")
+;; 	;;This is how the alist should look for a lisp that has no infinities.  In
+;; 	;; that case, MOST-POSITIVE-x-FLOAT really IS the most positive.
+;; 	#+(or CLOE-Runtime Minima)
+;; 	  '((fixnum   		most-positive-fixnum		most-negative-fixnum)
+;; 	    (short-float	most-positive-short-float	most-negative-short-float)
+;; 	    (single-float	most-positive-single-float	most-negative-single-float)
+;; 	    (double-float	most-positive-double-float	most-negative-double-float)
+;; 	    (long-float		most-positive-long-float	most-negative-long-float))
+;; 	;;If we don't know, then we cannot provide "infinite" initial values for any of the
+;; 	;; types but FIXNUM:
+;; 	#-(or Genera CLOE-Runtime Minima)
+;; 	  '((fixnum   		most-positive-fixnum		most-negative-fixnum))
+;; 	  )
+
+
+;; (defun make-loop-minimax (answer-variable type)
+;;   (let ((infinity-data (cdr (assoc type *loop-minimax-type-infinities-alist* :test #'subtypep))))
+;;     (make-loop-minimax-internal
+;;       :answer-variable answer-variable
+;;       :type type
+;;       :temp-variable (loop-gentemp 'loop-maxmin-temp-)
+;;       :flag-variable (and (not infinity-data) (loop-gentemp 'loop-maxmin-flag-))
+;;       :operations nil
+;;       :infinity-data infinity-data)))
+
+
+;; (defun loop-note-minimax-operation (operation minimax)
+;;   (pushnew (the symbol operation) (loop-minimax-operations minimax))
+;;   (when (and (cdr (loop-minimax-operations minimax))
+;; 	     (not (loop-minimax-flag-variable minimax)))
+;;     (setf (loop-minimax-flag-variable minimax) (loop-gentemp 'loop-maxmin-flag-)))
+;;   operation)
+
+
+;; (defmacro with-minimax-value (lm &body body)
+;;   (let ((init (loop-typed-init (loop-minimax-type lm)))
+;; 	(which (car (loop-minimax-operations lm)))
+;; 	(infinity-data (loop-minimax-infinity-data lm))
+;; 	(answer-var (loop-minimax-answer-variable lm))
+;; 	(temp-var (loop-minimax-temp-variable lm))
+;; 	(flag-var (loop-minimax-flag-variable lm))
+;; 	(type (loop-minimax-type lm)))
+;;     (if flag-var
+;; 	`(let ((,answer-var ,init) (,temp-var ,init) (,flag-var nil))
+;; 	   (declare (type ,type ,answer-var ,temp-var))
+;; 	   ,@body)
+;; 	`(let ((,answer-var ,(if (eq which 'min) (first infinity-data) (second infinity-data)))
+;; 	       (,temp-var ,init))
+;; 	   (declare (type ,type ,answer-var ,temp-var))
+;; 	   ,@body))))
+
+
+;; (defmacro loop-accumulate-minimax-value (lm operation form)
+;;   (let* ((answer-var (loop-minimax-answer-variable lm))
+;; 	 (temp-var (loop-minimax-temp-variable lm))
+;; 	 (flag-var (loop-minimax-flag-variable lm))
+;; 	 (test
+;; 	   (hide-variable-reference
+;; 	     t (loop-minimax-answer-variable lm)
+;; 	     `(,(ecase operation
+;; 		  (min '<)
+;; 		  (max '>))
+;; 	       ,temp-var ,answer-var))))
+;;     `(progn
+;;        (setq ,temp-var ,form)
+;;        (when ,(if flag-var `(or (not ,flag-var) ,test) test)
+;; 	 (setq ,@(and flag-var `(,flag-var t))
+;; 	       ,answer-var ,temp-var)))))
+;; 
+
+
+;; ;;;; Loop Keyword Tables
+
+
+;; #|
+;; LOOP keyword tables are hash tables string keys and a test of EQUAL.
+
+;; The actual descriptive/dispatch structure used by LOOP is called a "loop
+;; universe" contains a few tables and parameterizations.  The basic idea is
+;; that we can provide a non-extensible ANSI-compatible loop environment,
+;; an extensible ANSI-superset loop environment, and (for such environments
+;; as CLOE) one which is "sufficiently close" to the old Genera-vintage
+;; LOOP for use by old user programs without requiring all of the old LOOP
+;; code to be loaded.
+;; |#
+
+
+;; ;;;; Token Hackery
+
+
+;; ;;;Compare two "tokens".  The first is the frob out of *LOOP-SOURCE-CODE*,
+;; ;;; the second a symbol to check against.
+;; (defun loop-tequal (x1 x2)
+;;   (and (symbolp x1) (string= x1 x2)))
+
+
+;; (defun loop-tassoc (kwd alist)
+;;   (and (symbolp kwd) (assoc kwd alist :test #'string=)))
+
+
+;; (defun loop-tmember (kwd list)
+;;   (and (symbolp kwd) (member kwd list :test #'string=)))
+
+
+;; (defun loop-lookup-keyword (loop-token table)
+;;   (and (symbolp loop-token)
+;;        (values (gethash (symbol-name loop-token) table))))
+
+
+;; (defmacro loop-store-table-data (symbol table datum)
+;;   `(setf (gethash (symbol-name ,symbol) ,table) ,datum))
+
+
+;; (defstruct (loop-universe
+;; 	     (:print-function print-loop-universe)
+;; 	     (:copier nil)
+;; 	     (:predicate nil))
+;;   keywords					;hash table, value = (fn-name . extra-data).
+;;   iteration-keywords				;hash table, value = (fn-name . extra-data).
+;;   for-keywords					;hash table, value = (fn-name . extra-data).
+;;   path-keywords					;hash table, value = (fn-name . extra-data).
+;;   type-symbols					;hash table of type SYMBOLS, test EQ, value = CL type specifier.
+;;   type-keywords					;hash table of type STRINGS, test EQUAL, value = CL type spec.
+;;   ansi						;NIL, T, or :EXTENDED.
+;;   implicit-for-required				;see loop-hack-iteration
+;;   )
+
+
+;; (defun print-loop-universe (u stream level)
+;;   (declare (ignore level))
+;;   (let ((str (case (loop-universe-ansi u)
+;; 	       ((nil) "Non-ANSI")
+;; 	       ((t) "ANSI")
+;; 	       (:extended "Extended-ANSI")
+;; 	       (t (loop-universe-ansi u)))))
+;;     ;;Cloe could be done with the above except for bootstrap lossage...
+;;     #+CLOE
+;;     (format stream "#<~S ~A ~X>" (type-of u) str (sys::address-of u))
+;;     #+Genera					;@@@@ This is reallly the ANSI definition.
+;;     (print-unreadable-object (u stream :type t :identity t)
+;;       (princ str stream))
+;;     #-(or Genera CLOE)
+;;     (format stream "#<~S ~A>" (type-of u) str)
+;;     ))
+
+
+;; ;;;This is the "current" loop context in use when we are expanding a
+;; ;;;loop.  It gets bound on each invocation of LOOP.
+;; (defvar *loop-universe*)
+
+
+;; (defun make-standard-loop-universe (&key keywords for-keywords iteration-keywords path-keywords
+;; 				    type-keywords type-symbols ansi)
+;;   #-(and CLOE Source-Bootstrap) (check-type ansi (member nil t :extended))
+;;   (flet ((maketable (entries)
+;; 	   (let* ((size (length entries))
+;; 		  (ht (make-hash-table :size (if (< size 10) 10 size) :test #'equal)))
+;; 	     (dolist (x entries) (setf (gethash (symbol-name (car x)) ht) (cadr x)))
+;; 	     ht)))
+;;     (make-loop-universe
+;;       :keywords (maketable keywords)
+;;       :for-keywords (maketable for-keywords)
+;;       :iteration-keywords (maketable iteration-keywords)
+;;       :path-keywords (maketable path-keywords)
+;;       :ansi ansi
+;;       :implicit-for-required (not (null ansi))
+;;       :type-keywords (maketable type-keywords)
+;;       :type-symbols (let* ((size (length type-symbols))
+;; 			   (ht (make-hash-table :size (if (< size 10) 10 size) :test #'eq)))
+;; 		      (dolist (x type-symbols)
+;; 			(if (atom x) (setf (gethash x ht) x) (setf (gethash (car x) ht) (cadr x))))
+;; 		      ht)))) 
+;; 
+
+;; ;;;; Setq Hackery
+
+
+;; (defvar *loop-destructuring-hooks*
+;; 	nil
+;;   "If not NIL, this must be a list of two things:
+;; a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.")
+
+
+;; (defun loop-make-psetq (frobs)
+;;   (and frobs
+;;        (loop-make-desetq
+;; 	 (list (car frobs)
+;; 	       (if (null (cddr frobs)) (cadr frobs)
+;; 		   `(prog1 ,(cadr frobs)
+;; 			   ,(loop-make-psetq (cddr frobs))))))))
+
+
+;; (defun loop-make-desetq (var-val-pairs)
+;;   (if (null var-val-pairs)
+;;       nil
+;;       (cons (if *loop-destructuring-hooks*
+;; 		(cadr *loop-destructuring-hooks*)
+;; 		'loop-really-desetq)
+;; 	    var-val-pairs)))
+
+
+;; (defvar *loop-desetq-temporary*
+;; 	(make-symbol "LOOP-DESETQ-TEMP"))
+
+
+;; (defmacro loop-really-desetq (&environment env &rest var-val-pairs)
+;;   (labels ((find-non-null (var)
+;; 	     ;; see if there's any non-null thing here
+;; 	     ;; recurse if the list element is itself a list
+;; 	     (do ((tail var)) ((not (consp tail)) tail)
+;; 	       (when (find-non-null (pop tail)) (return t))))
+;; 	   (loop-desetq-internal (var val &optional temp)
+;; 	     ;; returns a list of actions to be performed
+;; 	     (typecase var
+;; 	       (null
+;; 		 (when (consp val)
+;; 		   ;; don't lose possible side-effects
+;; 		   (if (eq (car val) 'prog1)
+;; 		       ;; these can come from psetq or desetq below.
+;; 		       ;; throw away the value, keep the side-effects.
+;; 		       ;;Special case is for handling an expanded POP.
+;; 		       (mapcan #'(lambda (x)
+;; 				   (and (consp x)
+;; 					(or (not (eq (car x) 'car))
+;; 					    (not (symbolp (cadr x)))
+;; 					    (not (symbolp (setq x (macroexpand x env)))))
+;; 					(cons x nil)))
+;; 			       (cdr val))
+;; 		       `(,val))))
+;; 	       (cons
+;; 		 (let* ((car (car var))
+;; 			(cdr (cdr var))
+;; 			(car-non-null (find-non-null car))
+;; 			(cdr-non-null (find-non-null cdr)))
+;; 		   (when (or car-non-null cdr-non-null)
+;; 		     (if cdr-non-null
+;; 			 (let* ((temp-p temp)
+;; 				(temp (or temp *loop-desetq-temporary*))
+;; 				(body #+LOOP-Prefer-POP `(,@(loop-desetq-internal
+;; 							      car
+;; 							      `(prog1 (car ,temp)
+;; 								      (setq ,temp (cdr ,temp))))
+;; 							  ,@(loop-desetq-internal cdr temp temp))
+;; 				      #-LOOP-Prefer-POP `(,@(loop-desetq-internal car `(car ,temp))
+;; 							  (setq ,temp (cdr ,temp))
+;; 							  ,@(loop-desetq-internal cdr temp temp))))
+;; 			   (if temp-p
+;; 			       `(,@(unless (eq temp val)
+;; 				     `((setq ,temp ,val)))
+;; 				 ,@body)
+;; 			       `((let ((,temp ,val))
+;; 				   ,@body))))
+;; 			 ;; no cdring to do
+;; 			 (loop-desetq-internal car `(car ,val) temp)))))
+;; 	       (otherwise
+;; 		 (unless (eq var val)
+;; 		   `((setq ,var ,val)))))))
+;;     (do ((actions))
+;; 	((null var-val-pairs)
+;; 	 (if (null (cdr actions)) (car actions) `(progn ,@(nreverse actions))))
+;;       (setq actions (revappend
+;; 		      (loop-desetq-internal (pop var-val-pairs) (pop var-val-pairs))
+;; 		      actions)))))
+;; 
+
+;; ;;;; LOOP-local variables
+
+;; ;;;This is the "current" pointer into the LOOP source code.
+;; (defvar *loop-source-code*)
+
+
+;; ;;;This is the pointer to the original, for things like NAMED that
+;; ;;;insist on being in a particular position
+;; (defvar *loop-original-source-code*)
+
+
+;; ;;;This is *loop-source-code* as of the "last" clause.  It is used
+;; ;;;primarily for generating error messages (see loop-error, loop-warn).
+;; (defvar *loop-source-context*)
+
+
+;; ;;;List of names for the LOOP, supplied by the NAMED clause.
+;; (defvar *loop-names*)
+
+;; ;;;The macroexpansion environment given to the macro.
+;; (defvar *loop-macro-environment*)
+
+;; ;;;This holds variable names specified with the USING clause.
+;; ;;; See LOOP-NAMED-VARIABLE.
+;; (defvar *loop-named-variables*)
+
+;; ;;; LETlist-like list being accumulated for one group of parallel bindings.
+;; (defvar *loop-variables*)
+
+;; ;;;List of declarations being accumulated in parallel with
+;; ;;;*loop-variables*.
+;; (defvar *loop-declarations*)
+
+;; ;;;Used by LOOP for destructuring binding, if it is doing that itself.
+;; ;;; See loop-make-variable.
+;; (defvar *loop-desetq-crocks*)
+
+;; ;;; List of wrapping forms, innermost first, which go immediately inside
+;; ;;; the current set of parallel bindings being accumulated in
+;; ;;; *loop-variables*.  The wrappers are appended onto a body.  E.g.,
+;; ;;; this list could conceivably has as its value ((with-open-file (g0001
+;; ;;; g0002 ...))), with g0002 being one of the bindings in
+;; ;;; *loop-variables* (this is why the wrappers go inside of the variable
+;; ;;; bindings).
+;; (defvar *loop-wrappers*)
+
+;; ;;;This accumulates lists of previous values of *loop-variables* and the
+;; ;;;other lists  above, for each new nesting of bindings.  See
+;; ;;;loop-bind-block.
+;; (defvar *loop-bind-stack*)
+
+;; ;;;This is a LOOP-global variable for the (obsolete) NODECLARE clause
+;; ;;;which inhibits  LOOP from actually outputting a type declaration for
+;; ;;;an iteration (or any) variable.
+;; (defvar *loop-nodeclare*)
+
+;; ;;;This is simply a list of LOOP iteration variables, used for checking
+;; ;;;for duplications.
+;; (defvar *loop-iteration-variables*)
+
+
+;; ;;;List of prologue forms of the loop, accumulated in reverse order.
+;; (defvar *loop-prologue*)
+
+;; (defvar *loop-before-loop*)
+;; (defvar *loop-body*)
+;; (defvar *loop-after-body*)
+
+;; ;;;This is T if we have emitted any body code, so that iteration driving
+;; ;;;clauses can be disallowed.   This is not strictly the same as
+;; ;;;checking *loop-body*, because we permit some clauses  such as RETURN
+;; ;;;to not be considered "real" body (so as to permit the user to "code"
+;; ;;;an  abnormal return value "in loop").
+;; (defvar *loop-emitted-body*)
+
+
+;; ;;;List of epilogue forms (supplied by FINALLY generally), accumulated
+;; ;;; in reverse order.
+;; (defvar *loop-epilogue*)
+
+;; ;;;List of epilogue forms which are supplied after the above "user"
+;; ;;;epilogue.  "normal" termination return values are provide by putting
+;; ;;;the return form in here.  Normally this is done using
+;; ;;;loop-emit-final-value, q.v.
+;; (defvar *loop-after-epilogue*)
+
+;; ;;;The "culprit" responsible for supplying a final value from the loop.
+;; ;;;This  is so loop-emit-final-value can moan about multiple return
+;; ;;;values being supplied.
+;; (defvar *loop-final-value-culprit*)
+
+;; ;;;If not NIL, we are in some branch of a conditional.  Some clauses may
+;; ;;;be disallowed.
+;; (defvar *loop-inside-conditional*)
+
+;; ;;;If not NIL, this is a temporary bound around the loop for holding the
+;; ;;;temporary  value for "it" in things like "when (f) collect it".  It
+;; ;;;may be used as a supertemporary by some other things.
+;; (defvar *loop-when-it-variable*)
+
+;; ;;;Sometimes we decide we need to fold together parts of the loop, but
+;; ;;;some part of the generated iteration  code is different for the first
+;; ;;;and remaining iterations.  This variable will be the temporary which 
+;; ;;;is the flag used in the loop to tell whether we are in the first or
+;; ;;;remaining iterations.
+;; (defvar *loop-never-stepped-variable*)
+
+;; ;;;List of all the value-accumulation descriptor structures in the loop.
+;; ;;; See loop-get-collection-info.
+;; (defvar *loop-collection-cruft*)		; for multiple COLLECTs (etc)
+;; 
+
+;; ;;;; Code Analysis Stuff
+
+
+;; (defun loop-constant-fold-if-possible (form &optional expected-type)
+;;   #+Genera (declare (values new-form constantp constant-value))
+;;   (let ((new-form form) (constantp nil) (constant-value nil))
+;;     #+Genera (setq new-form (compiler:optimize-form form *loop-macro-environment*
+;; 						    :repeat t
+;; 						    :do-macro-expansion t
+;; 						    :do-named-constants t
+;; 						    :do-inline-forms t
+;; 						    :do-optimizers t
+;; 						    :do-constant-folding t
+;; 						    :do-function-args t)
+;; 		   constantp (constantp new-form *loop-macro-environment*)
+;; 		   constant-value (and constantp (lt:evaluate-constant new-form *loop-macro-environment*)))
+;;     #-Genera (when (setq constantp (constantp new-form))
+;; 	       (setq constant-value (eval new-form)))
+;;     (when (and constantp expected-type)
+;;       (unless (typep constant-value expected-type)
+;; 	(loop-warn "The form ~S evaluated to ~S, which was not of the anticipated type ~S."
+;; 		   form constant-value expected-type)
+;; 	(setq constantp nil constant-value nil)))
+;;     (values new-form constantp constant-value)))
+
+
+;; (defun loop-constantp (form)
+;;   #+Genera (constantp form *loop-macro-environment*)
+;;   #-Genera (constantp form))
+;; 
+
+;; ;;;; LOOP Iteration Optimization
+
+;; (defvar *loop-duplicate-code*
+;; 	nil)
+
+
+;; (defvar *loop-iteration-flag-variable*
+;; 	(make-symbol "LOOP-NOT-FIRST-TIME"))
+
+
+;; (defun loop-code-duplication-threshold (env)
+;;   (multiple-value-bind (speed space) (loop-optimization-quantities env)
+;;     (+ 40 (* (- speed space) 10))))
+
+
+;; (defmacro loop-body (&environment env
+;; 		     prologue
+;; 		     before-loop
+;; 		     main-body
+;; 		     after-loop
+;; 		     epilogue
+;; 		     &aux rbefore rafter flagvar)
+;;   (unless (= (length before-loop) (length after-loop))
+;;     (error "LOOP-BODY called with non-synched before- and after-loop lists."))
+;;   ;;All our work is done from these copies, working backwards from the end:
+;;   (setq rbefore (reverse before-loop) rafter (reverse after-loop))
+;;   (labels ((psimp (l)
+;; 	     (let ((ans nil))
+;; 	       (dolist (x l)
+;; 		 (when x
+;; 		   (push x ans)
+;; 		   (when (and (consp x) (member (car x) '(go return return-from)))
+;; 		     (return nil))))
+;; 	       (nreverse ans)))
+;; 	   (pify (l) (if (null (cdr l)) (car l) `(progn ,@l)))
+;; 	   (makebody ()
+;; 	     (let ((form `(tagbody
+;; 			    ,@(psimp (append prologue (nreverse rbefore)))
+;; 			 next-loop
+;; 			    ,@(psimp (append main-body (nreconc rafter `((go next-loop)))))
+;; 			 end-loop
+;; 			    ,@(psimp epilogue))))
+;; 	       (if flagvar `(let ((,flagvar nil)) ,form) form))))
+;;     (when (or *loop-duplicate-code* (not rbefore))
+;;       (return-from loop-body (makebody)))
+;;     ;; This outer loop iterates once for each not-first-time flag test generated
+;;     ;; plus once more for the forms that don't need a flag test
+;;     (do ((threshold (loop-code-duplication-threshold env))) (nil)
+;;       (declare (fixnum threshold))
+;;       ;; Go backwards from the ends of before-loop and after-loop merging all the equivalent
+;;       ;; forms into the body.
+;;       (do () ((or (null rbefore) (not (equal (car rbefore) (car rafter)))))
+;; 	(push (pop rbefore) main-body)
+;; 	(pop rafter))
+;;       (unless rbefore (return (makebody)))
+;;       ;; The first forms in rbefore & rafter (which are the chronologically
+;;       ;; last forms in the list) differ, therefore they cannot be moved
+;;       ;; into the main body.  If everything that chronologically precedes
+;;       ;; them either differs or is equal but is okay to duplicate, we can
+;;       ;; just put all of rbefore in the prologue and all of rafter after
+;;       ;; the body.  Otherwise, there is something that is not okay to
+;;       ;; duplicate, so it and everything chronologically after it in
+;;       ;; rbefore and rafter must go into the body, with a flag test to
+;;       ;; distinguish the first time around the loop from later times.
+;;       ;; What chronologically precedes the non-duplicatable form will
+;;       ;; be handled the next time around the outer loop.
+;;       (do ((bb rbefore (cdr bb)) (aa rafter (cdr aa)) (lastdiff nil) (count 0) (inc nil))
+;; 	  ((null bb) (return-from loop-body (makebody)))	;Did it.
+;; 	(cond ((not (equal (car bb) (car aa))) (setq lastdiff bb count 0))
+;; 	      ((or (not (setq inc (estimate-code-size (car bb) env)))
+;; 		   (> (incf count inc) threshold))
+;; 	       ;; Ok, we have found a non-duplicatable piece of code.  Everything
+;; 	       ;; chronologically after it must be in the central body.
+;; 	       ;; Everything chronologically at and after lastdiff goes into the
+;; 	       ;; central body under a flag test.
+;; 	       (let ((then nil) (else nil))
+;; 		 (do () (nil)
+;; 		   (push (pop rbefore) else)
+;; 		   (push (pop rafter) then)
+;; 		   (when (eq rbefore (cdr lastdiff)) (return)))
+;; 		 (unless flagvar
+;; 		   (push `(setq ,(setq flagvar *loop-iteration-flag-variable*) t) else))
+;; 		 (push `(if ,flagvar ,(pify (psimp then)) ,(pify (psimp else)))
+;; 		       main-body))
+;; 	       ;; Everything chronologically before lastdiff until the non-duplicatable form (car bb) 
+;; 	       ;; is the same in rbefore and rafter so just copy it into the body
+;; 	       (do () (nil)
+;; 		 (pop rafter)
+;; 		 (push (pop rbefore) main-body)
+;; 		 (when (eq rbefore (cdr bb)) (return)))
+;; 	       (return)))))))
+;; 
+
+
+;; (defun duplicatable-code-p (expr env)
+;;   (if (null expr) 0
+;;       (let ((ans (estimate-code-size expr env)))
+;; 	(declare (fixnum ans))
+;; 	;;@@@@ Use (DECLARATION-INFORMATION 'OPTIMIZE ENV) here to get an alist of
+;; 	;; optimize quantities back to help quantify how much code we are willing to
+;; 	;; duplicate.
+;; 	ans)))
+
+
+;; (defvar *special-code-sizes*
+;; 	'((return 0) (progn 0)
+;; 	  (null 1) (not 1) (eq 1) (car 1) (cdr 1)
+;; 	  (when 1) (unless 1) (if 1)
+;; 	  (caar 2) (cadr 2) (cdar 2) (cddr 2)
+;; 	  (caaar 3) (caadr 3) (cadar 3) (caddr 3) (cdaar 3) (cdadr 3) (cddar 3) (cdddr 3)
+;; 	  (caaaar 4) (caaadr 4) (caadar 4) (caaddr 4)
+;; 	  (cadaar 4) (cadadr 4) (caddar 4) (cadddr 4)
+;; 	  (cdaaar 4) (cdaadr 4) (cdadar 4) (cdaddr 4)
+;; 	  (cddaar 4) (cddadr 4) (cdddar 4) (cddddr 4)))
+
+
+;; (defvar *estimate-code-size-punt*
+;; 	'(block
+;; 	   do do* dolist
+;; 	   flet
+;; 	   labels lambda let let* locally
+;; 	   macrolet multiple-value-bind
+;; 	   prog prog*
+;; 	   symbol-macrolet
+;; 	   tagbody
+;; 	   unwind-protect
+;; 	   with-open-file))
+
+
+;; (defun destructuring-size (x)
+;;   (do ((x x (cdr x)) (n 0 (+ (destructuring-size (car x)) n)))
+;;       ((atom x) (+ n (if (null x) 0 1)))))
+
+
+;; (defun estimate-code-size (x env)
+;;   (catch 'estimate-code-size
+;;     (estimate-code-size-1 x env)))
+
+
+;; (defun estimate-code-size-1 (x env)
+;;   (flet ((list-size (l)
+;; 	   (let ((n 0))
+;; 	     (declare (fixnum n))
+;; 	     (dolist (x l n) (incf n (estimate-code-size-1 x env))))))
+;;     ;;@@@@ ???? (declare (function list-size (list) fixnum))
+;;     (cond ((constantp x #+Genera env) 1)
+;; 	  ((symbolp x) (multiple-value-bind (new-form expanded-p) (macroexpand-1 x env)
+;; 			 (if expanded-p (estimate-code-size-1 new-form env) 1)))
+;; 	  ((atom x) 1)				;??? self-evaluating???
+;; 	  ((symbolp (car x))
+;; 	   (let ((fn (car x)) (tem nil) (n 0))
+;; 	     (declare (symbol fn) (fixnum n))
+;; 	     (macrolet ((f (overhead &optional (args nil args-p))
+;; 			  `(the fixnum (+ (the fixnum ,overhead)
+;; 					  (the fixnum (list-size ,(if args-p args '(cdr x))))))))
+;; 	       (cond ((setq tem (get fn 'estimate-code-size))
+;; 		      (typecase tem
+;; 			(fixnum (f tem))
+;; 			(t (funcall tem x env))))
+;; 		     ((setq tem (assoc fn *special-code-sizes*)) (f (second tem)))
+;; 		     #+Genera
+;; 		     ((eq fn 'compiler:invisible-references) (list-size (cddr x)))
+;; 		     ((eq fn 'cond)
+;; 		      (dolist (clause (cdr x) n) (incf n (list-size clause)) (incf n)))
+;; 		     ((eq fn 'desetq)
+;; 		      (do ((l (cdr x) (cdr l))) ((null l) n)
+;; 			(setq n (+ n (destructuring-size (car l)) (estimate-code-size-1 (cadr l) env)))))
+;; 		     ((member fn '(setq psetq))
+;; 		      (do ((l (cdr x) (cdr l))) ((null l) n)
+;; 			(setq n (+ n (estimate-code-size-1 (cadr l) env) 1))))
+;; 		     ((eq fn 'go) 1)
+;; 		     ((eq fn 'function)
+;; 		      ;;This skirts the issue of implementationally-defined lambda macros
+;; 		      ;; by recognizing CL function names and nothing else.
+;; 		      (if (or (symbolp (cadr x))
+;; 			      (and (consp (cadr x)) (eq (caadr x) 'setf)))
+;; 			  1
+;; 			  (throw 'duplicatable-code-p nil)))
+;; 		     ((eq fn 'multiple-value-setq) (f (length (second x)) (cddr x)))
+;; 		     ((eq fn 'return-from) (1+ (estimate-code-size-1 (third x) env)))
+;; 		     ((or (special-operator-p fn) (member fn *estimate-code-size-punt*))
+;; 		      (throw 'estimate-code-size nil))
+;; 		     (t (multiple-value-bind (new-form expanded-p) (macroexpand-1 x env)
+;; 			  (if expanded-p
+;; 			      (estimate-code-size-1 new-form env)
+;; 			      (f 3))))))))
+;; 	  (t (throw 'estimate-code-size nil)))))
+;; 
+
+;; ;;;; Loop Errors
+
+
+;; (defun loop-context ()
+;;   (do ((l *loop-source-context* (cdr l)) (new nil (cons (car l) new)))
+;;       ((eq l (cdr *loop-source-code*)) (nreverse new))))
+
+
+;; (defun loop-error (format-string &rest format-args)
+;;   #+(or Genera CLOE) (declare (dbg:error-reporter))
+;;   #+Genera (setq format-args (copy-list format-args))	;Don't ask.
+;;   (error "~?~%Current LOOP context:~{ ~S~}." format-string format-args (loop-context)))
+
+
+;; (defun loop-warn (format-string &rest format-args)
+;;   (warn "~?~%Current LOOP context:~{ ~S~}." format-string format-args (loop-context)))
+
+
+;; (defun loop-check-data-type (specified-type required-type
+;; 			     &optional (default-type required-type))
+;;   (if (null specified-type)
+;;       default-type
+;;       (multiple-value-bind (a b) (subtypep specified-type required-type)
+;; 	(cond ((not b)
+;; 	       (loop-warn "LOOP couldn't verify that ~S is a subtype of the required type ~S."
+;; 			  specified-type required-type))
+;; 	      ((not a)
+;; 	       (loop-error "Specified data type ~S is not a subtype of ~S."
+;; 			   specified-type required-type)))
+;; 	specified-type)))
+;; 
+
+;; ;;;INTERFACE: Traditional, ANSI, Lucid.
+;; (defmacro loop-finish () 
+;;   "Causes the iteration to terminate \"normally\", the same as implicit
+;; termination by an iteration driving clause, or by use of WHILE or
+;; UNTIL -- the epilogue code (if any) will be run, and any implicitly
+;; collected result will be returned as the value of the LOOP."
+;;   '(go end-loop))
+
+
+;; 
+
+;; (defun loop-translate (*loop-source-code* *loop-macro-environment* *loop-universe*)
+;;   (let ((*loop-original-source-code* *loop-source-code*)
+;; 	(*loop-source-context* nil)
+;; 	(*loop-iteration-variables* nil)
+;; 	(*loop-variables* nil)
+;; 	(*loop-nodeclare* nil)
+;; 	(*loop-named-variables* nil)
+;; 	(*loop-declarations* nil)
+;; 	(*loop-desetq-crocks* nil)
+;; 	(*loop-bind-stack* nil)
+;; 	(*loop-prologue* nil)
+;; 	(*loop-wrappers* nil)
+;; 	(*loop-before-loop* nil)
+;; 	(*loop-body* nil)
+;; 	(*loop-emitted-body* nil)
+;; 	(*loop-after-body* nil)
+;; 	(*loop-epilogue* nil)
+;; 	(*loop-after-epilogue* nil)
+;; 	(*loop-final-value-culprit* nil)
+;; 	(*loop-inside-conditional* nil)
+;; 	(*loop-when-it-variable* nil)
+;; 	(*loop-never-stepped-variable* nil)
+;; 	(*loop-names* nil)
+;; 	(*loop-collection-cruft* nil))
+;;     (loop-iteration-driver)
+;;     (loop-bind-block)
+;;     (let ((answer `(loop-body
+;; 		     ,(nreverse *loop-prologue*)
+;; 		     ,(nreverse *loop-before-loop*)
+;; 		     ,(nreverse *loop-body*)
+;; 		     ,(nreverse *loop-after-body*)
+;; 		     ,(nreconc *loop-epilogue* (nreverse *loop-after-epilogue*)))))
+;;       (do () (nil)
+;; 	(setq answer `(block ,(pop *loop-names*) ,answer))
+;; 	(unless *loop-names* (return nil)))
+;;       (dolist (entry *loop-bind-stack*)
+;; 	(let ((vars (first entry))
+;; 	      (dcls (second entry))
+;; 	      (crocks (third entry))
+;; 	      (wrappers (fourth entry)))
+;; 	  (dolist (w wrappers)
+;; 	    (setq answer (append w (list answer))))
+;; 	  (when (or vars dcls crocks)
+;; 	    (let ((forms (list answer)))
+;; 	      ;;(when crocks (push crocks forms))
+;; 	      (when dcls (push `(declare ,@dcls) forms))
+;; 	      (setq answer `(,(cond ((not vars) 'locally)
+;; 				    (*loop-destructuring-hooks* (first *loop-destructuring-hooks*))
+;; 				    (t 'let))
+;; 			     ,vars
+;; 			     ,@(if crocks
+;; 				   `((destructuring-bind ,@crocks
+;; 					 ,@forms))
+;; 				 forms)))))))
+;;       answer)))
+
+
+;; (defun loop-iteration-driver ()
+;;   (do () ((null *loop-source-code*))
+;;     (let ((keyword (car *loop-source-code*)) (tem nil))
+;;       (cond ((not (symbolp keyword))
+;; 	     (loop-error "~S found where LOOP keyword expected." keyword))
+;; 	    (t (setq *loop-source-context* *loop-source-code*)
+;; 	       (loop-pop-source)
+;; 	       (cond ((setq tem (loop-lookup-keyword keyword (loop-universe-keywords *loop-universe*)))
+;; 		      ;;It's a "miscellaneous" toplevel LOOP keyword (do, collect, named, etc.)
+;; 		      (apply (symbol-function (first tem)) (rest tem)))
+;; 		     ((setq tem (loop-lookup-keyword keyword (loop-universe-iteration-keywords *loop-universe*)))
+;; 		      (loop-hack-iteration tem))
+;; 		     ((loop-tmember keyword '(and else))
+;; 		      ;; Alternative is to ignore it, ie let it go around to the next keyword...
+;; 		      (loop-error "Secondary clause misplaced at top level in LOOP macro: ~S ~S ~S ..."
+;; 				  keyword (car *loop-source-code*) (cadr *loop-source-code*)))
+;; 		     (t (loop-error "~S is an unknown keyword in LOOP macro." keyword))))))))
+;; 
+
+
+;; (defun loop-pop-source ()
+;;   (if *loop-source-code*
+;;       (pop *loop-source-code*)
+;;       (loop-error "LOOP source code ran out when another token was expected.")))
+
+
+;; (defun loop-get-progn ()
+;;   (do ((forms (list (loop-pop-source)) (cons (loop-pop-source) forms))
+;;        (nextform (car *loop-source-code*) (car *loop-source-code*)))
+;;       ((atom nextform)
+;;        (if (null (cdr forms)) (car forms) (cons 'progn (nreverse forms))))))
+
+
+;; (defun loop-get-form ()
+;;   (if *loop-source-code*
+;;       (loop-pop-source)
+;;       (loop-error "LOOP code ran out where a form was expected.")))
+
+
+;; (defun loop-construct-return (form)
+;;   `(return-from ,(car *loop-names*) ,form))
+
+
+;; (defun loop-pseudo-body (form)
+;;   (cond ((or *loop-emitted-body* *loop-inside-conditional*) (push form *loop-body*))
+;; 	(t (push form *loop-before-loop*) (push form *loop-after-body*))))
+
+;; (defun loop-emit-body (form)
+;;   (setq *loop-emitted-body* t)
+;;   (loop-pseudo-body form))
+
+;; (defun loop-emit-final-value (form)
+;;   (push (loop-construct-return form) *loop-after-epilogue*)
+;;   (when *loop-final-value-culprit*
+;;     (loop-warn "LOOP clause is providing a value for the iteration,~@
+;; 	        however one was already established by a ~S clause."
+;; 	       *loop-final-value-culprit*))
+;;   (setq *loop-final-value-culprit* (car *loop-source-context*)))
+
+
+;; (defun loop-disallow-conditional (&optional kwd)
+;;   #+(or Genera CLOE) (declare (dbg:error-reporter))
+;;   (when *loop-inside-conditional*
+;;     (loop-error "~:[This LOOP~;The LOOP ~:*~S~] clause is not permitted inside a conditional." kwd)))
+;; 
+
+;; ;;;; Loop Types
+
+
+;; (defun loop-typed-init (data-type)
+;;   (when (and data-type (subtypep data-type 'number))
+;;     (if (or (subtypep data-type 'float) (subtypep data-type '(complex float)))
+;; 	(coerce 0 data-type)
+;; 	0)))
+
+
+;; (defun loop-optional-type (&optional variable)
+;;   ;;No variable specified implies that no destructuring is permissible.
+;;   (and *loop-source-code*			;Don't get confused by NILs...
+;;        (let ((z (car *loop-source-code*)))
+;; 	 (cond ((loop-tequal z 'of-type)
+;; 		;;This is the syntactically unambigous form in that the form of the
+;; 		;; type specifier does not matter.  Also, it is assumed that the
+;; 		;; type specifier is unambiguously, and without need of translation,
+;; 		;; a common lisp type specifier or pattern (matching the variable) thereof.
+;; 		(loop-pop-source)
+;; 		(loop-pop-source))
+;; 	       ((symbolp z)
+;; 		;;This is the (sort of) "old" syntax, even though we didn't used to support all of
+;; 		;; these type symbols.
+;; 		(let ((type-spec (or (gethash z (loop-universe-type-symbols *loop-universe*))
+;; 				     (gethash (symbol-name z) (loop-universe-type-keywords *loop-universe*)))))
+;; 		  (when type-spec
+;; 		    (loop-pop-source)
+;; 		    type-spec)))
+;; 	       (t 
+;; 		;;This is our sort-of old syntax.  But this is only valid for when we are destructuring,
+;; 		;; so we will be compulsive (should we really be?) and require that we in fact be
+;; 		;; doing variable destructuring here.  We must translate the old keyword pattern typespec
+;; 		;; into a fully-specified pattern of real type specifiers here.
+;; 		(if (consp variable)
+;; 		    (unless (consp z)
+;; 		     (loop-error
+;; 			"~S found where a LOOP keyword, LOOP type keyword, or LOOP type pattern expected."
+;; 			z))
+;; 		    (loop-error "~S found where a LOOP keyword or LOOP type keyword expected." z))
+;; 		(loop-pop-source)
+;; 		(labels ((translate (k v)
+;; 			   (cond ((null k) nil)
+;; 				 ((atom k)
+;; 				  (replicate
+;; 				    (or (gethash k (loop-universe-type-symbols *loop-universe*))
+;; 					(gethash (symbol-name k) (loop-universe-type-keywords *loop-universe*))
+;; 					(loop-error
+;; 					  "Destructuring type pattern ~S contains unrecognized type keyword ~S."
+;; 					  z k))
+;; 				    v))
+;; 				 ((atom v)
+;; 				  (loop-error
+;; 				    "Destructuring type pattern ~S doesn't match variable pattern ~S."
+;; 				    z variable))
+;; 				 (t (cons (translate (car k) (car v)) (translate (cdr k) (cdr v))))))
+;; 			 (replicate (typ v)
+;; 			   (if (atom v) typ (cons (replicate typ (car v)) (replicate typ (cdr v))))))
+;; 		  (translate z variable)))))))
+;; 
+
+
+;; ;;;; Loop Variables
+
+
+;; (defun loop-bind-block ()
+;;   (when (or *loop-variables* *loop-declarations* *loop-wrappers*)
+;;     (push (list (nreverse *loop-variables*) *loop-declarations* *loop-desetq-crocks* *loop-wrappers*)
+;; 	  *loop-bind-stack*)
+;;     (setq *loop-variables* nil
+;; 	  *loop-declarations* nil
+;; 	  *loop-desetq-crocks* nil
+;; 	  *loop-wrappers* nil)))
+
+
+;; (defun loop-make-variable (name initialization dtype &optional iteration-variable-p)
+;;   (cond ((null name)
+;; 	 (cond ((not (null initialization))
+;; 		(push (list (setq name (loop-gentemp 'loop-ignore-))
+;; 			    initialization)
+;; 		      *loop-variables*)
+;; 		(push `(ignore ,name) *loop-declarations*))))
+;; 	((atom name)
+;; 	 (cond (iteration-variable-p
+;; 		(if (member name *loop-iteration-variables*)
+;; 		    (loop-error "Duplicated LOOP iteration variable ~S." name)
+;; 		    (push name *loop-iteration-variables*)))
+;; 	       ((assoc name *loop-variables*)
+;; 		(loop-error "Duplicated variable ~S in LOOP parallel binding." name)))
+;; 	 (unless (symbolp name)
+;; 	   (loop-error "Bad variable ~S somewhere in LOOP." name))
+;; 	 (loop-declare-variable name dtype)
+;; 	 ;; We use ASSOC on this list to check for duplications (above),
+;; 	 ;; so don't optimize out this list:
+;; 	 (push (list name (or initialization (loop-typed-init dtype)))
+;; 	       *loop-variables*))
+;; 	(initialization
+;; 	 (cond (*loop-destructuring-hooks*
+;; 		(loop-declare-variable name dtype)
+;; 		(push (list name initialization) *loop-variables*))
+;; 	       (t (let ((newvar (loop-gentemp 'loop-destructure-)))
+;; 		    (push (list newvar initialization) *loop-variables*)
+;; 		    ;; *LOOP-DESETQ-CROCKS* gathered in reverse order.
+;; 		    (setq *loop-desetq-crocks*
+;; 		      (list* name newvar *loop-desetq-crocks*))
+;; 		    #+ignore
+;; 		    (loop-make-variable name nil dtype iteration-variable-p)))))
+;; 	(t (let ((tcar nil) (tcdr nil))
+;; 	     (if (atom dtype) (setq tcar (setq tcdr dtype))
+;; 		 (setq tcar (car dtype) tcdr (cdr dtype)))
+;; 	     (loop-make-variable (car name) nil tcar iteration-variable-p)
+;; 	     (loop-make-variable (cdr name) nil tcdr iteration-variable-p))))
+;;   name)
+
+
+;; (defun loop-make-iteration-variable (name initialization dtype)
+;;   (loop-make-variable name initialization dtype t))
+
+
+;; (defun loop-declare-variable (name dtype)
+;;   (cond ((or (null name) (null dtype) (eq dtype t)) nil)
+;; 	((symbolp name)
+;; 	 (unless (or (eq dtype t) (member (the symbol name) *loop-nodeclare*))
+;; 	   (push `(type ,dtype ,name) *loop-declarations*)))
+;; 	((consp name)
+;; 	 (cond ((consp dtype)
+;; 		(loop-declare-variable (car name) (car dtype))
+;; 		(loop-declare-variable (cdr name) (cdr dtype)))
+;; 	       (t (loop-declare-variable (car name) dtype)
+;; 		  (loop-declare-variable (cdr name) dtype))))
+;; 	(t (error "Invalid LOOP variable passed in: ~S." name))))
+
+
+;; (defun loop-maybe-bind-form (form data-type)
+;;   (if (loop-constantp form)
+;;       form
+;;       (loop-make-variable (loop-gentemp 'loop-bind-) form data-type)))
+;; 
+
+
+;; (defun loop-do-if (for negatep)
+;;   (let ((form (loop-get-form)) (*loop-inside-conditional* t) (it-p nil))
+;;     (flet ((get-clause (for)
+;; 	     (do ((body nil)) (nil)
+;; 	       (let ((key (car *loop-source-code*)) (*loop-body* nil) data)
+;; 		 (cond ((not (symbolp key))
+;; 			(loop-error
+;; 			  "~S found where keyword expected getting LOOP clause after ~S."
+;; 			  key for))
+;; 		       (t (setq *loop-source-context* *loop-source-code*)
+;; 			  (loop-pop-source)
+;; 			  (when (loop-tequal (car *loop-source-code*) 'it)
+;; 			    (setq *loop-source-code*
+;; 				  (cons (or it-p (setq it-p (loop-when-it-variable)))
+;; 					(cdr *loop-source-code*))))
+;; 			  (cond ((or (not (setq data (loop-lookup-keyword
+;; 						       key (loop-universe-keywords *loop-universe*))))
+;; 				     (progn (apply (symbol-function (car data)) (cdr data))
+;; 					    (null *loop-body*)))
+;; 				 (loop-error
+;; 				   "~S does not introduce a LOOP clause that can follow ~S."
+;; 				   key for))
+;; 				(t (setq body (nreconc *loop-body* body)))))))
+;; 	       (if (loop-tequal (car *loop-source-code*) :and)
+;; 		   (loop-pop-source)
+;; 		   (return (if (cdr body) `(progn ,@(nreverse body)) (car body)))))))
+;;       (let ((then (get-clause for))
+;; 	    (else (when (loop-tequal (car *loop-source-code*) :else)
+;; 		    (loop-pop-source)
+;; 		    (list (get-clause :else)))))
+;; 	(when (loop-tequal (car *loop-source-code*) :end)
+;; 	  (loop-pop-source))
+;; 	(when it-p (setq form `(setq ,it-p ,form)))
+;; 	(loop-pseudo-body
+;; 	  `(if ,(if negatep `(not ,form) form)
+;; 	       ,then
+;; 	       ,@else))))))
+
+
+;; (defun loop-do-initially ()
+;;   (loop-disallow-conditional :initially)
+;;   (push (loop-get-progn) *loop-prologue*))
+
+;; (defun loop-do-finally ()
+;;   (loop-disallow-conditional :finally)
+;;   (push (loop-get-progn) *loop-epilogue*))
+
+;; (defun loop-do-do ()
+;;   (loop-emit-body (loop-get-progn)))
+
+;; (defun loop-do-named ()
+;;   (let ((name (loop-pop-source)))
+;;     (unless (symbolp name)
+;;       (loop-error "~S is an invalid name for your LOOP." name))
+;;     (when (or *loop-before-loop* *loop-body* *loop-after-epilogue* *loop-inside-conditional*)
+;;       (loop-error "The NAMED ~S clause occurs too late." name))
+;;     (when *loop-names*
+;;       (loop-error "You may only use one NAMED clause in your loop: NAMED ~S ... NAMED ~S."
+;; 		  (car *loop-names*) name))
+;;     (setq *loop-names* (list name nil))))
+
+;; (defun loop-do-return ()
+;;   (loop-pseudo-body (loop-construct-return (loop-get-form))))
+;; 
+
+;; ;;;; Value Accumulation: List
+
+
+;; (defstruct (loop-collector
+;; 	     (:copier nil)
+;; 	     (:predicate nil))
+;;   name
+;;   class
+;;   (history nil)
+;;   (tempvars nil)
+;;   dtype
+;;   (data nil))						;collector-specific data
+
+
+;; (defun loop-get-collection-info (collector class default-type)
+;;   (let ((form (loop-get-form))
+;; 	(dtype (and (not (loop-universe-ansi *loop-universe*)) (loop-optional-type)))
+;; 	(name (when (loop-tequal (car *loop-source-code*) 'into)
+;; 		(loop-pop-source)
+;; 		(loop-pop-source))))
+;;     (when (not (symbolp name))
+;;       (loop-error "Value accumulation recipient name, ~S, is not a symbol." name))
+;;     (unless dtype
+;;       (setq dtype (or (loop-optional-type) default-type)))
+;;     (let ((cruft (find (the symbol name) *loop-collection-cruft*
+;; 		       :key #'loop-collector-name)))
+;;       (cond ((not cruft)
+;; 	     (push (setq cruft (make-loop-collector
+;; 				 :name name :class class
+;; 				 :history (list collector) :dtype dtype))
+;; 		   *loop-collection-cruft*))
+;; 	    (t (unless (eq (loop-collector-class cruft) class)
+;; 		 (loop-error
+;; 		   "Incompatible kinds of LOOP value accumulation specified for collecting~@
+;; 		    ~:[as the value of the LOOP~;~:*INTO ~S~]: ~S and ~S."
+;; 		   name (car (loop-collector-history cruft)) collector))
+;; 	       (unless (equal dtype (loop-collector-dtype cruft))
+;; 		 (loop-warn
+;; 		   "Unequal datatypes specified in different LOOP value accumulations~@
+;; 		   into ~S: ~S and ~S."
+;; 		   name dtype (loop-collector-dtype cruft))
+;; 		 (when (eq (loop-collector-dtype cruft) t)
+;; 		   (setf (loop-collector-dtype cruft) dtype)))
+;; 	       (push collector (loop-collector-history cruft))))
+;;       (values cruft form))))
+
+
+;; (defun loop-list-collection (specifically)	;NCONC, LIST, or APPEND
+;;   (multiple-value-bind (lc form) (loop-get-collection-info specifically 'list 'list)
+;;     (let ((tempvars (loop-collector-tempvars lc)))
+;;       (unless tempvars
+;; 	(setf (loop-collector-tempvars lc)
+;; 	      (setq tempvars (list* (loop-gentemp 'loop-list-head-)
+;; 				    (loop-gentemp 'loop-list-tail-)
+;; 				    (and (loop-collector-name lc)
+;; 					 (list (loop-collector-name lc))))))
+;; 	(push `(with-loop-list-collection-head ,tempvars) *loop-wrappers*)
+;; 	(unless (loop-collector-name lc)
+;; 	  (loop-emit-final-value `(loop-collect-answer ,(car tempvars) ,@(cddr tempvars)))))
+;;       (ecase specifically
+;; 	(list (setq form `(list ,form)))
+;; 	(nconc nil)
+;; 	(append (unless (and (consp form) (eq (car form) 'list))
+;; 		  (setq form `(loop-copylist* ,form)))))
+;;       (loop-emit-body `(loop-collect-rplacd ,tempvars ,form)))))
+;; 
+
+;; ;;;; Value Accumulation: max, min, sum, count.
+
+
+
+;; (defun loop-sum-collection (specifically required-type default-type)	;SUM, COUNT
+;;   (multiple-value-bind (lc form)
+;;       (loop-get-collection-info specifically 'sum default-type)
+;;     (loop-check-data-type (loop-collector-dtype lc) required-type)
+;;     (let ((tempvars (loop-collector-tempvars lc)))
+;;       (unless tempvars
+;; 	(setf (loop-collector-tempvars lc)
+;; 	      (setq tempvars (list (loop-make-variable
+;; 				     (or (loop-collector-name lc)
+;; 					 (loop-gentemp 'loop-sum-))
+;; 				     nil (loop-collector-dtype lc)))))
+;; 	(unless (loop-collector-name lc)
+;; 	  (loop-emit-final-value (car (loop-collector-tempvars lc)))))
+;;       (loop-emit-body
+;; 	(if (eq specifically 'count)
+;; 	    `(when ,form
+;; 	       (setq ,(car tempvars)
+;; 		     ,(hide-variable-reference t (car tempvars) `(1+ ,(car tempvars)))))
+;; 	    `(setq ,(car tempvars)
+;; 		   (+ ,(hide-variable-reference t (car tempvars) (car tempvars))
+;; 		      ,form)))))))
+
+
+
+;; (defun loop-maxmin-collection (specifically)
+;;   (multiple-value-bind (lc form)
+;;       (loop-get-collection-info specifically 'maxmin *loop-real-data-type*)
+;;     (loop-check-data-type (loop-collector-dtype lc) *loop-real-data-type*)
+;;     (let ((data (loop-collector-data lc)))
+;;       (unless data
+;; 	(setf (loop-collector-data lc)
+;; 	      (setq data (make-loop-minimax
+;; 			   (or (loop-collector-name lc) (loop-gentemp 'loop-maxmin-))
+;; 			   (loop-collector-dtype lc))))
+;; 	(unless (loop-collector-name lc)
+;; 	  (loop-emit-final-value (loop-minimax-answer-variable data))))
+;;       (loop-note-minimax-operation specifically data)
+;;       (push `(with-minimax-value ,data) *loop-wrappers*)
+;;       (loop-emit-body `(loop-accumulate-minimax-value ,data ,specifically ,form))
+;;       )))
+;; 
+
+;; ;;;; Value Accumulation:  Aggregate Booleans
+
+;; ;;;ALWAYS and NEVER.
+;; ;;; Under ANSI these are not permitted to appear under conditionalization.
+;; (defun loop-do-always (restrictive negate)
+;;   (let ((form (loop-get-form)))
+;;     (when restrictive (loop-disallow-conditional))
+;;     (loop-emit-body `(,(if negate 'when 'unless) ,form
+;; 		      ,(loop-construct-return nil)))
+;;     (loop-emit-final-value t)))
+
+
+
+;; ;;;THERIS.
+;; ;;; Under ANSI this is not permitted to appear under conditionalization.
+;; (defun loop-do-thereis (restrictive)
+;;   (when restrictive (loop-disallow-conditional))
+;;   (loop-emit-body `(when (setq ,(loop-when-it-variable) ,(loop-get-form))
+;; 		     ,(loop-construct-return *loop-when-it-variable*))))
+;; 
+
+;; (defun loop-do-while (negate kwd &aux (form (loop-get-form)))
+;;   (loop-disallow-conditional kwd)
+;;   (loop-pseudo-body `(,(if negate 'when 'unless) ,form (go end-loop))))
+
+
+;; (defun loop-do-with ()
+;;   (loop-disallow-conditional :with)
+;;   (do ((var) (val) (dtype)) (nil)
+;;     (setq var (loop-pop-source)
+;; 	  dtype (loop-optional-type var)
+;; 	  val (cond ((loop-tequal (car *loop-source-code*) :=)
+;; 		     (loop-pop-source)
+;; 		     (loop-get-form))
+;; 		    (t nil)))
+;;     (loop-make-variable var val dtype)
+;;     (if (loop-tequal (car *loop-source-code*) :and)
+;; 	(loop-pop-source)
+;; 	(return (loop-bind-block)))))
+;; 
+
+;; ;;;; The iteration driver
+
+;; (defun loop-hack-iteration (entry)
+;;   (flet ((make-endtest (list-of-forms)
+;; 	   (cond ((null list-of-forms) nil)
+;; 		 ((member t list-of-forms) '(go end-loop))
+;; 		 (t `(when ,(if (null (cdr (setq list-of-forms (nreverse list-of-forms))))
+;; 				(car list-of-forms)
+;; 				(cons 'or list-of-forms))
+;; 		       (go end-loop))))))
+;;     (do ((pre-step-tests nil)
+;; 	 (steps nil)
+;; 	 (post-step-tests nil)
+;; 	 (pseudo-steps nil)
+;; 	 (pre-loop-pre-step-tests nil)
+;; 	 (pre-loop-steps nil)
+;; 	 (pre-loop-post-step-tests nil)
+;; 	 (pre-loop-pseudo-steps nil)
+;; 	 (tem) (data))
+;; 	(nil)
+;;       ;; Note we collect endtests in reverse order, but steps in correct
+;;       ;; order.  MAKE-ENDTEST does the nreverse for us.
+;;       (setq tem (setq data (apply (symbol-function (first entry)) (rest entry))))
+;;       (and (car tem) (push (car tem) pre-step-tests))
+;;       (setq steps (nconc steps (loop-copylist* (car (setq tem (cdr tem))))))
+;;       (and (car (setq tem (cdr tem))) (push (car tem) post-step-tests))
+;;       (setq pseudo-steps (nconc pseudo-steps (loop-copylist* (car (setq tem (cdr tem))))))
+;;       (setq tem (cdr tem))
+;;       (when *loop-emitted-body*
+;; 	(loop-error "Iteration in LOOP follows body code."))
+;;       (unless tem (setq tem data))
+;;       (when (car tem) (push (car tem) pre-loop-pre-step-tests))
+;;       (setq pre-loop-steps (nconc pre-loop-steps (loop-copylist* (car (setq tem (cdr tem))))))
+;;       (when (car (setq tem (cdr tem))) (push (car tem) pre-loop-post-step-tests))
+;;       (setq pre-loop-pseudo-steps (nconc pre-loop-pseudo-steps (loop-copylist* (cadr tem))))
+;;       (unless (loop-tequal (car *loop-source-code*) :and)
+;; 	(setq *loop-before-loop* (list* (loop-make-desetq pre-loop-pseudo-steps)
+;; 					(make-endtest pre-loop-post-step-tests)
+;; 					(loop-make-psetq pre-loop-steps)
+;; 					(make-endtest pre-loop-pre-step-tests)
+;; 					*loop-before-loop*)
+;; 	      *loop-after-body* (list* (loop-make-desetq pseudo-steps)
+;; 				       (make-endtest post-step-tests)
+;; 				       (loop-make-psetq steps)
+;; 				       (make-endtest pre-step-tests)
+;; 				       *loop-after-body*))
+;; 	(loop-bind-block)
+;; 	(return nil))
+;;       (loop-pop-source)				; flush the "AND"
+;;       (when (and (not (loop-universe-implicit-for-required *loop-universe*))
+;; 		 (setq tem (loop-lookup-keyword
+;; 			     (car *loop-source-code*)
+;; 			     (loop-universe-iteration-keywords *loop-universe*))))
+;; 	;;Latest ANSI clarification is that the FOR/AS after the AND must NOT be supplied.
+;; 	(loop-pop-source)
+;; 	(setq entry tem)))))
+;; 
+
+;; ;;;; Main Iteration Drivers
+
+
+;; ;FOR variable keyword ..args..
+;; (defun loop-do-for ()
+;;   (let* ((var (loop-pop-source))
+;; 	 (data-type (loop-optional-type var))
+;; 	 (keyword (loop-pop-source))
+;; 	 (first-arg nil)
+;; 	 (tem nil))
+;;     (setq first-arg (loop-get-form))
+;;     (unless (and (symbolp keyword)
+;; 		 (setq tem (loop-lookup-keyword
+;; 			     keyword
+;; 			     (loop-universe-for-keywords *loop-universe*))))
+;;       (loop-error "~S is an unknown keyword in FOR or AS clause in LOOP." keyword))
+;;     (apply (car tem) var first-arg data-type (cdr tem))))
+
+
+;; (defun loop-do-repeat ()
+;;   (let ((form (loop-get-form))
+;; 	(type (loop-check-data-type (loop-optional-type) *loop-real-data-type*)))
+;;     (when (and (consp form) (eq (car form) 'the) (subtypep (second form) type))
+;;       (setq type (second form)))
+;;     (multiple-value-bind (number constantp value)
+;; 	(loop-constant-fold-if-possible form type)
+;;       (cond ((and constantp (<= value 1)) `(t () () () ,(<= value 0) () () ()))
+;; 	    (t (let ((var (loop-make-variable (loop-gentemp 'loop-repeat-) number type)))
+;; 		 (if constantp
+;; 		     `((not (plusp (setq ,var (1- ,var)))) () () () () () () ())
+;; 		     `((minusp (setq ,var (1- ,var))) () () ()))))))))
+
+
+;; (defun loop-when-it-variable ()
+;;   (or *loop-when-it-variable*
+;;       (setq *loop-when-it-variable*
+;; 	    (loop-make-variable (loop-gentemp 'loop-it-) nil nil))))
+;; 
+
+;; ;;;; Various FOR/AS Subdispatches
+
+
+;; ;;;ANSI "FOR x = y [THEN z]" is sort of like the old Genera one when the THEN
+;; ;;; is omitted (other than being more stringent in its placement), and like
+;; ;;; the old "FOR x FIRST y THEN z" when the THEN is present.  I.e., the first
+;; ;;; initialization occurs in the loop body (first-step), not in the variable binding
+;; ;;; phase.
+;; (defun loop-ansi-for-equals (var val data-type)
+;;   (loop-make-iteration-variable var nil data-type)
+;;   (cond ((loop-tequal (car *loop-source-code*) :then)
+;; 	 ;;Then we are the same as "FOR x FIRST y THEN z".
+;; 	 (loop-pop-source)
+;; 	 `(() (,var ,(loop-get-form)) () ()
+;; 	   () (,var ,val) () ()))
+;; 	(t ;;We are the same as "FOR x = y".
+;; 	 `(() (,var ,val) () ()))))
+
+
+;; (defun loop-for-across (var val data-type)
+;;   (loop-make-iteration-variable var nil data-type)
+;;   (let ((vector-var (loop-gentemp 'loop-across-vector-))
+;; 	(index-var (loop-gentemp 'loop-across-index-)))
+;;     (multiple-value-bind (vector-form constantp vector-value)
+;; 	(loop-constant-fold-if-possible val 'vector)
+;;       (loop-make-variable
+;; 	vector-var vector-form
+;; 	(if (and (consp vector-form) (eq (car vector-form) 'the))
+;; 	    (cadr vector-form)
+;; 	    'vector))
+;;       #+Genera (push `(system:array-register ,vector-var) *loop-declarations*)
+;;       (loop-make-variable index-var 0 'fixnum)
+;;       (let* ((length 0)
+;; 	     (length-form (cond ((not constantp)
+;; 				 (let ((v (loop-gentemp 'loop-across-limit-)))
+;; 				   (push `(setq ,v (length ,vector-var)) *loop-prologue*)
+;; 				   (loop-make-variable v 0 'fixnum)))
+;; 				(t (setq length (length vector-value)))))
+;; 	     (first-test `(>= ,index-var ,length-form))
+;; 	     (other-test first-test)
+;; 	     (step `(,var (aref ,vector-var ,index-var)))
+;; 	     (pstep `(,index-var (1+ ,index-var))))
+;; 	(declare (fixnum length))
+;; 	(when constantp
+;; 	  (setq first-test (= length 0))
+;; 	  (when (<= length 1)
+;; 	    (setq other-test t)))
+;; 	`(,other-test ,step () ,pstep
+;; 	  ,@(and (not (eq first-test other-test)) `(,first-test ,step () ,pstep)))))))
+;; 
+
+
+;; ;;;; List Iteration
+
+
+;; (defun loop-list-step (listvar)
+;;   ;;We are not equipped to analyze whether 'FOO is the same as #'FOO here in any
+;;   ;; sensible fashion, so let's give an obnoxious warning whenever 'FOO is used
+;;   ;; as the stepping function.
+;;   ;;While a Discerning Compiler may deal intelligently with (funcall 'foo ...), not
+;;   ;; recognizing FOO may defeat some LOOP optimizations.
+;;   (let ((stepper (cond ((loop-tequal (car *loop-source-code*) :by)
+;; 			(loop-pop-source)
+;; 			(loop-get-form))
+;; 		       (t '(function cdr)))))
+;;     (cond ((and (consp stepper) (eq (car stepper) 'quote))
+;; 	   (loop-warn "Use of QUOTE around stepping function in LOOP will be left verbatim.")
+;; 	   (values `(funcall ,stepper ,listvar) nil))
+;; 	  ((and (consp stepper) (eq (car stepper) 'function))
+;; 	   (values (list (cadr stepper) listvar) (cadr stepper)))
+;; 	  (t (values `(funcall ,(loop-make-variable (loop-gentemp 'loop-fn-) stepper 'function)
+;; 			       ,listvar)
+;; 		     nil)))))
+
+
+;; (defun loop-for-on (var val data-type)
+;;   (multiple-value-bind (list constantp list-value) (loop-constant-fold-if-possible val)
+;;     (let ((listvar var))
+;;       (cond ((and var (symbolp var)) (loop-make-iteration-variable var list data-type))
+;; 	    (t (loop-make-variable (setq listvar (loop-gentemp)) list 'list)
+;; 	       (loop-make-iteration-variable var nil data-type)))
+;;       (multiple-value-bind (list-step step-function) (loop-list-step listvar)
+;; 	(declare #+(and (not LOOP-Prefer-POP) (not CLOE)) (ignore step-function))
+;; 	;;@@@@ The CLOE problem above has to do with bug in macroexpansion of multiple-value-bind.
+;; 	(let* ((first-endtest
+;; 		(hide-variable-reference
+;; 		 (eq var listvar)
+;; 		 listvar
+;; 		 ;; the following should use `atom' instead of `endp', per
+;; 		 ;; [bug2428]
+;; 		 `(atom ,listvar)))
+;; 	       (other-endtest first-endtest))
+;; 	  (when (and constantp (listp list-value))
+;; 	    (setq first-endtest (null list-value)))
+;; 	  (cond ((eq var listvar)
+;; 		 ;;Contour of the loop is different because we use the user's variable...
+;; 		 `(() (,listvar ,(hide-variable-reference t listvar list-step)) ,other-endtest
+;; 		   () () () ,first-endtest ()))
+;; 		#+LOOP-Prefer-POP
+;; 		((and step-function
+;; 		      (let ((n (cdr (assoc step-function '((cdr . 1) (cddr . 2)
+;; 							   (cdddr . 3) (cddddr . 4))))))
+;; 			(and n (do ((l var (cdr l)) (i 0 (1+ i)))
+;; 				   ((atom l) (and (null l) (= i n)))
+;; 				 (declare (fixnum i))))))
+;; 		 (let ((step (mapcan #'(lambda (x) (list x `(pop ,listvar))) var)))
+;; 		   `(,other-endtest () () ,step ,first-endtest () () ,step)))
+;; 		(t (let ((step `(,var ,listvar)) (pseudo `(,listvar ,list-step)))
+;; 		     `(,other-endtest ,step () ,pseudo
+;; 		       ,@(and (not (eq first-endtest other-endtest))
+;; 			      `(,first-endtest ,step () ,pseudo)))))))))))
+
+
+;; (defun loop-for-in (var val data-type)
+;;   (multiple-value-bind (list constantp list-value) (loop-constant-fold-if-possible val)
+;;     (let ((listvar (loop-gentemp 'loop-list-)))
+;;       (loop-make-iteration-variable var nil data-type)
+;;       (loop-make-variable listvar list 'list)
+;;       (multiple-value-bind (list-step step-function) (loop-list-step listvar)
+;; 	#-LOOP-Prefer-POP (declare (ignore step-function))
+;; 	(let* ((first-endtest `(endp ,listvar))
+;; 	       (other-endtest first-endtest)
+;; 	       (step `(,var (car ,listvar)))
+;; 	       (pseudo-step `(,listvar ,list-step)))
+;; 	  (when (and constantp (listp list-value))
+;; 	    (setq first-endtest (null list-value)))
+;; 	  #+LOOP-Prefer-POP (when (eq step-function 'cdr)
+;; 			      (setq step `(,var (pop ,listvar)) pseudo-step nil))
+;; 	  `(,other-endtest ,step () ,pseudo-step
+;; 	    ,@(and (not (eq first-endtest other-endtest))
+;; 		   `(,first-endtest ,step () ,pseudo-step))))))))
+;; 
+
+;; ;;;; Iteration Paths
+
+
+;; (defstruct (loop-path
+;; 	     (:copier nil)
+;; 	     (:predicate nil))
+;;   names
+;;   preposition-groups
+;;   inclusive-permitted
+;;   function
+;;   user-data)
+
+
+;; (defun add-loop-path (names function universe &key preposition-groups inclusive-permitted user-data)
+;;   (unless (listp names) (setq names (list names)))
+;;   ;; Can't do this due to CLOS bootstrapping problems.
+;;   #-(or Genera (and CLOE Source-Bootstrap)) (check-type universe loop-universe)
+;;   (let ((ht (loop-universe-path-keywords universe))
+;; 	(lp (make-loop-path
+;; 	      :names (mapcar #'symbol-name names)
+;; 	      :function function
+;; 	      :user-data user-data
+;; 	      :preposition-groups (mapcar #'(lambda (x) (if (listp x) x (list x))) preposition-groups)
+;; 	      :inclusive-permitted inclusive-permitted)))
+;;     (dolist (name names) (setf (gethash (symbol-name name) ht) lp))
+;;     lp))
+;; 
+
+;; ;;; Note:  path functions are allowed to use loop-make-variable, hack
+;; ;;; the prologue, etc.
+;; (defun loop-for-being (var val data-type)
+;;   ;; FOR var BEING each/the pathname prep-phrases using-stuff...
+;;   ;; each/the = EACH or THE.  Not clear if it is optional, so I guess we'll warn.
+;;   (let ((path nil)
+;; 	(data nil)
+;; 	(inclusive nil)
+;; 	(stuff nil)
+;; 	(initial-prepositions nil))
+;;     (cond ((loop-tmember val '(:each :the)) (setq path (loop-pop-source)))
+;; 	  ((loop-tequal (car *loop-source-code*) :and)
+;; 	   (loop-pop-source)
+;; 	   (setq inclusive t)
+;; 	   (unless (loop-tmember (car *loop-source-code*) '(:its :each :his :her))
+;; 	     (loop-error "~S found where ITS or EACH expected in LOOP iteration path syntax."
+;; 			 (car *loop-source-code*)))
+;; 	   (loop-pop-source)
+;; 	   (setq path (loop-pop-source))
+;; 	   (setq initial-prepositions `((:in ,val))))
+;; 	  (t (loop-error "Unrecognizable LOOP iteration path syntax.  Missing EACH or THE?")))
+;;     (cond ((not (symbolp path))
+;; 	   (loop-error "~S found where a LOOP iteration path name was expected." path))
+;; 	  ((not (setq data (loop-lookup-keyword path (loop-universe-path-keywords *loop-universe*))))
+;; 	   (loop-error "~S is not the name of a LOOP iteration path." path))
+;; 	  ((and inclusive (not (loop-path-inclusive-permitted data)))
+;; 	   (loop-error "\"Inclusive\" iteration is not possible with the ~S LOOP iteration path." path)))
+;;     (let ((fun (loop-path-function data))
+;; 	  (preps (nconc initial-prepositions
+;; 			(loop-collect-prepositional-phrases (loop-path-preposition-groups data) t)))
+;; 	  (user-data (loop-path-user-data data)))
+;;       (when (symbolp fun) (setq fun (symbol-function fun)))
+;;       (setq stuff (if inclusive
+;; 		      (apply fun var data-type preps :inclusive t user-data)
+;; 		      (apply fun var data-type preps user-data))))
+;;     (when *loop-named-variables*
+;;       (loop-error "Unused USING variables: ~S." *loop-named-variables*))
+;;     ;; STUFF is now (bindings prologue-forms . stuff-to-pass-back).  Protect the system from the user
+;;     ;; and the user from himself.
+;;     (unless (member (length stuff) '(6 10))
+;;       (loop-error "Value passed back by LOOP iteration path function for path ~S has invalid length."
+;; 		  path))
+;;     (do ((l (car stuff) (cdr l)) (x)) ((null l))
+;;       (if (atom (setq x (car l)))
+;; 	  (loop-make-iteration-variable x nil nil)
+;; 	  (loop-make-iteration-variable (car x) (cadr x) (caddr x))))
+;;     (setq *loop-prologue* (nconc (reverse (cadr stuff)) *loop-prologue*))
+;;     (cddr stuff)))
+;; 
+
+
+;; ;;;INTERFACE:  Lucid, exported.
+;; ;;; i.e., this is part of our extended ansi-loop interface.
+;; (defun named-variable (name)
+;;   (let ((tem (loop-tassoc name *loop-named-variables*)))
+;;     (declare (list tem))
+;;     (cond ((null tem) (values (loop-gentemp) nil))
+;; 	  (t (setq *loop-named-variables* (delete tem *loop-named-variables*))
+;; 	     (values (cdr tem) t)))))
+
+
+;; (defun loop-collect-prepositional-phrases (preposition-groups &optional USING-allowed initial-phrases)
+;;   (flet ((in-group-p (x group) (car (loop-tmember x group))))
+;;     (do ((token nil)
+;; 	 (prepositional-phrases initial-phrases)
+;; 	 (this-group nil nil)
+;; 	 (this-prep nil nil)
+;; 	 (disallowed-prepositions
+;; 	   (mapcan #'(lambda (x)
+;; 		       (loop-copylist*
+;; 			 (find (car x) preposition-groups :test #'in-group-p)))
+;; 		   initial-phrases))
+;; 	 (used-prepositions (mapcar #'car initial-phrases)))
+;; 	((null *loop-source-code*) (nreverse prepositional-phrases))
+;;       (declare (symbol this-prep))
+;;       (setq token (car *loop-source-code*))
+;;       (dolist (group preposition-groups)
+;; 	(when (setq this-prep (in-group-p token group))
+;; 	  (return (setq this-group group))))
+;;       (cond (this-group
+;; 	     (when (member this-prep disallowed-prepositions)
+;; 	       (loop-error
+;; 		 (if (member this-prep used-prepositions)
+;; 		     "A ~S prepositional phrase occurs multiply for some LOOP clause."
+;; 		     "Preposition ~S used when some other preposition has subsumed it.")
+;; 		 token))
+;; 	     (setq used-prepositions (if (listp this-group)
+;; 					 (append this-group used-prepositions)
+;; 					 (cons this-group used-prepositions)))
+;; 	     (loop-pop-source)
+;; 	     (push (list this-prep (loop-get-form)) prepositional-phrases))
+;; 	    ((and USING-allowed (loop-tequal token 'using))
+;; 	     (loop-pop-source)
+;; 	     (do ((z (loop-pop-source) (loop-pop-source)) (tem)) (nil)
+;; 	       (when (or (atom z)
+;; 			 (atom (cdr z))
+;; 			 (not (null (cddr z)))
+;; 			 (not (symbolp (car z)))
+;; 			 (and (cadr z) (not (symbolp (cadr z)))))
+;; 		 (loop-error "~S bad variable pair in path USING phrase." z))
+;; 	       (when (cadr z)
+;; 		 (if (setq tem (loop-tassoc (car z) *loop-named-variables*))
+;; 		     (loop-error
+;; 		       "The variable substitution for ~S occurs twice in a USING phrase,~@
+;; 		        with ~S and ~S."
+;; 		       (car z) (cadr z) (cadr tem))
+;; 		     (push (cons (car z) (cadr z)) *loop-named-variables*)))
+;; 	       (when (or (null *loop-source-code*) (symbolp (car *loop-source-code*)))
+;; 		 (return nil))))
+;; 	    (t (return (nreverse prepositional-phrases)))))))
+;; 
+
+;; ;;;; Master Sequencer Function
+
+
+;; (defun loop-sequencer (indexv indexv-type indexv-user-specified-p
+;; 			  variable variable-type
+;; 			  sequence-variable sequence-type
+;; 			  step-hack default-top
+;; 			  prep-phrases)
+;;    (let ((endform nil)				;Form (constant or variable) with limit value.
+;; 	 (sequencep nil)			;T if sequence arg has been provided.
+;; 	 (testfn nil)				;endtest function
+;; 	 (test nil)				;endtest form.
+;; 	 (stepby (1+ (or (loop-typed-init indexv-type) 0)))	;Our increment.
+;; 	 (stepby-constantp t)
+;; 	 (step nil)				;step form.
+;; 	 (dir nil)				;Direction of stepping: NIL, :UP, :DOWN.
+;; 	 (inclusive-iteration nil)		;T if include last index.
+;; 	 (start-given nil)			;T when prep phrase has specified start
+;; 	 (start-value nil)
+;; 	 (start-constantp nil)
+;; 	 (limit-given nil)			;T when prep phrase has specified end
+;; 	 (limit-constantp nil)
+;; 	 (limit-value nil)
+;; 	 )
+;;      (when variable (loop-make-iteration-variable variable nil variable-type))
+;;      (do ((l prep-phrases (cdr l)) (prep) (form) (odir)) ((null l))
+;;        (setq prep (caar l) form (cadar l))
+;;        (case prep
+;; 	 ((:of :in)
+;; 	  (setq sequencep t)
+;; 	  (loop-make-variable sequence-variable form sequence-type))
+;; 	 ((:from :downfrom :upfrom)
+;; 	  (setq start-given t)
+;; 	  (cond ((eq prep :downfrom) (setq dir ':down))
+;; 		((eq prep :upfrom) (setq dir ':up)))
+;; 	  (multiple-value-setq (form start-constantp start-value)
+;; 	    (loop-constant-fold-if-possible form indexv-type))
+;; 	  (loop-make-iteration-variable indexv form indexv-type))
+;; 	 ((:upto :to :downto :above :below)
+;; 	  (cond ((loop-tequal prep :upto) (setq inclusive-iteration (setq dir ':up)))
+;; 		((loop-tequal prep :to) (setq inclusive-iteration t))
+;; 		((loop-tequal prep :downto) (setq inclusive-iteration (setq dir ':down)))
+;; 		((loop-tequal prep :above) (setq dir ':down))
+;; 		((loop-tequal prep :below) (setq dir ':up)))
+;; 	  (setq limit-given t)
+;; 	  (multiple-value-setq (form limit-constantp limit-value)
+;; 	    (loop-constant-fold-if-possible form indexv-type))
+;; 	  (setq endform (if limit-constantp
+;; 			    `',limit-value
+;; 			    (loop-make-variable
+;; 			      (loop-gentemp 'loop-limit-) form indexv-type))))
+;; 	 (:by
+;; 	   (multiple-value-setq (form stepby-constantp stepby)
+;; 	     (loop-constant-fold-if-possible form indexv-type))
+;; 	   (unless stepby-constantp
+;; 	     (loop-make-variable (setq stepby (loop-gentemp 'loop-step-by-)) form indexv-type)))
+;; 	 (t (loop-error
+;; 	      "~S invalid preposition in sequencing or sequence path.~@
+;; 	       Invalid prepositions specified in iteration path descriptor or something?"
+;; 	      prep)))
+;;        (when (and odir dir (not (eq dir odir)))
+;; 	 (loop-error "Conflicting stepping directions in LOOP sequencing path"))
+;;        (setq odir dir))
+;;      (when (and sequence-variable (not sequencep))
+;;        (loop-error "Missing OF or IN phrase in sequence path"))
+;;      ;; Now fill in the defaults.
+;;      (unless start-given
+;;        (loop-make-iteration-variable
+;; 	 indexv
+;; 	 (setq start-constantp t start-value (or (loop-typed-init indexv-type) 0))
+;; 	 indexv-type))
+;;      (cond ((member dir '(nil :up))
+;; 	    (when (or limit-given default-top)
+;; 	      (unless limit-given
+;; 		(loop-make-variable (setq endform (loop-gentemp 'loop-seq-limit-))
+;; 				    nil indexv-type)
+;; 		(push `(setq ,endform ,default-top) *loop-prologue*))
+;; 	      (setq testfn (if inclusive-iteration '> '>=)))
+;; 	    (setq step (if (eql stepby 1) `(1+ ,indexv) `(+ ,indexv ,stepby))))
+;; 	   (t (unless start-given
+;; 		(unless default-top
+;; 		  (loop-error "Don't know where to start stepping."))
+;; 		(push `(setq ,indexv (1- ,default-top)) *loop-prologue*))
+;; 	      (when (and default-top (not endform))
+;; 		(setq endform (loop-typed-init indexv-type) inclusive-iteration t))
+;; 	      (when endform (setq testfn (if inclusive-iteration  '< '<=)))
+;; 	      (setq step (if (eql stepby 1) `(1- ,indexv) `(- ,indexv ,stepby)))))
+;;      (when testfn (setq test (hide-variable-reference t indexv `(,testfn ,indexv ,endform))))
+;;      (when step-hack
+;;        (setq step-hack `(,variable ,(hide-variable-reference indexv-user-specified-p indexv step-hack))))
+;;      (let ((first-test test) (remaining-tests test))
+;;        (when (and stepby-constantp start-constantp limit-constantp)
+;; 	 (when (setq first-test (funcall (symbol-function testfn) start-value limit-value))
+;; 	   (setq remaining-tests t)))
+;;        `(() (,indexv ,(hide-variable-reference t indexv step)) ,remaining-tests ,step-hack
+;; 	 () () ,first-test ,step-hack))))
+;; 
+
+;; ;;;; Interfaces to the Master Sequencer
+
+
+
+;; (defun loop-for-arithmetic (var val data-type kwd)
+;;   (loop-sequencer
+;;     var (loop-check-data-type data-type *loop-real-data-type*) t
+;;     nil nil nil nil nil nil
+;;     (loop-collect-prepositional-phrases
+;;       '((:from :upfrom :downfrom) (:to :upto :downto :above :below) (:by))
+;;       nil (list (list kwd val)))))
+
+
+;; (defun loop-sequence-elements-path (variable data-type prep-phrases
+;; 				    &key fetch-function size-function sequence-type element-type)
+;;   (multiple-value-bind (indexv indexv-user-specified-p) (named-variable 'index)
+;;     (let ((sequencev (named-variable 'sequence)))
+;;       #+Genera (when (and sequencev
+;; 			  (symbolp sequencev)
+;; 			  sequence-type
+;; 			  (subtypep sequence-type 'vector)
+;; 			  (not (member (the symbol sequencev) *loop-nodeclare*)))
+;; 		 (push `(sys:array-register ,sequencev) *loop-declarations*))
+;;       (list* nil nil				; dummy bindings and prologue
+;; 	     (loop-sequencer
+;; 	       indexv 'fixnum indexv-user-specified-p
+;; 	       variable (or data-type element-type)
+;; 	       sequencev sequence-type
+;; 	       `(,fetch-function ,sequencev ,indexv) `(,size-function ,sequencev)
+;; 	       prep-phrases)))))
+;; 
+
+;; ;;;; Builtin LOOP Iteration Paths
+
+
+;; #||
+;; (loop for v being the hash-values of ht do (print v))
+;; (loop for k being the hash-keys of ht do (print k))
+;; (loop for v being the hash-values of ht using (hash-key k) do (print (list k v)))
+;; (loop for k being the hash-keys of ht using (hash-value v) do (print (list k v)))
+;; ||#
+
+;; (defun loop-hash-table-iteration-path (variable data-type prep-phrases &key which)
+;;   (check-type which (member hash-key hash-value))
+;;   (cond ((or (cdr prep-phrases) (not (member (caar prep-phrases) '(:in :of))))
+;; 	 (loop-error "Too many prepositions!"))
+;; 	((null prep-phrases) (loop-error "Missing OF or IN in ~S iteration path.")))
+;;   (let ((ht-var (loop-gentemp 'loop-hashtab-))
+;; 	(next-fn (loop-gentemp 'loop-hashtab-next-))
+;; 	(dummy-predicate-var nil)
+;; 	(post-steps nil))
+;;     (multiple-value-bind (other-var other-p)
+;; 	(named-variable (if (eq which 'hash-key) 'hash-value 'hash-key))
+;;       ;;@@@@ named-variable returns a second value of T if the name was actually
+;;       ;; specified, so clever code can throw away the gensym'ed up variable if
+;;       ;; it isn't really needed.
+;;       ;;The following is for those implementations in which we cannot put dummy NILs
+;;       ;; into multiple-value-setq variable lists.
+;;       #-Genera (setq other-p t
+;; 		     dummy-predicate-var (loop-when-it-variable))
+;;       (let ((key-var nil)
+;; 	    (val-var nil)
+;; 	    (bindings `((,variable nil ,data-type)
+;; 			(,ht-var ,(cadar prep-phrases))
+;; 			,@(and other-p other-var `((,other-var nil))))))
+;; 	(if (eq which 'hash-key)
+;; 	    (setq key-var variable val-var (and other-p other-var))
+;; 	    (setq key-var (and other-p other-var) val-var variable))
+;; 	(push `(with-hash-table-iterator (,next-fn ,ht-var)) *loop-wrappers*)
+;; 	(when (consp key-var)
+;; 	  (setq post-steps `(,key-var ,(setq key-var (loop-gentemp 'loop-hash-key-temp-))
+;; 			     ,@post-steps))
+;; 	  (push `(,key-var nil) bindings))
+;; 	(when (consp val-var)
+;; 	  (setq post-steps `(,val-var ,(setq val-var (loop-gentemp 'loop-hash-val-temp-))
+;; 			     ,@post-steps))
+;; 	  (push `(,val-var nil) bindings))
+;; 	`(,bindings				;bindings
+;; 	  ()					;prologue
+;; 	  ()					;pre-test
+;; 	  ()					;parallel steps
+;; 	  (not (multiple-value-setq (,dummy-predicate-var ,key-var ,val-var) (,next-fn)))	;post-test
+;; 	  ,post-steps)))))
+
+
+;; (defun loop-package-symbols-iteration-path (variable data-type prep-phrases &key symbol-types)
+;;   (cond ((or (cdr prep-phrases) (not (member (caar prep-phrases) '(:in :of))))
+;; 	 (loop-error "Too many prepositions!"))
+;; 	((null prep-phrases) (loop-error "Missing OF or IN in ~S iteration path.")))
+;;   (unless (symbolp variable)
+;;     (loop-error "Destructuring is not valid for package symbol iteration."))
+;;   (let ((pkg-var (loop-gentemp 'loop-pkgsym-))
+;; 	(next-fn (loop-gentemp 'loop-pkgsym-next-)))
+;;     (push `(with-package-iterator (,next-fn ,pkg-var ,@symbol-types)) *loop-wrappers*)
+;;     `(((,variable nil ,data-type) (,pkg-var ,(cadar prep-phrases)))
+;;       ()
+;;       ()
+;;       ()
+;;       (not (multiple-value-setq (,(progn
+;; 				    ;;@@@@ If an implementation can get away without actually
+;; 				    ;; using a variable here, so much the better.
+;; 				    #+Genera NIL
+;; 				    #-Genera (loop-when-it-variable))
+;; 				 ,variable)
+;; 	     (,next-fn)))
+;;       ())))
+;; 
+;; ;;;; ANSI Loop
+
+;; (defun make-ansi-loop-universe (extended-p)
+;;   (let ((w (make-standard-loop-universe
+;; 	     :keywords `((named (loop-do-named))
+;; 			 (initially (loop-do-initially))
+;; 			 (finally (loop-do-finally))
+;; 			 (do (loop-do-do))
+;; 			 (doing (loop-do-do))
+;; 			 (return (loop-do-return))
+;; 			 (collect (loop-list-collection list))
+;; 			 (collecting (loop-list-collection list))
+;; 			 (append (loop-list-collection append))
+;; 			 (appending (loop-list-collection append))
+;; 			 (nconc (loop-list-collection nconc))
+;; 			 (nconcing (loop-list-collection nconc))
+;; 			 (count (loop-sum-collection count ,*loop-real-data-type* fixnum))
+;; 			 (counting (loop-sum-collection count ,*loop-real-data-type* fixnum))
+;; 			 (sum (loop-sum-collection sum number number))
+;; 			 (summing (loop-sum-collection sum number number))
+;; 			 (maximize (loop-maxmin-collection max))
+;; 			 (minimize (loop-maxmin-collection min))
+;; 			 (maximizing (loop-maxmin-collection max))
+;; 			 (minimizing (loop-maxmin-collection min))
+;; 			 (always (loop-do-always t nil))	; Normal, do always
+;; 			 (never (loop-do-always t t))	; Negate the test on always.
+;; 			 (thereis (loop-do-thereis t))
+;; 			 (while (loop-do-while nil :while))	; Normal, do while
+;; 			 (until (loop-do-while t :until))	; Negate the test on while
+;; 			 (when (loop-do-if when nil))	; Normal, do when
+;; 			 (if (loop-do-if if nil))	; synonymous
+;; 			 (unless (loop-do-if unless t))	; Negate the test on when
+;; 			 (with (loop-do-with)))
+;; 	     :for-keywords '((= (loop-ansi-for-equals))
+;; 			     (across (loop-for-across))
+;; 			     (in (loop-for-in))
+;; 			     (on (loop-for-on))
+;; 			     (from (loop-for-arithmetic :from))
+;; 			     (downfrom (loop-for-arithmetic :downfrom))
+;; 			     (upfrom (loop-for-arithmetic :upfrom))
+;; 			     (below (loop-for-arithmetic :below))
+;; 			     (to (loop-for-arithmetic :to))
+;; 			     (upto (loop-for-arithmetic :upto))
+;; 			     (being (loop-for-being)))
+;; 	     :iteration-keywords '((for (loop-do-for))
+;; 				   (as (loop-do-for))
+;; 				   (repeat (loop-do-repeat)))
+;; 	     :type-symbols '(array atom bignum bit bit-vector character #| common |# compiled-function
+;; 				   complex cons double-float fixnum float
+;; 				   function hash-table integer keyword list long-float
+;; 				   nil null number package pathname random-state
+;; 				   ratio rational readtable sequence short-float
+;; 				   simple-array simple-bit-vector simple-string
+;; 				   simple-vector single-float standard-char
+;; 				   stream string string-char
+;; 				   symbol t vector)
+;; 	     :type-keywords nil
+;; 	     :ansi (if extended-p :extended t))))
+;;     (add-loop-path '(hash-key hash-keys) 'loop-hash-table-iteration-path w
+;; 		   :preposition-groups '((:of :in))
+;; 		   :inclusive-permitted nil
+;; 		   :user-data '(:which hash-key))
+;;     (add-loop-path '(hash-value hash-values) 'loop-hash-table-iteration-path w
+;; 		   :preposition-groups '((:of :in))
+;; 		   :inclusive-permitted nil
+;; 		   :user-data '(:which hash-value))
+;;     (add-loop-path '(symbol symbols) 'loop-package-symbols-iteration-path w
+;; 		   :preposition-groups '((:of :in))
+;; 		   :inclusive-permitted nil
+;; 		   :user-data '(:symbol-types (:internal :external :inherited)))
+;;     (add-loop-path '(external-symbol external-symbols) 'loop-package-symbols-iteration-path w
+;; 		   :preposition-groups '((:of :in))
+;; 		   :inclusive-permitted nil
+;; 		   :user-data '(:symbol-types (:external)))
+;;     (add-loop-path '(present-symbol present-symbols) 'loop-package-symbols-iteration-path w
+;; 		   :preposition-groups '((:of :in))
+;; 		   :inclusive-permitted nil
+;; 		   :user-data '(:symbol-types (:internal)))
+;;     w))
+
+
+;; (defparameter *loop-ansi-universe*
+;; 	      (make-ansi-loop-universe nil))
+
+
+;; (defun loop-standard-expansion (keywords-and-forms environment universe)
+;;   (if (and keywords-and-forms (symbolp (car keywords-and-forms)))
+;;       (loop-translate keywords-and-forms environment universe)
+;;       (let ((tag (gensym)))
+;; 	`(block nil (tagbody ,tag (progn ,@keywords-and-forms) (go ,tag))))))
+
+
+;; ;;;INTERFACE: ANSI
+;; (defmacro loop (&environment env &rest keywords-and-forms)
+;;   #+Genera (declare (compiler:do-not-record-macroexpansions)
+;; 		    (zwei:indentation . zwei:indent-loop))
+;;   (loop-standard-expansion keywords-and-forms env *loop-ansi-universe*))
+
+;; #+allegro
+;; (defun excl::complex-loop-expander (body env)
+;;   (loop-standard-expansion body env *loop-ansi-universe*))
+
+
+
+;;; FIXME: Somehow the pacakge is not being bound properly in
+;;; !compile-file.
+(in-package :cl)

--- a/src/ansiloop/ansi-loop.lisp
+++ b/src/ansiloop/ansi-loop.lisp
@@ -1065,209 +1065,209 @@ collected result will be returned as the value of the LOOP."
 ;;;; Loop Types
 
 
-;; (defun loop-typed-init (data-type)
-;;   (when (and data-type (subtypep data-type 'number))
-;;     (if (or (subtypep data-type 'float) (subtypep data-type '(complex float)))
-;; 	(coerce 0 data-type)
-;; 	0)))
+(defun loop-typed-init (data-type)
+  (when (and data-type (subtypep data-type 'number))
+    (if (or (subtypep data-type 'float) (subtypep data-type '(complex float)))
+	(coerce 0 data-type)
+	0)))
 
 
-;; (defun loop-optional-type (&optional variable)
-;;   ;;No variable specified implies that no destructuring is permissible.
-;;   (and *loop-source-code*			;Don't get confused by NILs...
-;;        (let ((z (car *loop-source-code*)))
-;; 	 (cond ((loop-tequal z 'of-type)
-;; 		;;This is the syntactically unambigous form in that the form of the
-;; 		;; type specifier does not matter.  Also, it is assumed that the
-;; 		;; type specifier is unambiguously, and without need of translation,
-;; 		;; a common lisp type specifier or pattern (matching the variable) thereof.
-;; 		(loop-pop-source)
-;; 		(loop-pop-source))
-;; 	       ((symbolp z)
-;; 		;;This is the (sort of) "old" syntax, even though we didn't used to support all of
-;; 		;; these type symbols.
-;; 		(let ((type-spec (or (gethash z (loop-universe-type-symbols *loop-universe*))
-;; 				     (gethash (symbol-name z) (loop-universe-type-keywords *loop-universe*)))))
-;; 		  (when type-spec
-;; 		    (loop-pop-source)
-;; 		    type-spec)))
-;; 	       (t 
-;; 		;;This is our sort-of old syntax.  But this is only valid for when we are destructuring,
-;; 		;; so we will be compulsive (should we really be?) and require that we in fact be
-;; 		;; doing variable destructuring here.  We must translate the old keyword pattern typespec
-;; 		;; into a fully-specified pattern of real type specifiers here.
-;; 		(if (consp variable)
-;; 		    (unless (consp z)
-;; 		     (loop-error
-;; 			"~S found where a LOOP keyword, LOOP type keyword, or LOOP type pattern expected."
-;; 			z))
-;; 		    (loop-error "~S found where a LOOP keyword or LOOP type keyword expected." z))
-;; 		(loop-pop-source)
-;; 		(labels ((translate (k v)
-;; 			   (cond ((null k) nil)
-;; 				 ((atom k)
-;; 				  (replicate
-;; 				    (or (gethash k (loop-universe-type-symbols *loop-universe*))
-;; 					(gethash (symbol-name k) (loop-universe-type-keywords *loop-universe*))
-;; 					(loop-error
-;; 					  "Destructuring type pattern ~S contains unrecognized type keyword ~S."
-;; 					  z k))
-;; 				    v))
-;; 				 ((atom v)
-;; 				  (loop-error
-;; 				    "Destructuring type pattern ~S doesn't match variable pattern ~S."
-;; 				    z variable))
-;; 				 (t (cons (translate (car k) (car v)) (translate (cdr k) (cdr v))))))
-;; 			 (replicate (typ v)
-;; 			   (if (atom v) typ (cons (replicate typ (car v)) (replicate typ (cdr v))))))
-;; 		  (translate z variable)))))))
-;; 
+(defun loop-optional-type (&optional variable)
+  ;;No variable specified implies that no destructuring is permissible.
+  (and *loop-source-code*			;Don't get confused by NILs...
+       (let ((z (car *loop-source-code*)))
+	 (cond ((loop-tequal z 'of-type)
+		;;This is the syntactically unambigous form in that the form of the
+		;; type specifier does not matter.  Also, it is assumed that the
+		;; type specifier is unambiguously, and without need of translation,
+		;; a common lisp type specifier or pattern (matching the variable) thereof.
+		(loop-pop-source)
+		(loop-pop-source))
+	       ((symbolp z)
+		;;This is the (sort of) "old" syntax, even though we didn't used to support all of
+		;; these type symbols.
+		(let ((type-spec (or (gethash z (loop-universe-type-symbols *loop-universe*))
+				     (gethash (symbol-name z) (loop-universe-type-keywords *loop-universe*)))))
+		  (when type-spec
+		    (loop-pop-source)
+		    type-spec)))
+	       (t 
+		;;This is our sort-of old syntax.  But this is only valid for when we are destructuring,
+		;; so we will be compulsive (should we really be?) and require that we in fact be
+		;; doing variable destructuring here.  We must translate the old keyword pattern typespec
+		;; into a fully-specified pattern of real type specifiers here.
+		(if (consp variable)
+		    (unless (consp z)
+		     (loop-error
+			"~S found where a LOOP keyword, LOOP type keyword, or LOOP type pattern expected."
+			z))
+		    (loop-error "~S found where a LOOP keyword or LOOP type keyword expected." z))
+		(loop-pop-source)
+		(labels ((translate (k v)
+			   (cond ((null k) nil)
+				 ((atom k)
+				  (replicate
+				    (or (gethash k (loop-universe-type-symbols *loop-universe*))
+					(gethash (symbol-name k) (loop-universe-type-keywords *loop-universe*))
+					(loop-error
+					  "Destructuring type pattern ~S contains unrecognized type keyword ~S."
+					  z k))
+				    v))
+				 ((atom v)
+				  (loop-error
+				    "Destructuring type pattern ~S doesn't match variable pattern ~S."
+				    z variable))
+				 (t (cons (translate (car k) (car v)) (translate (cdr k) (cdr v))))))
+			 (replicate (typ v)
+			   (if (atom v) typ (cons (replicate typ (car v)) (replicate typ (cdr v))))))
+		  (translate z variable)))))))
+
 
 
-;; ;;;; Loop Variables
+;;;; Loop Variables
 
 
-;; (defun loop-bind-block ()
-;;   (when (or *loop-variables* *loop-declarations* *loop-wrappers*)
-;;     (push (list (nreverse *loop-variables*) *loop-declarations* *loop-desetq-crocks* *loop-wrappers*)
-;; 	  *loop-bind-stack*)
-;;     (setq *loop-variables* nil
-;; 	  *loop-declarations* nil
-;; 	  *loop-desetq-crocks* nil
-;; 	  *loop-wrappers* nil)))
+(defun loop-bind-block ()
+  (when (or *loop-variables* *loop-declarations* *loop-wrappers*)
+    (push (list (nreverse *loop-variables*) *loop-declarations* *loop-desetq-crocks* *loop-wrappers*)
+	  *loop-bind-stack*)
+    (setq *loop-variables* nil
+	  *loop-declarations* nil
+	  *loop-desetq-crocks* nil
+	  *loop-wrappers* nil)))
 
 
-;; (defun loop-make-variable (name initialization dtype &optional iteration-variable-p)
-;;   (cond ((null name)
-;; 	 (cond ((not (null initialization))
-;; 		(push (list (setq name (loop-gentemp 'loop-ignore-))
-;; 			    initialization)
-;; 		      *loop-variables*)
-;; 		(push `(ignore ,name) *loop-declarations*))))
-;; 	((atom name)
-;; 	 (cond (iteration-variable-p
-;; 		(if (member name *loop-iteration-variables*)
-;; 		    (loop-error "Duplicated LOOP iteration variable ~S." name)
-;; 		    (push name *loop-iteration-variables*)))
-;; 	       ((assoc name *loop-variables*)
-;; 		(loop-error "Duplicated variable ~S in LOOP parallel binding." name)))
-;; 	 (unless (symbolp name)
-;; 	   (loop-error "Bad variable ~S somewhere in LOOP." name))
-;; 	 (loop-declare-variable name dtype)
-;; 	 ;; We use ASSOC on this list to check for duplications (above),
-;; 	 ;; so don't optimize out this list:
-;; 	 (push (list name (or initialization (loop-typed-init dtype)))
-;; 	       *loop-variables*))
-;; 	(initialization
-;; 	 (cond (*loop-destructuring-hooks*
-;; 		(loop-declare-variable name dtype)
-;; 		(push (list name initialization) *loop-variables*))
-;; 	       (t (let ((newvar (loop-gentemp 'loop-destructure-)))
-;; 		    (push (list newvar initialization) *loop-variables*)
-;; 		    ;; *LOOP-DESETQ-CROCKS* gathered in reverse order.
-;; 		    (setq *loop-desetq-crocks*
-;; 		      (list* name newvar *loop-desetq-crocks*))
-;; 		    #+ignore
-;; 		    (loop-make-variable name nil dtype iteration-variable-p)))))
-;; 	(t (let ((tcar nil) (tcdr nil))
-;; 	     (if (atom dtype) (setq tcar (setq tcdr dtype))
-;; 		 (setq tcar (car dtype) tcdr (cdr dtype)))
-;; 	     (loop-make-variable (car name) nil tcar iteration-variable-p)
-;; 	     (loop-make-variable (cdr name) nil tcdr iteration-variable-p))))
-;;   name)
+(defun loop-make-variable (name initialization dtype &optional iteration-variable-p)
+  (cond ((null name)
+	 (cond ((not (null initialization))
+		(push (list (setq name (loop-gentemp 'loop-ignore-))
+			    initialization)
+		      *loop-variables*)
+		(push `(ignore ,name) *loop-declarations*))))
+	((atom name)
+	 (cond (iteration-variable-p
+		(if (member name *loop-iteration-variables*)
+		    (loop-error "Duplicated LOOP iteration variable ~S." name)
+		    (push name *loop-iteration-variables*)))
+	       ((assoc name *loop-variables*)
+		(loop-error "Duplicated variable ~S in LOOP parallel binding." name)))
+	 (unless (symbolp name)
+	   (loop-error "Bad variable ~S somewhere in LOOP." name))
+	 (loop-declare-variable name dtype)
+	 ;; We use ASSOC on this list to check for duplications (above),
+	 ;; so don't optimize out this list:
+	 (push (list name (or initialization (loop-typed-init dtype)))
+	       *loop-variables*))
+	(initialization
+	 (cond (*loop-destructuring-hooks*
+		(loop-declare-variable name dtype)
+		(push (list name initialization) *loop-variables*))
+	       (t (let ((newvar (loop-gentemp 'loop-destructure-)))
+		    (push (list newvar initialization) *loop-variables*)
+		    ;; *LOOP-DESETQ-CROCKS* gathered in reverse order.
+		    (setq *loop-desetq-crocks*
+		      (list* name newvar *loop-desetq-crocks*))
+		    #+ignore
+		    (loop-make-variable name nil dtype iteration-variable-p)))))
+	(t (let ((tcar nil) (tcdr nil))
+	     (if (atom dtype) (setq tcar (setq tcdr dtype))
+		 (setq tcar (car dtype) tcdr (cdr dtype)))
+	     (loop-make-variable (car name) nil tcar iteration-variable-p)
+	     (loop-make-variable (cdr name) nil tcdr iteration-variable-p))))
+  name)
 
 
-;; (defun loop-make-iteration-variable (name initialization dtype)
-;;   (loop-make-variable name initialization dtype t))
+(defun loop-make-iteration-variable (name initialization dtype)
+  (loop-make-variable name initialization dtype t))
 
 
-;; (defun loop-declare-variable (name dtype)
-;;   (cond ((or (null name) (null dtype) (eq dtype t)) nil)
-;; 	((symbolp name)
-;; 	 (unless (or (eq dtype t) (member (the symbol name) *loop-nodeclare*))
-;; 	   (push `(type ,dtype ,name) *loop-declarations*)))
-;; 	((consp name)
-;; 	 (cond ((consp dtype)
-;; 		(loop-declare-variable (car name) (car dtype))
-;; 		(loop-declare-variable (cdr name) (cdr dtype)))
-;; 	       (t (loop-declare-variable (car name) dtype)
-;; 		  (loop-declare-variable (cdr name) dtype))))
-;; 	(t (error "Invalid LOOP variable passed in: ~S." name))))
+(defun loop-declare-variable (name dtype)
+  (cond ((or (null name) (null dtype) (eq dtype t)) nil)
+	((symbolp name)
+	 (unless (or (eq dtype t) (member (the symbol name) *loop-nodeclare*))
+	   (push `(type ,dtype ,name) *loop-declarations*)))
+	((consp name)
+	 (cond ((consp dtype)
+		(loop-declare-variable (car name) (car dtype))
+		(loop-declare-variable (cdr name) (cdr dtype)))
+	       (t (loop-declare-variable (car name) dtype)
+		  (loop-declare-variable (cdr name) dtype))))
+	(t (error "Invalid LOOP variable passed in: ~S." name))))
 
 
-;; (defun loop-maybe-bind-form (form data-type)
-;;   (if (loop-constantp form)
-;;       form
-;;       (loop-make-variable (loop-gentemp 'loop-bind-) form data-type)))
-;; 
+(defun loop-maybe-bind-form (form data-type)
+  (if (loop-constantp form)
+      form
+      (loop-make-variable (loop-gentemp 'loop-bind-) form data-type)))
+
 
 
-;; (defun loop-do-if (for negatep)
-;;   (let ((form (loop-get-form)) (*loop-inside-conditional* t) (it-p nil))
-;;     (flet ((get-clause (for)
-;; 	     (do ((body nil)) (nil)
-;; 	       (let ((key (car *loop-source-code*)) (*loop-body* nil) data)
-;; 		 (cond ((not (symbolp key))
-;; 			(loop-error
-;; 			  "~S found where keyword expected getting LOOP clause after ~S."
-;; 			  key for))
-;; 		       (t (setq *loop-source-context* *loop-source-code*)
-;; 			  (loop-pop-source)
-;; 			  (when (loop-tequal (car *loop-source-code*) 'it)
-;; 			    (setq *loop-source-code*
-;; 				  (cons (or it-p (setq it-p (loop-when-it-variable)))
-;; 					(cdr *loop-source-code*))))
-;; 			  (cond ((or (not (setq data (loop-lookup-keyword
-;; 						       key (loop-universe-keywords *loop-universe*))))
-;; 				     (progn (apply (symbol-function (car data)) (cdr data))
-;; 					    (null *loop-body*)))
-;; 				 (loop-error
-;; 				   "~S does not introduce a LOOP clause that can follow ~S."
-;; 				   key for))
-;; 				(t (setq body (nreconc *loop-body* body)))))))
-;; 	       (if (loop-tequal (car *loop-source-code*) :and)
-;; 		   (loop-pop-source)
-;; 		   (return (if (cdr body) `(progn ,@(nreverse body)) (car body)))))))
-;;       (let ((then (get-clause for))
-;; 	    (else (when (loop-tequal (car *loop-source-code*) :else)
-;; 		    (loop-pop-source)
-;; 		    (list (get-clause :else)))))
-;; 	(when (loop-tequal (car *loop-source-code*) :end)
-;; 	  (loop-pop-source))
-;; 	(when it-p (setq form `(setq ,it-p ,form)))
-;; 	(loop-pseudo-body
-;; 	  `(if ,(if negatep `(not ,form) form)
-;; 	       ,then
-;; 	       ,@else))))))
+(defun loop-do-if (for negatep)
+  (let ((form (loop-get-form)) (*loop-inside-conditional* t) (it-p nil))
+    (flet ((get-clause (for)
+	     (do ((body nil)) (nil)
+	       (let ((key (car *loop-source-code*)) (*loop-body* nil) data)
+		 (cond ((not (symbolp key))
+			(loop-error
+			  "~S found where keyword expected getting LOOP clause after ~S."
+			  key for))
+		       (t (setq *loop-source-context* *loop-source-code*)
+			  (loop-pop-source)
+			  (when (loop-tequal (car *loop-source-code*) 'it)
+			    (setq *loop-source-code*
+				  (cons (or it-p (setq it-p (loop-when-it-variable)))
+					(cdr *loop-source-code*))))
+			  (cond ((or (not (setq data (loop-lookup-keyword
+						       key (loop-universe-keywords *loop-universe*))))
+				     (progn (apply (symbol-function (car data)) (cdr data))
+					    (null *loop-body*)))
+				 (loop-error
+				   "~S does not introduce a LOOP clause that can follow ~S."
+				   key for))
+				(t (setq body (nreconc *loop-body* body)))))))
+	       (if (loop-tequal (car *loop-source-code*) :and)
+		   (loop-pop-source)
+		   (return (if (cdr body) `(progn ,@(nreverse body)) (car body)))))))
+      (let ((then (get-clause for))
+	    (else (when (loop-tequal (car *loop-source-code*) :else)
+		    (loop-pop-source)
+		    (list (get-clause :else)))))
+	(when (loop-tequal (car *loop-source-code*) :end)
+	  (loop-pop-source))
+	(when it-p (setq form `(setq ,it-p ,form)))
+	(loop-pseudo-body
+	  `(if ,(if negatep `(not ,form) form)
+	       ,then
+	       ,@else))))))
 
 
-;; (defun loop-do-initially ()
-;;   (loop-disallow-conditional :initially)
-;;   (push (loop-get-progn) *loop-prologue*))
+(defun loop-do-initially ()
+  (loop-disallow-conditional :initially)
+  (push (loop-get-progn) *loop-prologue*))
 
-;; (defun loop-do-finally ()
-;;   (loop-disallow-conditional :finally)
-;;   (push (loop-get-progn) *loop-epilogue*))
+(defun loop-do-finally ()
+  (loop-disallow-conditional :finally)
+  (push (loop-get-progn) *loop-epilogue*))
 
-;; (defun loop-do-do ()
-;;   (loop-emit-body (loop-get-progn)))
+(defun loop-do-do ()
+  (loop-emit-body (loop-get-progn)))
 
-;; (defun loop-do-named ()
-;;   (let ((name (loop-pop-source)))
-;;     (unless (symbolp name)
-;;       (loop-error "~S is an invalid name for your LOOP." name))
-;;     (when (or *loop-before-loop* *loop-body* *loop-after-epilogue* *loop-inside-conditional*)
-;;       (loop-error "The NAMED ~S clause occurs too late." name))
-;;     (when *loop-names*
-;;       (loop-error "You may only use one NAMED clause in your loop: NAMED ~S ... NAMED ~S."
-;; 		  (car *loop-names*) name))
-;;     (setq *loop-names* (list name nil))))
+(defun loop-do-named ()
+  (let ((name (loop-pop-source)))
+    (unless (symbolp name)
+      (loop-error "~S is an invalid name for your LOOP." name))
+    (when (or *loop-before-loop* *loop-body* *loop-after-epilogue* *loop-inside-conditional*)
+      (loop-error "The NAMED ~S clause occurs too late." name))
+    (when *loop-names*
+      (loop-error "You may only use one NAMED clause in your loop: NAMED ~S ... NAMED ~S."
+		  (car *loop-names*) name))
+    (setq *loop-names* (list name nil))))
 
-;; (defun loop-do-return ()
-;;   (loop-pseudo-body (loop-construct-return (loop-get-form))))
-;; 
+(defun loop-do-return ()
+  (loop-pseudo-body (loop-construct-return (loop-get-form))))
+
 
-;; ;;;; Value Accumulation: List
+;;;; Value Accumulation: List
 
 
 ;; (defstruct (loop-collector

--- a/src/ansiloop/ansi-loop.lisp
+++ b/src/ansiloop/ansi-loop.lisp
@@ -313,7 +313,15 @@ constructed.
 
 
 (defun make-loop-minimax (answer-variable type)
-  (let ((infinity-data (cdr (assoc type *loop-minimax-type-infinities-alist* :test #'subtypep))))
+  (let ((infinity-data
+         ;; FIXME: The original code relies relied on subtypep, but
+         ;; JSCL still doesn't have a proper implementation of the
+         ;; type system.
+         #+nil (cdr (assoc type *loop-minimax-type-infinities-alist* :test #'subtypep))
+         ;;
+         ;; so we just inline the value in here
+         '(most-positive-fixnum most-negative-fixnum)))
+
     (make-loop-minimax-internal
       :answer-variable answer-variable
       :type type

--- a/src/ansiloop/ansi-loop.lisp
+++ b/src/ansiloop/ansi-loop.lisp
@@ -858,6 +858,7 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
 	  ((atom x) 1)				;??? self-evaluating???
 	  ((symbolp (car x))
 	   (let ((fn (car x)) (tem nil) (n 0))
+         ;; FIXME: JSCL doen't support declarations at this context
 	     (declare (symbol fn) (fixnum n))
 	     (macrolet ((f (overhead &optional (args nil args-p))
 			  `(the fixnum (+ (the fixnum ,overhead)
@@ -1760,7 +1761,8 @@ collected result will be returned as the value of the LOOP."
 		   initial-phrases))
 	 (used-prepositions (mapcar #'car initial-phrases)))
 	((null *loop-source-code*) (nreverse prepositional-phrases))
-      (declare (symbol this-prep))
+      ;; FIXME: JSCL doen't support declarations at this context
+      #+nil (declare (symbol this-prep))
       (setq token (car *loop-source-code*))
       (dolist (group preposition-groups)
 	(when (setq this-prep (in-group-p token group))

--- a/src/ansiloop/ansi-loop.lisp
+++ b/src/ansiloop/ansi-loop.lisp
@@ -452,7 +452,7 @@ code to be loaded.
 (defun make-standard-loop-universe (&key keywords for-keywords iteration-keywords path-keywords
 				    type-keywords type-symbols ansi)
   #-(and CLOE Source-Bootstrap)
-  (check-type ansi (member nil t :extended))
+  ;; (check-type ansi (member nil t :extended))
   (flet ((maketable (entries)
 	   (let* ((size (length entries))
 		  (ht (make-hash-table :size (if (< size 10) 10 size) :test #'equal)))
@@ -1667,7 +1667,8 @@ collected result will be returned as the value of the LOOP."
 (defun add-loop-path (names function universe &key preposition-groups inclusive-permitted user-data)
   (unless (listp names) (setq names (list names)))
   ;; Can't do this due to CLOS bootstrapping problems.
-  #-(or Genera (and CLOE Source-Bootstrap)) (check-type universe loop-universe)
+  #-(or Genera (and CLOE Source-Bootstrap))
+  ;; (check-type universe loop-universe)
   (let ((ht (loop-universe-path-keywords universe))
 	(lp (make-loop-path
 	      :names (mapcar #'symbol-name names)
@@ -1932,7 +1933,7 @@ collected result will be returned as the value of the LOOP."
 ||#
 
 (defun loop-hash-table-iteration-path (variable data-type prep-phrases &key which)
-  (check-type which (member hash-key hash-value))
+  ;; (check-type which (member hash-key hash-value))
   (cond ((or (cdr prep-phrases) (not (member (caar prep-phrases) '(:in :of))))
 	 (loop-error "Too many prepositions!"))
 	((null prep-phrases) (loop-error "Missing OF or IN in ~S iteration path.")))
@@ -2054,6 +2055,7 @@ collected result will be returned as the value of the LOOP."
 				   symbol t vector)
 	     :type-keywords nil
 	     :ansi (if extended-p :extended t))))
+
     (add-loop-path '(hash-key hash-keys) 'loop-hash-table-iteration-path w
 		   :preposition-groups '((:of :in))
 		   :inclusive-permitted nil
@@ -2078,9 +2080,7 @@ collected result will be returned as the value of the LOOP."
 
 
 (defparameter *loop-ansi-universe*
-  ;; (make-ansi-loop-universe nil))
-  nil
-  )
+  (make-ansi-loop-universe nil)))
 
 (defun loop-standard-expansion (keywords-and-forms environment universe)
   (if (and keywords-and-forms (symbolp (car keywords-and-forms)))

--- a/src/ansiloop/ansi-loop.lisp
+++ b/src/ansiloop/ansi-loop.lisp
@@ -703,10 +703,12 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
     #-Genera (when (setq constantp (constantp new-form))
 	       (setq constant-value (eval new-form)))
     (when (and constantp expected-type)
+      ;; FIXME: The warning are useful but we do not have a type system yet.
+      #+nil
       (unless (typep constant-value expected-type)
-	(loop-warn "The form ~S evaluated to ~S, which was not of the anticipated type ~S."
+        (loop-warn "The form ~S evaluated to ~S, which was not of the anticipated type ~S."
 		   form constant-value expected-type)
-	(setq constantp nil constant-value nil)))
+        (setq constantp nil constant-value nil)))
     (values new-form constantp constant-value)))
 
 

--- a/src/ansiloop/ansi-loop.lisp
+++ b/src/ansiloop/ansi-loop.lisp
@@ -929,7 +929,7 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
 
 
 ;;;INTERFACE: Traditional, ANSI, Lucid.
-(defmacro loop-finish () 
+(defmacro !loop-finish () 
   "Causes the iteration to terminate \"normally\", the same as implicit
 termination by an iteration driving clause, or by use of WHILE or
 UNTIL -- the epilogue code (if any) will be run, and any implicitly
@@ -939,61 +939,67 @@ collected result will be returned as the value of the LOOP."
 
 
 
-(defun loop-translate (*loop-source-code* *loop-macro-environment* *loop-universe*)
-  (let ((*loop-original-source-code* *loop-source-code*)
-	(*loop-source-context* nil)
-	(*loop-iteration-variables* nil)
-	(*loop-variables* nil)
-	(*loop-nodeclare* nil)
-	(*loop-named-variables* nil)
-	(*loop-declarations* nil)
-	(*loop-desetq-crocks* nil)
-	(*loop-bind-stack* nil)
-	(*loop-prologue* nil)
-	(*loop-wrappers* nil)
-	(*loop-before-loop* nil)
-	(*loop-body* nil)
-	(*loop-emitted-body* nil)
-	(*loop-after-body* nil)
-	(*loop-epilogue* nil)
-	(*loop-after-epilogue* nil)
-	(*loop-final-value-culprit* nil)
-	(*loop-inside-conditional* nil)
-	(*loop-when-it-variable* nil)
-	(*loop-never-stepped-variable* nil)
-	(*loop-names* nil)
-	(*loop-collection-cruft* nil))
-    (loop-iteration-driver)
-    (loop-bind-block)
-    (let ((answer `(loop-body
-		     ,(nreverse *loop-prologue*)
-		     ,(nreverse *loop-before-loop*)
-		     ,(nreverse *loop-body*)
-		     ,(nreverse *loop-after-body*)
-		     ,(nreconc *loop-epilogue* (nreverse *loop-after-epilogue*)))))
-      (do () (nil)
-	(setq answer `(block ,(pop *loop-names*) ,answer))
-	(unless *loop-names* (return nil)))
-      (dolist (entry *loop-bind-stack*)
-	(let ((vars (first entry))
-	      (dcls (second entry))
-	      (crocks (third entry))
-	      (wrappers (fourth entry)))
-	  (dolist (w wrappers)
-	    (setq answer (append w (list answer))))
-	  (when (or vars dcls crocks)
-	    (let ((forms (list answer)))
-	      ;;(when crocks (push crocks forms))
-	      (when dcls (push `(declare ,@dcls) forms))
-	      (setq answer `(,(cond ((not vars) 'locally)
-				    (*loop-destructuring-hooks* (first *loop-destructuring-hooks*))
-				    (t 'let))
-			     ,vars
-			     ,@(if crocks
-				   `((destructuring-bind ,@crocks
-					 ,@forms))
-				 forms)))))))
-      answer)))
+(defun loop-translate (loop-source-code loop-macro-environment loop-universe)
+  ;; FIXME: Originally, these variables were bound in the arguments
+  ;; directly, but as the time of writing, JSCL does not support
+  ;; special bindings as function arguments yet.
+  (let* ((*loop-source-code* loop-source-code)
+         (*loop-macro-environment* loop-macro-environment)
+         (*loop-universe* loop-universe))
+    (let ((*loop-original-source-code* *loop-source-code*)
+          (*loop-source-context* nil)
+          (*loop-iteration-variables* nil)
+          (*loop-variables* nil)
+          (*loop-nodeclare* nil)
+          (*loop-named-variables* nil)
+          (*loop-declarations* nil)
+          (*loop-desetq-crocks* nil)
+          (*loop-bind-stack* nil)
+          (*loop-prologue* nil)
+          (*loop-wrappers* nil)
+          (*loop-before-loop* nil)
+          (*loop-body* nil)
+          (*loop-emitted-body* nil)
+          (*loop-after-body* nil)
+          (*loop-epilogue* nil)
+          (*loop-after-epilogue* nil)
+          (*loop-final-value-culprit* nil)
+          (*loop-inside-conditional* nil)
+          (*loop-when-it-variable* nil)
+          (*loop-never-stepped-variable* nil)
+          (*loop-names* nil)
+          (*loop-collection-cruft* nil))
+      (loop-iteration-driver)
+      (loop-bind-block)
+      (let ((answer `(loop-body
+                        ,(nreverse *loop-prologue*)
+                        ,(nreverse *loop-before-loop*)
+                        ,(nreverse *loop-body*)
+                        ,(nreverse *loop-after-body*)
+                        ,(nreconc *loop-epilogue* (nreverse *loop-after-epilogue*)))))
+        (do () (nil)
+          (setq answer `(block ,(pop *loop-names*) ,answer))
+          (unless *loop-names* (return nil)))
+        (dolist (entry *loop-bind-stack*)
+          (let ((vars (first entry))
+                (dcls (second entry))
+                (crocks (third entry))
+                (wrappers (fourth entry)))
+            (dolist (w wrappers)
+              (setq answer (append w (list answer))))
+            (when (or vars dcls crocks)
+              (let ((forms (list answer)))
+                ;;(when crocks (push crocks forms))
+                (when dcls (push `(declare ,@dcls) forms))
+                (setq answer `(,(cond ((not vars) 'locally)
+                                      (*loop-destructuring-hooks* (first *loop-destructuring-hooks*))
+                                      (t 'let))
+                                ,vars
+                                ,@(if crocks
+                                      `((destructuring-bind ,@crocks
+                                            ,@forms))
+                                      forms)))))))
+        answer))))
 
 
 (defun loop-iteration-driver ()
@@ -2094,7 +2100,7 @@ collected result will be returned as the value of the LOOP."
 
 
 ;; INTERFACE: ANSI
-(defmacro loop (&rest keywords-and-forms)
+(defmacro !loop (&rest keywords-and-forms)
   #+Genera (declare (compiler:do-not-record-macroexpansions)
 		    (zwei:indentation . zwei:indent-loop))
   (loop-standard-expansion keywords-and-forms jscl::*environment* *loop-ansi-universe*))

--- a/src/ansiloop/ansi-loop.lisp
+++ b/src/ansiloop/ansi-loop.lisp
@@ -1,49 +1,46 @@
 ;;;   -*- Mode: LISP; Syntax: Common-lisp; Base: 10; Lowercase:T -*-
-;;;>
-;;;> Portions of LOOP are Copyright (c) 1986 by the Massachusetts Institute of Technology.
-;;;> All Rights Reserved.
-;;;> 
-;;;> Permission to use, copy, modify and distribute this software and its
-;;;> documentation for any purpose and without fee is hereby granted,
-;;;> provided that the M.I.T. copyright notice appear in all copies and that
-;;;> both that copyright notice and this permission notice appear in
-;;;> supporting documentation.  The names "M.I.T." and "Massachusetts
-;;;> Institute of Technology" may not be used in advertising or publicity
-;;;> pertaining to distribution of the software without specific, written
-;;;> prior permission.  Notice must be given in supporting documentation that
-;;;> copying distribution is by permission of M.I.T.  M.I.T. makes no
-;;;> representations about the suitability of this software for any purpose.
-;;;> It is provided "as is" without express or implied warranty.
-;;;> 
-;;;>      Massachusetts Institute of Technology
-;;;>      77 Massachusetts Avenue
-;;;>      Cambridge, Massachusetts  02139
-;;;>      United States of America
-;;;>      +1-617-253-1000
-;;;>
-;;;> Portions of LOOP are Copyright (c) 1989, 1990, 1991, 1992 by Symbolics, Inc.
-;;;> All Rights Reserved.
-;;;> 
-;;;> Permission to use, copy, modify and distribute this software and its
-;;;> documentation for any purpose and without fee is hereby granted,
-;;;> provided that the Symbolics copyright notice appear in all copies and
-;;;> that both that copyright notice and this permission notice appear in
-;;;> supporting documentation.  The name "Symbolics" may not be used in
-;;;> advertising or publicity pertaining to distribution of the software
-;;;> without specific, written prior permission.  Notice must be given in
-;;;> supporting documentation that copying distribution is by permission of
-;;;> Symbolics.  Symbolics makes no representations about the suitability of
-;;;> this software for any purpose.  It is provided "as is" without express
-;;;> or implied warranty.
-;;;> 
-;;;> Symbolics, CLOE Runtime, and Minima are trademarks, and CLOE, Genera,
-;;;> and Zetalisp are registered trademarks of Symbolics, Inc.
-;;;>
-;;;>      Symbolics, Inc.
-;;;>      8 New England Executive Park, East
-;;;>      Burlington, Massachusetts  01803
-;;;>      United States of America
-;;;>      +1-617-221-1000
+;;;
+;;;  Portions  of  LOOP are  Copyright  (c)  1986 by  the  Massachusetts
+;;;  Institute of Technology. All Rights Reserved.
+;;;
+;;;  Permission to  use, copy, modify  and distribute this  software and
+;;;  its  documentation  for  any  purpose and  without  fee  is  hereby
+;;;  granted, provided  that the M.I.T.  copyright notice appear  in all
+;;;  copies  and that  both that  copyright notice  and this  permission
+;;;  notice appear  in supporting documentation. The  names "M.I.T." and
+;;;  "Massachusetts  Institute  of  Technology"   may  not  be  used  in
+;;;  advertising or publicity pertaining to distribution of the software
+;;;  without specific, written prior permission. Notice must be given in
+;;;  supporting documentation that copying distribution is by permission
+;;;  of M.I.T. M.I.T. makes no  representations about the suitability of
+;;;  this  software for  any purpose.  It  is provided  "as is"  without
+;;;  express or implied warranty.
+;;;
+;;;       Massachusetts Institute of  Technology 77 Massachusetts Avenue
+;;;       Cambridge,  Massachusetts  02139   United  States  of  America
+;;;       +1-617-253-1000
+;;;
+;;;  Portions  of LOOP  are  Copyright  (c) 1989,  1990,  1991, 1992  by
+;;;  Symbolics, Inc. All Rights Reserved.
+;;;
+;;;  Permission to  use, copy, modify  and distribute this  software and
+;;;  its  documentation  for  any  purpose and  without  fee  is  hereby
+;;;  granted, provided that the Symbolics copyright notice appear in all
+;;;  copies  and that  both that  copyright notice  and this  permission
+;;;  notice appear in supporting documentation. The name "Symbolics" may
+;;;  not be used in advertising  or publicity pertaining to distribution
+;;;  of  the  software  without   specific,  written  prior  permission.
+;;;  Notice  must  be given  in  supporting  documentation that  copying
+;;;  distribution  is by  permission  of Symbolics.  Symbolics makes  no
+;;;  representations  about the  suitability  of this  software for  any
+;;;  purpose.   It   is   provided    "as   is"   without   express   or
+;;;  implied warranty.
+;;;
+;;;  Symbolics,  CLOE  Runtime, and  Minima  are  trademarks, and  CLOE,
+;;;  Genera, and Zetalisp are registered trademarks of Symbolics, Inc.
+;;;
+;;;       Symbolics, Inc. 8 New England Executive Park, East Burlington,
+;;;       Massachusetts 01803 United States of America +1-617-221-1000
 
 ;; $aclHeader: loop.cl,v 1.5 91/12/04 01:13:48 cox acl4_1 $
 
@@ -56,14 +53,14 @@
 
 ;;; Technology.
 ;;;
-;;; The LOOP iteration macro is one of a number of pieces of code
-;;; originally developed at MIT for which free distribution has been
-;;; permitted, as long as the code is not sold for profit, and as long
+;;; The  LOOP iteration  macro is  one  of a  number of  pieces of  code
+;;; originally developed  at MIT  for which  free distribution  has been
+;;; permitted, as long as  the code is not sold for  profit, and as long
 ;;; as notification of MIT's interest in the code is preserved.
 ;;;
-;;; This version of LOOP, which is almost entirely rewritten both as
-;;; clean-up and to conform with the ANSI Lisp LOOP standard, started
-;;; life as MIT LOOP version 829 (which was a part of NIL, possibly
+;;; This version  of LOOP,  which is almost  entirely rewritten  both as
+;;; clean-up and  to conform with  the ANSI Lisp LOOP  standard, started
+;;; life as  MIT LOOP  version 829  (which was a  part of  NIL, possibly
 ;;; never released).
 ;;;
 ;;; A "light revision" was performed by me (Glenn Burke) while at
@@ -85,7 +82,7 @@
 
 ;;; The design of this LOOP is intended to permit, using mostly the same
 ;;; kernel of code, up to three different "loop" macros:
-;;; 
+;;;
 ;;; (1) The unextended, unextensible ANSI standard LOOP;
 ;;;
 ;;; (2) A clean "superset" extension of the ANSI LOOP which provides
@@ -100,7 +97,7 @@
 ;;;
 ;;; Each of the above three LOOP variations can coexist in the same LISP
 ;;; environment.
-;;; 
+;;;
 
 
 ;;;; Miscellaneous Environment Things
@@ -131,7 +128,7 @@
 
 
 (defvar *loop-gentemp*
-	nil)
+  nil)
 
 (defun loop-gentemp (&optional (pref 'loopvar-))
   (if *loop-gentemp*
@@ -151,15 +148,15 @@
   ;; replaced with the appropriate conditional name for your
   ;; implementation/dialect.
   (declare #-ANSI (ignore env)
-	   #+Genera (values speed space safety compilation-speed debug))
+           #+Genera (values speed space safety compilation-speed debug))
   #+ANSI (let ((stuff (declaration-information 'optimize env)))
-	   (values (or (cdr (assoc 'speed stuff)) 1)
-		   (or (cdr (assoc 'space stuff)) 1)
-		   (or (cdr (assoc 'safety stuff)) 1)
-		   (or (cdr (assoc 'compilation-speed stuff)) 1)
-		   (or (cdr (assoc 'debug stuff)) 1)))
+           (values (or (cdr (assoc 'speed stuff)) 1)
+                   (or (cdr (assoc 'space stuff)) 1)
+                   (or (cdr (assoc 'safety stuff)) 1)
+                   (or (cdr (assoc 'compilation-speed stuff)) 1)
+                   (or (cdr (assoc 'debug stuff)) 1)))
   #+CLOE-Runtime (values compiler::time compiler::space
-			 compiler::safety compiler::compilation-speed 1)
+                         compiler::safety compiler::compilation-speed 1)
   #-(or ANSI CLOE-Runtime) (values 1 1 1 1 1))
 
 
@@ -199,8 +196,8 @@
 (defun hide-variable-reference (really-hide variable form)
   (declare #-Genera (ignore really-hide variable))
   #+Genera (if (and really-hide variable (atom variable))	;Punt on destructuring patterns
-	       `(compiler:invisible-references (,variable) ,form)
-	       form)
+               `(compiler:invisible-references (,variable) ,form)
+               form)
   #-Genera form)
 
 
@@ -208,7 +205,7 @@
 
 
 (defmacro with-loop-list-collection-head ((head-var tail-var &optional user-head-var)
-					  &body body)
+                                          &body body)
   (let ((l (and user-head-var (list (list user-head-var nil)))))
     `(let* ((,head-var (list nil)) (,tail-var ,head-var) ,@l)
        ,@body)))
@@ -227,7 +224,7 @@
                                               (2 'cddr)
                                               (3 'cdddr)
                                               (4 'cddddr))
-                                            ,form)))
+                                           ,form)))
                (setq form `(cddddr ,form) n (- n 4)))))
       (let ((tail-form form) (ncdrs nil))
         ;;Determine if the form being constructed is a list of known length.
@@ -243,18 +240,18 @@
                  (when (and (cddr form) (member (car (last form)) '(nil 'nil)))
                    (setq ncdrs (- (length (cdr form)) 2))))))
         (let ((answer
-               (cond ((null ncdrs)
-                      `(when (setf (cdr ,tail-var) ,tail-form)
-                         (setq ,tail-var (last (cdr ,tail-var)))))
-                     ((< ncdrs 0) (return-from loop-collect-rplacd nil))
-                     ((= ncdrs 0)
-                      ;;@@@@ Here we have a choice of two idioms:
-                      ;; (rplacd tail (setq tail tail-form))
-                      ;; (setq tail (setf (cdr tail) tail-form)).
-                      ;;Genera and most others I have seen do better with the former.
-                      `(rplacd ,tail-var (setq ,tail-var ,tail-form)))
-                     (t `(setq ,tail-var ,(cdr-wrap `(setf (cdr ,tail-var) ,tail-form)
-                                                    ncdrs))))))
+                (cond ((null ncdrs)
+                       `(when (setf (cdr ,tail-var) ,tail-form)
+                          (setq ,tail-var (last (cdr ,tail-var)))))
+                      ((< ncdrs 0) (return-from loop-collect-rplacd nil))
+                      ((= ncdrs 0)
+                       ;;@@@@ Here we have a choice of two idioms:
+                       ;; (rplacd tail (setq tail tail-form))
+                       ;; (setq tail (setf (cdr tail) tail-form)).
+                       ;;Genera and most others I have seen do better with the former.
+                       `(rplacd ,tail-var (setq ,tail-var ,tail-form)))
+                      (t `(setq ,tail-var ,(cdr-wrap `(setf (cdr ,tail-var) ,tail-form)
+                                                     ncdrs))))))
           ;;If not using locatives or something similar to update the user's
           ;; head variable, we've got to set it...  It's harmless to repeatedly set it
           ;; unconditionally, and probably faster than checking.
@@ -266,11 +263,11 @@
 (defmacro loop-collect-answer (head-var &optional user-head-var)
   (or user-head-var
       (progn
-	;;If we use locatives to get tail-updating to update the head var,
-	;; then the head var itself contains the answer.  Otherwise we
-	;; have to cdr it.
-	#+LISPM head-var
-	#-LISPM `(cdr ,head-var))))
+        ;;If we use locatives to get tail-updating to update the head var,
+        ;; then the head var itself contains the answer.  Otherwise we
+        ;; have to cdr it.
+        #+LISPM head-var
+        #-LISPM `(cdr ,head-var))))
 
 
 ;;;; Maximization Technology
@@ -291,9 +288,9 @@ constructed.
 |#
 
 (jscl::def!struct (loop-minimax
-	     (:constructor make-loop-minimax-internal)
-	     (:copier nil)
-	     (:predicate nil))
+                   (:constructor make-loop-minimax-internal)
+                   (:copier nil)
+                   (:predicate nil))
   answer-variable
   type
   temp-variable
@@ -303,32 +300,32 @@ constructed.
 
 
 (defvar *loop-minimax-type-infinities-alist*
-	;;@@@@ This is the sort of value this should take on for a Lisp that has
-	;; "eminently usable" infinities.  n.b. there are neither constants nor
-	;; printed representations for infinities defined by CL.
-	;;@@@@ This grotesque read-from-string below is to help implementations
-	;; which croak on the infinity character when it appears in a token, even
-	;; conditionalized out.
+  ;;@@@@ This is the sort of value this should take on for a Lisp that has
+  ;; "eminently usable" infinities.  n.b. there are neither constants nor
+  ;; printed representations for infinities defined by CL.
+  ;;@@@@ This grotesque read-from-string below is to help implementations
+  ;; which croak on the infinity character when it appears in a token, even
+  ;; conditionalized out.
   '((fixnum most-positive-fixnum most-negative-fixnum)))
 
 
 (defun make-loop-minimax (answer-variable type)
   (let ((infinity-data
-         ;; FIXME: The original code relies relied on subtypep, but
-         ;; JSCL still doesn't have a proper implementation of the
-         ;; type system.
-         #+nil (cdr (assoc type *loop-minimax-type-infinities-alist* :test #'subtypep))
-         ;;
-         ;; so we just inline the value in here
-         '(most-positive-fixnum most-negative-fixnum)))
+          ;; FIXME: The original code relies relied on subtypep, but
+          ;; JSCL still doesn't have a proper implementation of the
+          ;; type system.
+          #+nil (cdr (assoc type *loop-minimax-type-infinities-alist* :test #'subtypep))
+          ;;
+          ;; so we just inline the value in here
+          '(most-positive-fixnum most-negative-fixnum)))
 
     (make-loop-minimax-internal
-      :answer-variable answer-variable
-      :type type
-      :temp-variable (loop-gentemp 'loop-maxmin-temp-)
-      :flag-variable (and (not infinity-data) (loop-gentemp 'loop-maxmin-flag-))
-      :operations nil
-      :infinity-data infinity-data)))
+     :answer-variable answer-variable
+     :type type
+     :temp-variable (loop-gentemp 'loop-maxmin-temp-)
+     :flag-variable (and (not infinity-data) (loop-gentemp 'loop-maxmin-flag-))
+     :operations nil
+     :infinity-data infinity-data)))
 
 
 (defun loop-note-minimax-operation (operation minimax)
@@ -359,20 +356,20 @@ constructed.
 
 (defmacro loop-accumulate-minimax-value (lm operation form)
   (let* ((answer-var (loop-minimax-answer-variable lm))
-	 (temp-var (loop-minimax-temp-variable lm))
-	 (flag-var (loop-minimax-flag-variable lm))
-	 (test
-	   (hide-variable-reference
-	     t (loop-minimax-answer-variable lm)
-	     `(,(ecase operation
-		  (min '<)
-		  (max '>))
-	       ,temp-var ,answer-var))))
+         (temp-var (loop-minimax-temp-variable lm))
+         (flag-var (loop-minimax-flag-variable lm))
+         (test
+           (hide-variable-reference
+            t (loop-minimax-answer-variable lm)
+            `(,(ecase operation
+                 (min '<)
+                 (max '>))
+              ,temp-var ,answer-var))))
     `(progn
        (setq ,temp-var ,form)
        (when ,(if flag-var `(or (not ,flag-var) ,test) test)
-	 (setq ,@(and flag-var `(,flag-var t))
-	       ,answer-var ,temp-var)))))
+         (setq ,@(and flag-var `(,flag-var t))
+               ,answer-var ,temp-var)))))
 
 
 
@@ -419,10 +416,10 @@ code to be loaded.
 
 
 (jscl::def!struct (loop-universe
-              ;; FIXME: Implement me in JSCL!
-              ;; (:print-function print-loop-universe)
-              (:copier nil)
-              (:predicate nil))
+ ;; FIXME: Implement me in JSCL!
+ ;; (:print-function print-loop-universe)
+                   (:copier nil)
+                   (:predicate nil))
   keywords					;hash table, value = (fn-name . extra-data).
   iteration-keywords				;hash table, value = (fn-name . extra-data).
   for-keywords					;hash table, value = (fn-name . extra-data).
@@ -437,10 +434,10 @@ code to be loaded.
 (defun print-loop-universe (u stream level)
   (declare (ignore level))
   (let ((str (case (loop-universe-ansi u)
-	       ((nil) "Non-ANSI")
-	       ((t) "ANSI")
-	       (:extended "Extended-ANSI")
-	       (t (loop-universe-ansi u)))))
+               ((nil) "Non-ANSI")
+               ((t) "ANSI")
+               (:extended "Extended-ANSI")
+               (t (loop-universe-ansi u)))))
     ;;Cloe could be done with the above except for bootstrap lossage...
     #+CLOE
     (format stream "#<~S ~A ~X>" (type-of u) str (sys::address-of u))
@@ -458,34 +455,34 @@ code to be loaded.
 
 
 (defun make-standard-loop-universe (&key keywords for-keywords iteration-keywords path-keywords
-				    type-keywords type-symbols ansi)
+                                         type-keywords type-symbols ansi)
   #-(and CLOE Source-Bootstrap)
   ;; (check-type ansi (member nil t :extended))
   (flet ((maketable (entries)
-	   (let* ((size (length entries))
-		  (ht (make-hash-table :size (if (< size 10) 10 size) :test #'equal)))
-	     (dolist (x entries) (setf (gethash (symbol-name (car x)) ht) (cadr x)))
-	     ht)))
+           (let* ((size (length entries))
+                  (ht (make-hash-table :size (if (< size 10) 10 size) :test #'equal)))
+             (dolist (x entries) (setf (gethash (symbol-name (car x)) ht) (cadr x)))
+             ht)))
     (make-loop-universe
-      :keywords (maketable keywords)
-      :for-keywords (maketable for-keywords)
-      :iteration-keywords (maketable iteration-keywords)
-      :path-keywords (maketable path-keywords)
-      :ansi ansi
-      :implicit-for-required (not (null ansi))
-      :type-keywords (maketable type-keywords)
-      :type-symbols (let* ((size (length type-symbols))
-			   (ht (make-hash-table :size (if (< size 10) 10 size) :test #'eq)))
-		      (dolist (x type-symbols)
-			(if (atom x) (setf (gethash x ht) x) (setf (gethash (car x) ht) (cadr x))))
-		      ht)))) 
+     :keywords (maketable keywords)
+     :for-keywords (maketable for-keywords)
+     :iteration-keywords (maketable iteration-keywords)
+     :path-keywords (maketable path-keywords)
+     :ansi ansi
+     :implicit-for-required (not (null ansi))
+     :type-keywords (maketable type-keywords)
+     :type-symbols (let* ((size (length type-symbols))
+                          (ht (make-hash-table :size (if (< size 10) 10 size) :test #'eq)))
+                     (dolist (x type-symbols)
+                       (if (atom x) (setf (gethash x ht) x) (setf (gethash (car x) ht) (cadr x))))
+                     ht))))
 
 
 ;;;; Setq Hackery
 
 
 (defvar *loop-destructuring-hooks*
-	nil
+  nil
   "If not NIL, this must be a list of two things:
 a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.")
 
@@ -493,19 +490,19 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
 (defun loop-make-psetq (frobs)
   (and frobs
        (loop-make-desetq
-	 (list (car frobs)
-	       (if (null (cddr frobs)) (cadr frobs)
-		   `(prog1 ,(cadr frobs)
-			   ,(loop-make-psetq (cddr frobs))))))))
+        (list (car frobs)
+              (if (null (cddr frobs)) (cadr frobs)
+                  `(prog1 ,(cadr frobs)
+                     ,(loop-make-psetq (cddr frobs))))))))
 
 
 (defun loop-make-desetq (var-val-pairs)
   (if (null var-val-pairs)
       nil
       (cons (if *loop-destructuring-hooks*
-		(cadr *loop-destructuring-hooks*)
-		'loop-really-desetq)
-	    var-val-pairs)))
+                (cadr *loop-destructuring-hooks*)
+                'loop-really-desetq)
+            var-val-pairs)))
 
 
 (defvar *loop-desetq-temporary*
@@ -520,51 +517,51 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
                (do ((tail var)) ((not (consp tail)) tail)
                  (when (find-non-null (pop tail)) (return t))))
              (loop-desetq-internal (var val &optional temp)
-                ;; returns a list of actions to be performed
-                (typecase var
-                  (null
-                   (when (consp val)
-                     ;; don't lose possible side-effects
-                     (if (eq (car val) 'prog1)
-                         ;; these can come from psetq or desetq below.
-                         ;; throw away the value, keep the side-effects.
-                         ;;Special case is for handling an expanded POP.
-                         (mapcan #'(lambda (x)
-                                     (and (consp x)
-                                          (or (not (eq (car x) 'car))
-                                              (not (symbolp (cadr x)))
-                                              (not (symbolp (setq x (macroexpand x env)))))
-                                          (cons x nil)))
-                                 (cdr val))
-                         `(,val))))
-                  (cons
-                   (let* ((car (car var))
-                          (cdr (cdr var))
-                          (car-non-null (find-non-null car))
-                          (cdr-non-null (find-non-null cdr)))
-                     (when (or car-non-null cdr-non-null)
-                       (if cdr-non-null
-                           (let* ((temp-p temp)
-                                  (temp (or temp *loop-desetq-temporary*))
-                                  (body #+LOOP-Prefer-POP `(,@(loop-desetq-internal
-                                                                 car
-                                                                   `(prog1 (car ,temp)
-                                                                      (setq ,temp (cdr ,temp))))
-                                                              ,@(loop-desetq-internal cdr temp temp))
-                                        #-LOOP-Prefer-POP `(,@(loop-desetq-internal car `(car ,temp))
-                                                              (setq ,temp (cdr ,temp))
-                                                              ,@(loop-desetq-internal cdr temp temp))))
-                             (if temp-p
-                                 `(,@(unless (eq temp val)
-                                       `((setq ,temp ,val)))
-                                     ,@body)
-                                 `((let ((,temp ,val))
-                                     ,@body))))
-                           ;; no cdring to do
-                           (loop-desetq-internal car `(car ,val) temp)))))
-                  (otherwise
-                   (unless (eq var val)
-                     `((setq ,var ,val)))))))
+               ;; returns a list of actions to be performed
+               (typecase var
+                 (null
+                  (when (consp val)
+                    ;; don't lose possible side-effects
+                    (if (eq (car val) 'prog1)
+                        ;; these can come from psetq or desetq below.
+                        ;; throw away the value, keep the side-effects.
+                        ;;Special case is for handling an expanded POP.
+                        (mapcan #'(lambda (x)
+                                    (and (consp x)
+                                         (or (not (eq (car x) 'car))
+                                             (not (symbolp (cadr x)))
+                                             (not (symbolp (setq x (macroexpand x env)))))
+                                         (cons x nil)))
+                                (cdr val))
+                        `(,val))))
+                 (cons
+                  (let* ((car (car var))
+                         (cdr (cdr var))
+                         (car-non-null (find-non-null car))
+                         (cdr-non-null (find-non-null cdr)))
+                    (when (or car-non-null cdr-non-null)
+                      (if cdr-non-null
+                          (let* ((temp-p temp)
+                                 (temp (or temp *loop-desetq-temporary*))
+                                 (body #+LOOP-Prefer-POP `(,@(loop-desetq-internal
+                                                              car
+                                                              `(prog1 (car ,temp)
+                                                                 (setq ,temp (cdr ,temp))))
+                                                           ,@(loop-desetq-internal cdr temp temp))
+                                       #-LOOP-Prefer-POP `(,@(loop-desetq-internal car `(car ,temp))
+                                                           (setq ,temp (cdr ,temp))
+                                                           ,@(loop-desetq-internal cdr temp temp))))
+                            (if temp-p
+                                `(,@(unless (eq temp val)
+                                      `((setq ,temp ,val)))
+                                  ,@body)
+                                `((let ((,temp ,val))
+                                    ,@body))))
+                          ;; no cdring to do
+                          (loop-desetq-internal car `(car ,val) temp)))))
+                 (otherwise
+                  (unless (eq var val)
+                    `((setq ,var ,val)))))))
       (do ((actions))
           ((null var-val-pairs)
            (if (null (cdr actions)) (car actions) `(progn ,@(nreverse actions))))
@@ -675,7 +672,7 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
 
 ;;;Sometimes we decide we need to fold together parts of the loop, but
 ;;;some part of the generated iteration  code is different for the first
-;;;and remaining iterations.  This variable will be the temporary which 
+;;;and remaining iterations.  This variable will be the temporary which
 ;;;is the flag used in the loop to tell whether we are in the first or
 ;;;remaining iterations.
 (defvar *loop-never-stepped-variable*)
@@ -692,23 +689,23 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
   #+Genera (declare (values new-form constantp constant-value))
   (let ((new-form form) (constantp nil) (constant-value nil))
     #+Genera (setq new-form (compiler:optimize-form form *loop-macro-environment*
-						    :repeat t
-						    :do-macro-expansion t
-						    :do-named-constants t
-						    :do-inline-forms t
-						    :do-optimizers t
-						    :do-constant-folding t
-						    :do-function-args t)
-		   constantp (constantp new-form *loop-macro-environment*)
-		   constant-value (and constantp (lt:evaluate-constant new-form *loop-macro-environment*)))
+                                                    :repeat t
+                                                    :do-macro-expansion t
+                                                    :do-named-constants t
+                                                    :do-inline-forms t
+                                                    :do-optimizers t
+                                                    :do-constant-folding t
+                                                    :do-function-args t)
+                   constantp (constantp new-form *loop-macro-environment*)
+                   constant-value (and constantp (lt:evaluate-constant new-form *loop-macro-environment*)))
     #-Genera (when (setq constantp (constantp new-form))
-	       (setq constant-value (eval new-form)))
+               (setq constant-value (eval new-form)))
     (when (and constantp expected-type)
       ;; FIXME: The warning are useful but we do not have a type system yet.
       #+nil
       (unless (typep constant-value expected-type)
         (loop-warn "The form ~S evaluated to ~S, which was not of the anticipated type ~S."
-		   form constant-value expected-type)
+                   form constant-value expected-type)
         (setq constantp nil constant-value nil)))
     (values new-form constantp constant-value)))
 
@@ -721,11 +718,11 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
 ;;;; LOOP Iteration Optimization
 
 (defvar *loop-duplicate-code*
-	nil)
+  nil)
 
 
 (defvar *loop-iteration-flag-variable*
-	(make-symbol "LOOP-NOT-FIRST-TIME"))
+  (make-symbol "LOOP-NOT-FIRST-TIME"))
 
 
 (defun loop-code-duplication-threshold (env)
@@ -734,11 +731,11 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
 
 
 (defmacro loop-body (
-		     prologue
-		     before-loop
-		     main-body
-		     after-loop
-		     epilogue)
+                     prologue
+                     before-loop
+                     main-body
+                     after-loop
+                     epilogue)
 
   ;; FIXME: JSCL doesn't support &environment keyword in macro
   ;; lambda-lists or &aux variables.
@@ -746,7 +743,7 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
         rbefore
         rafter
         flagvar)
-    
+
     (unless (= (length before-loop) (length after-loop))
       (error "LOOP-BODY called with non-synched before- and after-loop lists."))
     ;;All our work is done from these copies, working backwards from the end:
@@ -809,7 +806,7 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
                      (push `(setq ,(setq flagvar *loop-iteration-flag-variable*) t) else))
                    (push `(if ,flagvar ,(pify (psimp then)) ,(pify (psimp else)))
                          main-body))
-                 ;; Everything chronologically before lastdiff until the non-duplicatable form (car bb) 
+                 ;; Everything chronologically before lastdiff until the non-duplicatable form (car bb)
                  ;; is the same in rbefore and rafter so just copy it into the body
                  (do () (nil)
                    (pop rafter)
@@ -822,36 +819,36 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
 (defun duplicatable-code-p (expr env)
   (if (null expr) 0
       (let ((ans (estimate-code-size expr env)))
-	#+nil (declare (fixnum ans))
-	;;@@@@ Use (DECLARATION-INFORMATION 'OPTIMIZE ENV) here to get an alist of
-	;; optimize quantities back to help quantify how much code we are willing to
-	;; duplicate.
-	ans)))
+        #+nil (declare (fixnum ans))
+        ;;@@@@ Use (DECLARATION-INFORMATION 'OPTIMIZE ENV) here to get an alist of
+        ;; optimize quantities back to help quantify how much code we are willing to
+        ;; duplicate.
+        ans)))
 
 
 (defvar *special-code-sizes*
-	'((return 0) (progn 0)
-	  (null 1) (not 1) (eq 1) (car 1) (cdr 1)
-	  (when 1) (unless 1) (if 1)
-	  (caar 2) (cadr 2) (cdar 2) (cddr 2)
-	  (caaar 3) (caadr 3) (cadar 3) (caddr 3) (cdaar 3) (cdadr 3) (cddar 3) (cdddr 3)
-	  (caaaar 4) (caaadr 4) (caadar 4) (caaddr 4)
-	  (cadaar 4) (cadadr 4) (caddar 4) (cadddr 4)
-	  (cdaaar 4) (cdaadr 4) (cdadar 4) (cdaddr 4)
-	  (cddaar 4) (cddadr 4) (cdddar 4) (cddddr 4)))
+  '((return 0) (progn 0)
+    (null 1) (not 1) (eq 1) (car 1) (cdr 1)
+    (when 1) (unless 1) (if 1)
+    (caar 2) (cadr 2) (cdar 2) (cddr 2)
+    (caaar 3) (caadr 3) (cadar 3) (caddr 3) (cdaar 3) (cdadr 3) (cddar 3) (cdddr 3)
+    (caaaar 4) (caaadr 4) (caadar 4) (caaddr 4)
+    (cadaar 4) (cadadr 4) (caddar 4) (cadddr 4)
+    (cdaaar 4) (cdaadr 4) (cdadar 4) (cdaddr 4)
+    (cddaar 4) (cddadr 4) (cdddar 4) (cddddr 4)))
 
 
 (defvar *estimate-code-size-punt*
-	'(block
-	   do do* dolist
-	   flet
-	   labels lambda let let* locally
-	   macrolet multiple-value-bind
-	   prog prog*
-	   symbol-macrolet
-	   tagbody
-	   unwind-protect
-	   with-open-file))
+  '(block
+    do do* dolist
+    flet
+    labels lambda let let* locally
+    macrolet multiple-value-bind
+    prog prog*
+    symbol-macrolet
+    tagbody
+    unwind-protect
+    with-open-file))
 
 
 (defun destructuring-size (x)
@@ -866,53 +863,53 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
 
 (defun estimate-code-size-1 (x env)
   (flet ((list-size (l)
-	   (let ((n 0))
-	     #+nil (declare (fixnum n))
-	     (dolist (x l n) (incf n (estimate-code-size-1 x env))))))
+           (let ((n 0))
+             #+nil (declare (fixnum n))
+             (dolist (x l n) (incf n (estimate-code-size-1 x env))))))
     ;;@@@@ ???? (declare (function list-size (list) fixnum))
     (cond ((constantp x #+Genera env) 1)
-	  ((symbolp x) (multiple-value-bind (new-form expanded-p) (macroexpand-1 x env)
-			 (if expanded-p (estimate-code-size-1 new-form env) 1)))
-	  ((atom x) 1)				;??? self-evaluating???
-	  ((symbolp (car x))
-	   (let ((fn (car x)) (tem nil) (n 0))
-         ;; FIXME: JSCL doen't support declarations at this context
-	     #+nil (declare (symbol fn) (fixnum n))
-	     (macrolet ((f (overhead &optional (args nil args-p))
-			  `(the fixnum (+ (the fixnum ,overhead)
-					  (the fixnum (list-size ,(if args-p args '(cdr x))))))))
-	       (cond ((setq tem (get fn 'estimate-code-size))
-		      (typecase tem
-			(fixnum (f tem))
-			(t (funcall tem x env))))
-		     ((setq tem (assoc fn *special-code-sizes*)) (f (second tem)))
-		     #+Genera
-		     ((eq fn 'compiler:invisible-references) (list-size (cddr x)))
-		     ((eq fn 'cond)
-		      (dolist (clause (cdr x) n) (incf n (list-size clause)) (incf n)))
-		     ((eq fn 'desetq)
-		      (do ((l (cdr x) (cdr l))) ((null l) n)
-			(setq n (+ n (destructuring-size (car l)) (estimate-code-size-1 (cadr l) env)))))
-		     ((member fn '(setq psetq))
-		      (do ((l (cdr x) (cdr l))) ((null l) n)
-			(setq n (+ n (estimate-code-size-1 (cadr l) env) 1))))
-		     ((eq fn 'go) 1)
-		     ((eq fn 'function)
-		      ;;This skirts the issue of implementationally-defined lambda macros
-		      ;; by recognizing CL function names and nothing else.
-		      (if (or (symbolp (cadr x))
-			      (and (consp (cadr x)) (eq (caadr x) 'setf)))
-			  1
-			  (throw 'duplicatable-code-p nil)))
-		     ((eq fn 'multiple-value-setq) (f (length (second x)) (cddr x)))
-		     ((eq fn 'return-from) (1+ (estimate-code-size-1 (third x) env)))
-		     ((or (special-operator-p fn) (member fn *estimate-code-size-punt*))
-		      (throw 'estimate-code-size nil))
-		     (t (multiple-value-bind (new-form expanded-p) (macroexpand-1 x env)
-			  (if expanded-p
-			      (estimate-code-size-1 new-form env)
-			      (f 3))))))))
-	  (t (throw 'estimate-code-size nil)))))
+          ((symbolp x) (multiple-value-bind (new-form expanded-p) (macroexpand-1 x env)
+                         (if expanded-p (estimate-code-size-1 new-form env) 1)))
+          ((atom x) 1)				;??? self-evaluating???
+          ((symbolp (car x))
+           (let ((fn (car x)) (tem nil) (n 0))
+             ;; FIXME: JSCL doen't support declarations at this context
+             #+nil (declare (symbol fn) (fixnum n))
+             (macrolet ((f (overhead &optional (args nil args-p))
+                          `(the fixnum (+ (the fixnum ,overhead)
+                                          (the fixnum (list-size ,(if args-p args '(cdr x))))))))
+               (cond ((setq tem (get fn 'estimate-code-size))
+                      (typecase tem
+                        (fixnum (f tem))
+                        (t (funcall tem x env))))
+                     ((setq tem (assoc fn *special-code-sizes*)) (f (second tem)))
+                     #+Genera
+                     ((eq fn 'compiler:invisible-references) (list-size (cddr x)))
+                     ((eq fn 'cond)
+                      (dolist (clause (cdr x) n) (incf n (list-size clause)) (incf n)))
+                     ((eq fn 'desetq)
+                      (do ((l (cdr x) (cdr l))) ((null l) n)
+                        (setq n (+ n (destructuring-size (car l)) (estimate-code-size-1 (cadr l) env)))))
+                     ((member fn '(setq psetq))
+                      (do ((l (cdr x) (cdr l))) ((null l) n)
+                        (setq n (+ n (estimate-code-size-1 (cadr l) env) 1))))
+                     ((eq fn 'go) 1)
+                     ((eq fn 'function)
+                      ;;This skirts the issue of implementationally-defined lambda macros
+                      ;; by recognizing CL function names and nothing else.
+                      (if (or (symbolp (cadr x))
+                              (and (consp (cadr x)) (eq (caadr x) 'setf)))
+                          1
+                          (throw 'duplicatable-code-p nil)))
+                     ((eq fn 'multiple-value-setq) (f (length (second x)) (cddr x)))
+                     ((eq fn 'return-from) (1+ (estimate-code-size-1 (third x) env)))
+                     ((or (special-operator-p fn) (member fn *estimate-code-size-punt*))
+                      (throw 'estimate-code-size nil))
+                     (t (multiple-value-bind (new-form expanded-p) (macroexpand-1 x env)
+                          (if expanded-p
+                              (estimate-code-size-1 new-form env)
+                              (f 3))))))))
+          (t (throw 'estimate-code-size nil)))))
 
 
 ;;;; Loop Errors
@@ -934,21 +931,21 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
 
 
 (defun loop-check-data-type (specified-type required-type
-			     &optional (default-type required-type))
+                             &optional (default-type required-type))
   (if (null specified-type)
       default-type
       (multiple-value-bind (a b) (subtypep specified-type required-type)
-	(cond ((not b)
-	       (loop-warn "LOOP couldn't verify that ~S is a subtype of the required type ~S."
-			  specified-type required-type))
-	      ((not a)
-	       (loop-error "Specified data type ~S is not a subtype of ~S."
-			   specified-type required-type)))
-	specified-type)))
+        (cond ((not b)
+               (loop-warn "LOOP couldn't verify that ~S is a subtype of the required type ~S."
+                          specified-type required-type))
+              ((not a)
+               (loop-error "Specified data type ~S is not a subtype of ~S."
+                           specified-type required-type)))
+        specified-type)))
 
 
 ;;;INTERFACE: Traditional, ANSI, Lucid.
-(defmacro !loop-finish () 
+(defmacro !loop-finish ()
   "Causes the iteration to terminate \"normally\", the same as implicit
 termination by an iteration driving clause, or by use of WHILE or
 UNTIL -- the epilogue code (if any) will be run, and any implicitly
@@ -991,11 +988,11 @@ collected result will be returned as the value of the LOOP."
       (loop-iteration-driver)
       (loop-bind-block)
       (let ((answer `(loop-body
-                        ,(nreverse *loop-prologue*)
-                        ,(nreverse *loop-before-loop*)
-                        ,(nreverse *loop-body*)
-                        ,(nreverse *loop-after-body*)
-                        ,(nreconc *loop-epilogue* (nreverse *loop-after-epilogue*)))))
+                      ,(nreverse *loop-prologue*)
+                      ,(nreverse *loop-before-loop*)
+                      ,(nreverse *loop-body*)
+                      ,(nreverse *loop-after-body*)
+                      ,(nreconc *loop-epilogue* (nreverse *loop-after-epilogue*)))))
         (do () (nil)
           (setq answer `(block ,(pop *loop-names*) ,answer))
           (unless *loop-names* (return nil)))
@@ -1013,11 +1010,11 @@ collected result will be returned as the value of the LOOP."
                 (setq answer `(,(cond ((not vars) 'locally)
                                       (*loop-destructuring-hooks* (first *loop-destructuring-hooks*))
                                       (t 'let))
-                                ,vars
-                                ,@(if crocks
-                                      `((destructuring-bind ,@crocks
-                                            ,@forms))
-                                      forms)))))))
+                               ,vars
+                               ,@(if crocks
+                                     `((destructuring-bind ,@crocks
+                                           ,@forms))
+                                     forms)))))))
         answer))))
 
 
@@ -1025,19 +1022,19 @@ collected result will be returned as the value of the LOOP."
   (do () ((null *loop-source-code*))
     (let ((keyword (car *loop-source-code*)) (tem nil))
       (cond ((not (symbolp keyword))
-	     (loop-error "~S found where LOOP keyword expected." keyword))
-	    (t (setq *loop-source-context* *loop-source-code*)
-	       (loop-pop-source)
-	       (cond ((setq tem (loop-lookup-keyword keyword (loop-universe-keywords *loop-universe*)))
-		      ;;It's a "miscellaneous" toplevel LOOP keyword (do, collect, named, etc.)
-		      (apply (symbol-function (first tem)) (rest tem)))
-		     ((setq tem (loop-lookup-keyword keyword (loop-universe-iteration-keywords *loop-universe*)))
-		      (loop-hack-iteration tem))
-		     ((loop-tmember keyword '(and else))
-		      ;; Alternative is to ignore it, ie let it go around to the next keyword...
-		      (loop-error "Secondary clause misplaced at top level in LOOP macro: ~S ~S ~S ..."
-				  keyword (car *loop-source-code*) (cadr *loop-source-code*)))
-		     (t (loop-error "~S is an unknown keyword in LOOP macro." keyword))))))))
+             (loop-error "~S found where LOOP keyword expected." keyword))
+            (t (setq *loop-source-context* *loop-source-code*)
+               (loop-pop-source)
+               (cond ((setq tem (loop-lookup-keyword keyword (loop-universe-keywords *loop-universe*)))
+                      ;;It's a "miscellaneous" toplevel LOOP keyword (do, collect, named, etc.)
+                      (apply (symbol-function (first tem)) (rest tem)))
+                     ((setq tem (loop-lookup-keyword keyword (loop-universe-iteration-keywords *loop-universe*)))
+                      (loop-hack-iteration tem))
+                     ((loop-tmember keyword '(and else))
+                      ;; Alternative is to ignore it, ie let it go around to the next keyword...
+                      (loop-error "Secondary clause misplaced at top level in LOOP macro: ~S ~S ~S ..."
+                                  keyword (car *loop-source-code*) (cadr *loop-source-code*)))
+                     (t (loop-error "~S is an unknown keyword in LOOP macro." keyword))))))))
 
 
 
@@ -1066,7 +1063,7 @@ collected result will be returned as the value of the LOOP."
 
 (defun loop-pseudo-body (form)
   (cond ((or *loop-emitted-body* *loop-inside-conditional*) (push form *loop-body*))
-	(t (push form *loop-before-loop*) (push form *loop-after-body*))))
+        (t (push form *loop-before-loop*) (push form *loop-after-body*))))
 
 (defun loop-emit-body (form)
   (setq *loop-emitted-body* t)
@@ -1076,8 +1073,8 @@ collected result will be returned as the value of the LOOP."
   (push (loop-construct-return form) *loop-after-epilogue*)
   (when *loop-final-value-culprit*
     (loop-warn "LOOP clause is providing a value for the iteration,~@
-	        however one was already established by a ~S clause."
-	       *loop-final-value-culprit*))
+ however one was already established by a ~S clause."
+               *loop-final-value-culprit*))
   (setq *loop-final-value-culprit* (car *loop-source-context*)))
 
 
@@ -1093,59 +1090,59 @@ collected result will be returned as the value of the LOOP."
 (defun loop-typed-init (data-type)
   (when (and data-type (subtypep data-type 'number))
     (if (or (subtypep data-type 'float) (subtypep data-type '(complex float)))
-	(coerce 0 data-type)
-	0)))
+        (coerce 0 data-type)
+        0)))
 
 
 (defun loop-optional-type (&optional variable)
   ;;No variable specified implies that no destructuring is permissible.
   (and *loop-source-code*			;Don't get confused by NILs...
        (let ((z (car *loop-source-code*)))
-	 (cond ((loop-tequal z 'of-type)
-		;;This is the syntactically unambigous form in that the form of the
-		;; type specifier does not matter.  Also, it is assumed that the
-		;; type specifier is unambiguously, and without need of translation,
-		;; a common lisp type specifier or pattern (matching the variable) thereof.
-		(loop-pop-source)
-		(loop-pop-source))
-	       ((symbolp z)
-		;;This is the (sort of) "old" syntax, even though we didn't used to support all of
-		;; these type symbols.
-		(let ((type-spec (or (gethash z (loop-universe-type-symbols *loop-universe*))
-				     (gethash (symbol-name z) (loop-universe-type-keywords *loop-universe*)))))
-		  (when type-spec
-		    (loop-pop-source)
-		    type-spec)))
-	       (t 
-		;;This is our sort-of old syntax.  But this is only valid for when we are destructuring,
-		;; so we will be compulsive (should we really be?) and require that we in fact be
-		;; doing variable destructuring here.  We must translate the old keyword pattern typespec
-		;; into a fully-specified pattern of real type specifiers here.
-		(if (consp variable)
-		    (unless (consp z)
-		     (loop-error
-			"~S found where a LOOP keyword, LOOP type keyword, or LOOP type pattern expected."
-			z))
-		    (loop-error "~S found where a LOOP keyword or LOOP type keyword expected." z))
-		(loop-pop-source)
-		(labels ((translate (k v)
-			   (cond ((null k) nil)
-				 ((atom k)
-				  (replicate
-				    (or (gethash k (loop-universe-type-symbols *loop-universe*))
-					(gethash (symbol-name k) (loop-universe-type-keywords *loop-universe*))
-					(loop-error
-					  "Destructuring type pattern ~S contains unrecognized type keyword ~S."
-					  z k))
-				    v))
-				 ((atom v)
-				  (loop-error
-				    "Destructuring type pattern ~S doesn't match variable pattern ~S."
-				    z variable))
-				 (t (cons (translate (car k) (car v)) (translate (cdr k) (cdr v))))))
-			 (replicate (typ v)
-			   (if (atom v) typ (cons (replicate typ (car v)) (replicate typ (cdr v))))))
-		  (translate z variable)))))))
+         (cond ((loop-tequal z 'of-type)
+                ;;This is the syntactically unambigous form in that the form of the
+                ;; type specifier does not matter.  Also, it is assumed that the
+                ;; type specifier is unambiguously, and without need of translation,
+                ;; a common lisp type specifier or pattern (matching the variable) thereof.
+                (loop-pop-source)
+                (loop-pop-source))
+               ((symbolp z)
+                ;;This is the (sort of) "old" syntax, even though we didn't used to support all of
+                ;; these type symbols.
+                (let ((type-spec (or (gethash z (loop-universe-type-symbols *loop-universe*))
+                                     (gethash (symbol-name z) (loop-universe-type-keywords *loop-universe*)))))
+                  (when type-spec
+                    (loop-pop-source)
+                    type-spec)))
+               (t
+                ;;This is our sort-of old syntax.  But this is only valid for when we are destructuring,
+                ;; so we will be compulsive (should we really be?) and require that we in fact be
+                ;; doing variable destructuring here.  We must translate the old keyword pattern typespec
+                ;; into a fully-specified pattern of real type specifiers here.
+                (if (consp variable)
+                    (unless (consp z)
+                      (loop-error
+                       "~S found where a LOOP keyword, LOOP type keyword, or LOOP type pattern expected."
+                       z))
+                    (loop-error "~S found where a LOOP keyword or LOOP type keyword expected." z))
+                (loop-pop-source)
+                (labels ((translate (k v)
+                           (cond ((null k) nil)
+                                 ((atom k)
+                                  (replicate
+                                   (or (gethash k (loop-universe-type-symbols *loop-universe*))
+                                       (gethash (symbol-name k) (loop-universe-type-keywords *loop-universe*))
+                                       (loop-error
+                                        "Destructuring type pattern ~S contains unrecognized type keyword ~S."
+                                        z k))
+                                   v))
+                                 ((atom v)
+                                  (loop-error
+                                   "Destructuring type pattern ~S doesn't match variable pattern ~S."
+                                   z variable))
+                                 (t (cons (translate (car k) (car v)) (translate (cdr k) (cdr v))))))
+                         (replicate (typ v)
+                           (if (atom v) typ (cons (replicate typ (car v)) (replicate typ (cdr v))))))
+                  (translate z variable)))))))
 
 
 
@@ -1155,50 +1152,50 @@ collected result will be returned as the value of the LOOP."
 (defun loop-bind-block ()
   (when (or *loop-variables* *loop-declarations* *loop-wrappers*)
     (push (list (nreverse *loop-variables*) *loop-declarations* *loop-desetq-crocks* *loop-wrappers*)
-	  *loop-bind-stack*)
+          *loop-bind-stack*)
     (setq *loop-variables* nil
-	  *loop-declarations* nil
-	  *loop-desetq-crocks* nil
-	  *loop-wrappers* nil)))
+          *loop-declarations* nil
+          *loop-desetq-crocks* nil
+          *loop-wrappers* nil)))
 
 
 (defun loop-make-variable (name initialization dtype &optional iteration-variable-p)
   (cond ((null name)
-	 (cond ((not (null initialization))
-		(push (list (setq name (loop-gentemp 'loop-ignore-))
-			    initialization)
-		      *loop-variables*)
-		(push `(ignore ,name) *loop-declarations*))))
-	((atom name)
-	 (cond (iteration-variable-p
-		(if (member name *loop-iteration-variables*)
-		    (loop-error "Duplicated LOOP iteration variable ~S." name)
-		    (push name *loop-iteration-variables*)))
-	       ((assoc name *loop-variables*)
-		(loop-error "Duplicated variable ~S in LOOP parallel binding." name)))
-	 (unless (symbolp name)
-	   (loop-error "Bad variable ~S somewhere in LOOP." name))
-	 (loop-declare-variable name dtype)
-	 ;; We use ASSOC on this list to check for duplications (above),
-	 ;; so don't optimize out this list:
-	 (push (list name (or initialization (loop-typed-init dtype)))
-	       *loop-variables*))
-	(initialization
-	 (cond (*loop-destructuring-hooks*
-		(loop-declare-variable name dtype)
-		(push (list name initialization) *loop-variables*))
-	       (t (let ((newvar (loop-gentemp 'loop-destructure-)))
-		    (push (list newvar initialization) *loop-variables*)
-		    ;; *LOOP-DESETQ-CROCKS* gathered in reverse order.
-		    (setq *loop-desetq-crocks*
-		      (list* name newvar *loop-desetq-crocks*))
-		    #+ignore
-		    (loop-make-variable name nil dtype iteration-variable-p)))))
-	(t (let ((tcar nil) (tcdr nil))
-	     (if (atom dtype) (setq tcar (setq tcdr dtype))
-		 (setq tcar (car dtype) tcdr (cdr dtype)))
-	     (loop-make-variable (car name) nil tcar iteration-variable-p)
-	     (loop-make-variable (cdr name) nil tcdr iteration-variable-p))))
+         (cond ((not (null initialization))
+                (push (list (setq name (loop-gentemp 'loop-ignore-))
+                            initialization)
+                      *loop-variables*)
+                (push `(ignore ,name) *loop-declarations*))))
+        ((atom name)
+         (cond (iteration-variable-p
+                (if (member name *loop-iteration-variables*)
+                    (loop-error "Duplicated LOOP iteration variable ~S." name)
+                    (push name *loop-iteration-variables*)))
+               ((assoc name *loop-variables*)
+                (loop-error "Duplicated variable ~S in LOOP parallel binding." name)))
+         (unless (symbolp name)
+           (loop-error "Bad variable ~S somewhere in LOOP." name))
+         (loop-declare-variable name dtype)
+         ;; We use ASSOC on this list to check for duplications (above),
+         ;; so don't optimize out this list:
+         (push (list name (or initialization (loop-typed-init dtype)))
+               *loop-variables*))
+        (initialization
+         (cond (*loop-destructuring-hooks*
+                (loop-declare-variable name dtype)
+                (push (list name initialization) *loop-variables*))
+               (t (let ((newvar (loop-gentemp 'loop-destructure-)))
+                    (push (list newvar initialization) *loop-variables*)
+                    ;; *LOOP-DESETQ-CROCKS* gathered in reverse order.
+                    (setq *loop-desetq-crocks*
+                          (list* name newvar *loop-desetq-crocks*))
+                    #+ignore
+                    (loop-make-variable name nil dtype iteration-variable-p)))))
+        (t (let ((tcar nil) (tcdr nil))
+             (if (atom dtype) (setq tcar (setq tcdr dtype))
+                 (setq tcar (car dtype) tcdr (cdr dtype)))
+             (loop-make-variable (car name) nil tcar iteration-variable-p)
+             (loop-make-variable (cdr name) nil tcdr iteration-variable-p))))
   name)
 
 
@@ -1208,16 +1205,16 @@ collected result will be returned as the value of the LOOP."
 
 (defun loop-declare-variable (name dtype)
   (cond ((or (null name) (null dtype) (eq dtype t)) nil)
-	((symbolp name)
-	 (unless (or (eq dtype t) (member (the symbol name) *loop-nodeclare*))
-	   (push `(type ,dtype ,name) *loop-declarations*)))
-	((consp name)
-	 (cond ((consp dtype)
-		(loop-declare-variable (car name) (car dtype))
-		(loop-declare-variable (cdr name) (cdr dtype)))
-	       (t (loop-declare-variable (car name) dtype)
-		  (loop-declare-variable (cdr name) dtype))))
-	(t (error "Invalid LOOP variable passed in: ~S." name))))
+        ((symbolp name)
+         (unless (or (eq dtype t) (member (the symbol name) *loop-nodeclare*))
+           (push `(type ,dtype ,name) *loop-declarations*)))
+        ((consp name)
+         (cond ((consp dtype)
+                (loop-declare-variable (car name) (car dtype))
+                (loop-declare-variable (cdr name) (cdr dtype)))
+               (t (loop-declare-variable (car name) dtype)
+                  (loop-declare-variable (cdr name) dtype))))
+        (t (error "Invalid LOOP variable passed in: ~S." name))))
 
 
 (defun loop-maybe-bind-form (form data-type)
@@ -1230,40 +1227,40 @@ collected result will be returned as the value of the LOOP."
 (defun loop-do-if (for negatep)
   (let ((form (loop-get-form)) (*loop-inside-conditional* t) (it-p nil))
     (flet ((get-clause (for)
-	     (do ((body nil)) (nil)
-	       (let ((key (car *loop-source-code*)) (*loop-body* nil) data)
-		 (cond ((not (symbolp key))
-			(loop-error
-			  "~S found where keyword expected getting LOOP clause after ~S."
-			  key for))
-		       (t (setq *loop-source-context* *loop-source-code*)
-			  (loop-pop-source)
-			  (when (loop-tequal (car *loop-source-code*) 'it)
-			    (setq *loop-source-code*
-				  (cons (or it-p (setq it-p (loop-when-it-variable)))
-					(cdr *loop-source-code*))))
-			  (cond ((or (not (setq data (loop-lookup-keyword
-						       key (loop-universe-keywords *loop-universe*))))
-				     (progn (apply (symbol-function (car data)) (cdr data))
-					    (null *loop-body*)))
-				 (loop-error
-				   "~S does not introduce a LOOP clause that can follow ~S."
-				   key for))
-				(t (setq body (nreconc *loop-body* body)))))))
-	       (if (loop-tequal (car *loop-source-code*) :and)
-		   (loop-pop-source)
-		   (return (if (cdr body) `(progn ,@(nreverse body)) (car body)))))))
+             (do ((body nil)) (nil)
+               (let ((key (car *loop-source-code*)) (*loop-body* nil) data)
+                 (cond ((not (symbolp key))
+                        (loop-error
+                         "~S found where keyword expected getting LOOP clause after ~S."
+                         key for))
+                       (t (setq *loop-source-context* *loop-source-code*)
+                          (loop-pop-source)
+                          (when (loop-tequal (car *loop-source-code*) 'it)
+                            (setq *loop-source-code*
+                                  (cons (or it-p (setq it-p (loop-when-it-variable)))
+                                        (cdr *loop-source-code*))))
+                          (cond ((or (not (setq data (loop-lookup-keyword
+                                                      key (loop-universe-keywords *loop-universe*))))
+                                     (progn (apply (symbol-function (car data)) (cdr data))
+                                            (null *loop-body*)))
+                                 (loop-error
+                                  "~S does not introduce a LOOP clause that can follow ~S."
+                                  key for))
+                                (t (setq body (nreconc *loop-body* body)))))))
+               (if (loop-tequal (car *loop-source-code*) :and)
+                   (loop-pop-source)
+                   (return (if (cdr body) `(progn ,@(nreverse body)) (car body)))))))
       (let ((then (get-clause for))
-	    (else (when (loop-tequal (car *loop-source-code*) :else)
-		    (loop-pop-source)
-		    (list (get-clause :else)))))
-	(when (loop-tequal (car *loop-source-code*) :end)
-	  (loop-pop-source))
-	(when it-p (setq form `(setq ,it-p ,form)))
-	(loop-pseudo-body
-	  `(if ,(if negatep `(not ,form) form)
-	       ,then
-	       ,@else))))))
+            (else (when (loop-tequal (car *loop-source-code*) :else)
+                    (loop-pop-source)
+                    (list (get-clause :else)))))
+        (when (loop-tequal (car *loop-source-code*) :end)
+          (loop-pop-source))
+        (when it-p (setq form `(setq ,it-p ,form)))
+        (loop-pseudo-body
+         `(if ,(if negatep `(not ,form) form)
+              ,then
+              ,@else))))))
 
 
 (defun loop-do-initially ()
@@ -1285,7 +1282,7 @@ collected result will be returned as the value of the LOOP."
       (loop-error "The NAMED ~S clause occurs too late." name))
     (when *loop-names*
       (loop-error "You may only use one NAMED clause in your loop: NAMED ~S ... NAMED ~S."
-		  (car *loop-names*) name))
+                  (car *loop-names*) name))
     (setq *loop-names* (list name nil))))
 
 (defun loop-do-return ()
@@ -1296,8 +1293,8 @@ collected result will be returned as the value of the LOOP."
 
 
 (jscl::def!struct (loop-collector
-	     (:copier nil)
-	     (:predicate nil))
+                   (:copier nil)
+                   (:predicate nil))
   name
   class
   (history nil)
@@ -1308,34 +1305,34 @@ collected result will be returned as the value of the LOOP."
 
 (defun loop-get-collection-info (collector class default-type)
   (let ((form (loop-get-form))
-	(dtype (and (not (loop-universe-ansi *loop-universe*)) (loop-optional-type)))
-	(name (when (loop-tequal (car *loop-source-code*) 'into)
-		(loop-pop-source)
-		(loop-pop-source))))
+        (dtype (and (not (loop-universe-ansi *loop-universe*)) (loop-optional-type)))
+        (name (when (loop-tequal (car *loop-source-code*) 'into)
+                (loop-pop-source)
+                (loop-pop-source))))
     (when (not (symbolp name))
       (loop-error "Value accumulation recipient name, ~S, is not a symbol." name))
     (unless dtype
       (setq dtype (or (loop-optional-type) default-type)))
     (let ((cruft (find (the symbol name) *loop-collection-cruft*
-		       :key #'loop-collector-name)))
+                       :key #'loop-collector-name)))
       (cond ((not cruft)
-	     (push (setq cruft (make-loop-collector
-				 :name name :class class
-				 :history (list collector) :dtype dtype))
-		   *loop-collection-cruft*))
-	    (t (unless (eq (loop-collector-class cruft) class)
-		 (loop-error
-		   "Incompatible kinds of LOOP value accumulation specified for collecting~@
-		    ~:[as the value of the LOOP~;~:*INTO ~S~]: ~S and ~S."
-		   name (car (loop-collector-history cruft)) collector))
-	       (unless (equal dtype (loop-collector-dtype cruft))
-		 (loop-warn
-		   "Unequal datatypes specified in different LOOP value accumulations~@
-		   into ~S: ~S and ~S."
-		   name dtype (loop-collector-dtype cruft))
-		 (when (eq (loop-collector-dtype cruft) t)
-		   (setf (loop-collector-dtype cruft) dtype)))
-	       (push collector (loop-collector-history cruft))))
+             (push (setq cruft (make-loop-collector
+                                :name name :class class
+                                :history (list collector) :dtype dtype))
+                   *loop-collection-cruft*))
+            (t (unless (eq (loop-collector-class cruft) class)
+                 (loop-error
+                  "Incompatible kinds of LOOP value accumulation specified for collecting~@
+ ~:[as the value of the LOOP~;~:*INTO ~S~]: ~S and ~S."
+                  name (car (loop-collector-history cruft)) collector))
+               (unless (equal dtype (loop-collector-dtype cruft))
+                 (loop-warn
+                  "Unequal datatypes specified in different LOOP value accumulations~@
+ into ~S: ~S and ~S."
+                  name dtype (loop-collector-dtype cruft))
+                 (when (eq (loop-collector-dtype cruft) t)
+                   (setf (loop-collector-dtype cruft) dtype)))
+               (push collector (loop-collector-history cruft))))
       (values cruft form))))
 
 
@@ -1343,19 +1340,19 @@ collected result will be returned as the value of the LOOP."
   (multiple-value-bind (lc form) (loop-get-collection-info specifically 'list 'list)
     (let ((tempvars (loop-collector-tempvars lc)))
       (unless tempvars
-	(setf (loop-collector-tempvars lc)
-	      (setq tempvars (list* (loop-gentemp 'loop-list-head-)
-				    (loop-gentemp 'loop-list-tail-)
-				    (and (loop-collector-name lc)
-					 (list (loop-collector-name lc))))))
-	(push `(with-loop-list-collection-head ,tempvars) *loop-wrappers*)
-	(unless (loop-collector-name lc)
-	  (loop-emit-final-value `(loop-collect-answer ,(car tempvars) ,@(cddr tempvars)))))
+        (setf (loop-collector-tempvars lc)
+              (setq tempvars (list* (loop-gentemp 'loop-list-head-)
+                                    (loop-gentemp 'loop-list-tail-)
+                                    (and (loop-collector-name lc)
+                                         (list (loop-collector-name lc))))))
+        (push `(with-loop-list-collection-head ,tempvars) *loop-wrappers*)
+        (unless (loop-collector-name lc)
+          (loop-emit-final-value `(loop-collect-answer ,(car tempvars) ,@(cddr tempvars)))))
       (ecase specifically
-	(list (setq form `(list ,form)))
-	(nconc nil)
-	(append (unless (and (consp form) (eq (car form) 'list))
-		  (setq form `(loop-copylist* ,form)))))
+        (list (setq form `(list ,form)))
+        (nconc nil)
+        (append (unless (and (consp form) (eq (car form) 'list))
+                  (setq form `(loop-copylist* ,form)))))
       (loop-emit-body `(loop-collect-rplacd ,tempvars ,form)))))
 
 
@@ -1369,21 +1366,21 @@ collected result will be returned as the value of the LOOP."
     (loop-check-data-type (loop-collector-dtype lc) required-type)
     (let ((tempvars (loop-collector-tempvars lc)))
       (unless tempvars
-	(setf (loop-collector-tempvars lc)
-	      (setq tempvars (list (loop-make-variable
-				     (or (loop-collector-name lc)
-					 (loop-gentemp 'loop-sum-))
-				     nil (loop-collector-dtype lc)))))
-	(unless (loop-collector-name lc)
-	  (loop-emit-final-value (car (loop-collector-tempvars lc)))))
+        (setf (loop-collector-tempvars lc)
+              (setq tempvars (list (loop-make-variable
+                                    (or (loop-collector-name lc)
+                                        (loop-gentemp 'loop-sum-))
+                                    nil (loop-collector-dtype lc)))))
+        (unless (loop-collector-name lc)
+          (loop-emit-final-value (car (loop-collector-tempvars lc)))))
       (loop-emit-body
-	(if (eq specifically 'count)
-	    `(when ,form
-	       (setq ,(car tempvars)
-		     ,(hide-variable-reference t (car tempvars) `(1+ ,(car tempvars)))))
-	    `(setq ,(car tempvars)
-		   (+ ,(hide-variable-reference t (car tempvars) (car tempvars))
-		      ,form)))))))
+       (if (eq specifically 'count)
+           `(when ,form
+              (setq ,(car tempvars)
+                    ,(hide-variable-reference t (car tempvars) `(1+ ,(car tempvars)))))
+           `(setq ,(car tempvars)
+                  (+ ,(hide-variable-reference t (car tempvars) (car tempvars))
+                     ,form)))))))
 
 
 
@@ -1393,12 +1390,12 @@ collected result will be returned as the value of the LOOP."
     (loop-check-data-type (loop-collector-dtype lc) *loop-real-data-type*)
     (let ((data (loop-collector-data lc)))
       (unless data
-	(setf (loop-collector-data lc)
-	      (setq data (make-loop-minimax
-			   (or (loop-collector-name lc) (loop-gentemp 'loop-maxmin-))
-			   (loop-collector-dtype lc))))
-	(unless (loop-collector-name lc)
-	  (loop-emit-final-value (loop-minimax-answer-variable data))))
+        (setf (loop-collector-data lc)
+              (setq data (make-loop-minimax
+                          (or (loop-collector-name lc) (loop-gentemp 'loop-maxmin-))
+                          (loop-collector-dtype lc))))
+        (unless (loop-collector-name lc)
+          (loop-emit-final-value (loop-minimax-answer-variable data))))
       (loop-note-minimax-operation specifically data)
       (push `(with-minimax-value ,data) *loop-wrappers*)
       (loop-emit-body `(loop-accumulate-minimax-value ,data ,specifically ,form))
@@ -1413,7 +1410,7 @@ collected result will be returned as the value of the LOOP."
   (let ((form (loop-get-form)))
     (when restrictive (loop-disallow-conditional))
     (loop-emit-body `(,(if negate 'when 'unless) ,form
-		      ,(loop-construct-return nil)))
+                      ,(loop-construct-return nil)))
     (loop-emit-final-value t)))
 
 
@@ -1423,7 +1420,7 @@ collected result will be returned as the value of the LOOP."
 (defun loop-do-thereis (restrictive)
   (when restrictive (loop-disallow-conditional))
   (loop-emit-body `(when (setq ,(loop-when-it-variable) ,(loop-get-form))
-		     ,(loop-construct-return *loop-when-it-variable*))))
+                     ,(loop-construct-return *loop-when-it-variable*))))
 
 
 (defun loop-do-while (negate kwd)
@@ -1436,37 +1433,37 @@ collected result will be returned as the value of the LOOP."
   (loop-disallow-conditional :with)
   (do ((var) (val) (dtype)) (nil)
     (setq var (loop-pop-source)
-	  dtype (loop-optional-type var)
-	  val (cond ((loop-tequal (car *loop-source-code*) :=)
-		     (loop-pop-source)
-		     (loop-get-form))
-		    (t nil)))
+          dtype (loop-optional-type var)
+          val (cond ((loop-tequal (car *loop-source-code*) :=)
+                     (loop-pop-source)
+                     (loop-get-form))
+                    (t nil)))
     (loop-make-variable var val dtype)
     (if (loop-tequal (car *loop-source-code*) :and)
-	(loop-pop-source)
-	(return (loop-bind-block)))))
+        (loop-pop-source)
+        (return (loop-bind-block)))))
 
 
 ;;;; The iteration driver
 
 (defun loop-hack-iteration (entry)
   (flet ((make-endtest (list-of-forms)
-	   (cond ((null list-of-forms) nil)
-		 ((member t list-of-forms) '(go end-loop))
-		 (t `(when ,(if (null (cdr (setq list-of-forms (nreverse list-of-forms))))
-				(car list-of-forms)
-				(cons 'or list-of-forms))
-		       (go end-loop))))))
+           (cond ((null list-of-forms) nil)
+                 ((member t list-of-forms) '(go end-loop))
+                 (t `(when ,(if (null (cdr (setq list-of-forms (nreverse list-of-forms))))
+                                (car list-of-forms)
+                                (cons 'or list-of-forms))
+                       (go end-loop))))))
     (do ((pre-step-tests nil)
-	 (steps nil)
-	 (post-step-tests nil)
-	 (pseudo-steps nil)
-	 (pre-loop-pre-step-tests nil)
-	 (pre-loop-steps nil)
-	 (pre-loop-post-step-tests nil)
-	 (pre-loop-pseudo-steps nil)
-	 (tem) (data))
-	(nil)
+         (steps nil)
+         (post-step-tests nil)
+         (pseudo-steps nil)
+         (pre-loop-pre-step-tests nil)
+         (pre-loop-steps nil)
+         (pre-loop-post-step-tests nil)
+         (pre-loop-pseudo-steps nil)
+         (tem) (data))
+        (nil)
       ;; Note we collect endtests in reverse order, but steps in correct
       ;; order.  MAKE-ENDTEST does the nreverse for us.
       (setq tem (setq data (apply (symbol-function (first entry)) (rest entry))))
@@ -1476,72 +1473,72 @@ collected result will be returned as the value of the LOOP."
       (setq pseudo-steps (nconc pseudo-steps (loop-copylist* (car (setq tem (cdr tem))))))
       (setq tem (cdr tem))
       (when *loop-emitted-body*
-	(loop-error "Iteration in LOOP follows body code."))
+        (loop-error "Iteration in LOOP follows body code."))
       (unless tem (setq tem data))
       (when (car tem) (push (car tem) pre-loop-pre-step-tests))
       (setq pre-loop-steps (nconc pre-loop-steps (loop-copylist* (car (setq tem (cdr tem))))))
       (when (car (setq tem (cdr tem))) (push (car tem) pre-loop-post-step-tests))
       (setq pre-loop-pseudo-steps (nconc pre-loop-pseudo-steps (loop-copylist* (cadr tem))))
       (unless (loop-tequal (car *loop-source-code*) :and)
-	(setq *loop-before-loop* (list* (loop-make-desetq pre-loop-pseudo-steps)
-					(make-endtest pre-loop-post-step-tests)
-					(loop-make-psetq pre-loop-steps)
-					(make-endtest pre-loop-pre-step-tests)
-					*loop-before-loop*)
-	      *loop-after-body* (list* (loop-make-desetq pseudo-steps)
-				       (make-endtest post-step-tests)
-				       (loop-make-psetq steps)
-				       (make-endtest pre-step-tests)
-				       *loop-after-body*))
-	(loop-bind-block)
-	(return nil))
+        (setq *loop-before-loop* (list* (loop-make-desetq pre-loop-pseudo-steps)
+                                        (make-endtest pre-loop-post-step-tests)
+                                        (loop-make-psetq pre-loop-steps)
+                                        (make-endtest pre-loop-pre-step-tests)
+                                        *loop-before-loop*)
+              *loop-after-body* (list* (loop-make-desetq pseudo-steps)
+                                       (make-endtest post-step-tests)
+                                       (loop-make-psetq steps)
+                                       (make-endtest pre-step-tests)
+                                       *loop-after-body*))
+        (loop-bind-block)
+        (return nil))
       (loop-pop-source)				; flush the "AND"
       (when (and (not (loop-universe-implicit-for-required *loop-universe*))
-		 (setq tem (loop-lookup-keyword
-			     (car *loop-source-code*)
-			     (loop-universe-iteration-keywords *loop-universe*))))
-	;;Latest ANSI clarification is that the FOR/AS after the AND must NOT be supplied.
-	(loop-pop-source)
-	(setq entry tem)))))
+                 (setq tem (loop-lookup-keyword
+                            (car *loop-source-code*)
+                            (loop-universe-iteration-keywords *loop-universe*))))
+        ;;Latest ANSI clarification is that the FOR/AS after the AND must NOT be supplied.
+        (loop-pop-source)
+        (setq entry tem)))))
 
 
 ;;;; Main Iteration Drivers
 
 
-;FOR variable keyword ..args..
+                                        ;FOR variable keyword ..args..
 (defun loop-do-for ()
   (let* ((var (loop-pop-source))
-	 (data-type (loop-optional-type var))
-	 (keyword (loop-pop-source))
-	 (first-arg nil)
-	 (tem nil))
+         (data-type (loop-optional-type var))
+         (keyword (loop-pop-source))
+         (first-arg nil)
+         (tem nil))
     (setq first-arg (loop-get-form))
     (unless (and (symbolp keyword)
-		 (setq tem (loop-lookup-keyword
-			     keyword
-			     (loop-universe-for-keywords *loop-universe*))))
+                 (setq tem (loop-lookup-keyword
+                            keyword
+                            (loop-universe-for-keywords *loop-universe*))))
       (loop-error "~S is an unknown keyword in FOR or AS clause in LOOP." keyword))
     (apply (car tem) var first-arg data-type (cdr tem))))
 
 
 (defun loop-do-repeat ()
   (let ((form (loop-get-form))
-	(type (loop-check-data-type (loop-optional-type) *loop-real-data-type*)))
+        (type (loop-check-data-type (loop-optional-type) *loop-real-data-type*)))
     (when (and (consp form) (eq (car form) 'the) (subtypep (second form) type))
       (setq type (second form)))
     (multiple-value-bind (number constantp value)
-	(loop-constant-fold-if-possible form type)
+        (loop-constant-fold-if-possible form type)
       (cond ((and constantp (<= value 1)) `(t () () () ,(<= value 0) () () ()))
-	    (t (let ((var (loop-make-variable (loop-gentemp 'loop-repeat-) number type)))
-		 (if constantp
-		     `((not (plusp (setq ,var (1- ,var)))) () () () () () () ())
-		     `((minusp (setq ,var (1- ,var))) () () ()))))))))
+            (t (let ((var (loop-make-variable (loop-gentemp 'loop-repeat-) number type)))
+                 (if constantp
+                     `((not (plusp (setq ,var (1- ,var)))) () () () () () () ())
+                     `((minusp (setq ,var (1- ,var))) () () ()))))))))
 
 
 (defun loop-when-it-variable ()
   (or *loop-when-it-variable*
       (setq *loop-when-it-variable*
-	    (loop-make-variable (loop-gentemp 'loop-it-) nil nil))))
+            (loop-make-variable (loop-gentemp 'loop-it-) nil nil))))
 
 
 ;;;; Various FOR/AS Subdispatches
@@ -1555,44 +1552,44 @@ collected result will be returned as the value of the LOOP."
 (defun loop-ansi-for-equals (var val data-type)
   (loop-make-iteration-variable var nil data-type)
   (cond ((loop-tequal (car *loop-source-code*) :then)
-	 ;;Then we are the same as "FOR x FIRST y THEN z".
-	 (loop-pop-source)
-	 `(() (,var ,(loop-get-form)) () ()
-	   () (,var ,val) () ()))
-	(t ;;We are the same as "FOR x = y".
-	 `(() (,var ,val) () ()))))
+         ;;Then we are the same as "FOR x FIRST y THEN z".
+         (loop-pop-source)
+         `(() (,var ,(loop-get-form)) () ()
+           () (,var ,val) () ()))
+        (t ;;We are the same as "FOR x = y".
+         `(() (,var ,val) () ()))))
 
 
 (defun loop-for-across (var val data-type)
   (loop-make-iteration-variable var nil data-type)
   (let ((vector-var (loop-gentemp 'loop-across-vector-))
-	(index-var (loop-gentemp 'loop-across-index-)))
+        (index-var (loop-gentemp 'loop-across-index-)))
     (multiple-value-bind (vector-form constantp vector-value)
-	(loop-constant-fold-if-possible val 'vector)
+        (loop-constant-fold-if-possible val 'vector)
       (loop-make-variable
-	vector-var vector-form
-	(if (and (consp vector-form) (eq (car vector-form) 'the))
-	    (cadr vector-form)
-	    'vector))
+       vector-var vector-form
+       (if (and (consp vector-form) (eq (car vector-form) 'the))
+           (cadr vector-form)
+           'vector))
       #+Genera (push `(system:array-register ,vector-var) *loop-declarations*)
       (loop-make-variable index-var 0 'fixnum)
       (let* ((length 0)
-	     (length-form (cond ((not constantp)
-				 (let ((v (loop-gentemp 'loop-across-limit-)))
-				   (push `(setq ,v (length ,vector-var)) *loop-prologue*)
-				   (loop-make-variable v 0 'fixnum)))
-				(t (setq length (length vector-value)))))
-	     (first-test `(>= ,index-var ,length-form))
-	     (other-test first-test)
-	     (step `(,var (aref ,vector-var ,index-var)))
-	     (pstep `(,index-var (1+ ,index-var))))
-	#+nil (declare (fixnum length))
-	(when constantp
-	  (setq first-test (= length 0))
-	  (when (<= length 1)
-	    (setq other-test t)))
-	`(,other-test ,step () ,pstep
-	  ,@(and (not (eq first-test other-test)) `(,first-test ,step () ,pstep)))))))
+             (length-form (cond ((not constantp)
+                                 (let ((v (loop-gentemp 'loop-across-limit-)))
+                                   (push `(setq ,v (length ,vector-var)) *loop-prologue*)
+                                   (loop-make-variable v 0 'fixnum)))
+                                (t (setq length (length vector-value)))))
+             (first-test `(>= ,index-var ,length-form))
+             (other-test first-test)
+             (step `(,var (aref ,vector-var ,index-var)))
+             (pstep `(,index-var (1+ ,index-var))))
+        #+nil (declare (fixnum length))
+        (when constantp
+          (setq first-test (= length 0))
+          (when (<= length 1)
+            (setq other-test t)))
+        `(,other-test ,step () ,pstep
+                      ,@(and (not (eq first-test other-test)) `(,first-test ,step () ,pstep)))))))
 
 
 
@@ -1606,55 +1603,55 @@ collected result will be returned as the value of the LOOP."
   ;;While a Discerning Compiler may deal intelligently with (funcall 'foo ...), not
   ;; recognizing FOO may defeat some LOOP optimizations.
   (let ((stepper (cond ((loop-tequal (car *loop-source-code*) :by)
-			(loop-pop-source)
-			(loop-get-form))
-		       (t '(function cdr)))))
+                        (loop-pop-source)
+                        (loop-get-form))
+                       (t '(function cdr)))))
     (cond ((and (consp stepper) (eq (car stepper) 'quote))
-	   (loop-warn "Use of QUOTE around stepping function in LOOP will be left verbatim.")
-	   (values `(funcall ,stepper ,listvar) nil))
-	  ((and (consp stepper) (eq (car stepper) 'function))
-	   (values (list (cadr stepper) listvar) (cadr stepper)))
-	  (t (values `(funcall ,(loop-make-variable (loop-gentemp 'loop-fn-) stepper 'function)
-			       ,listvar)
-		     nil)))))
+           (loop-warn "Use of QUOTE around stepping function in LOOP will be left verbatim.")
+           (values `(funcall ,stepper ,listvar) nil))
+          ((and (consp stepper) (eq (car stepper) 'function))
+           (values (list (cadr stepper) listvar) (cadr stepper)))
+          (t (values `(funcall ,(loop-make-variable (loop-gentemp 'loop-fn-) stepper 'function)
+                               ,listvar)
+                     nil)))))
 
 
 (defun loop-for-on (var val data-type)
   (multiple-value-bind (list constantp list-value) (loop-constant-fold-if-possible val)
     (let ((listvar var))
       (cond ((and var (symbolp var)) (loop-make-iteration-variable var list data-type))
-	    (t (loop-make-variable (setq listvar (loop-gentemp)) list 'list)
-	       (loop-make-iteration-variable var nil data-type)))
+            (t (loop-make-variable (setq listvar (loop-gentemp)) list 'list)
+               (loop-make-iteration-variable var nil data-type)))
       (multiple-value-bind (list-step step-function) (loop-list-step listvar)
-	(declare #+(and (not LOOP-Prefer-POP) (not CLOE)) (ignore step-function))
-	;;@@@@ The CLOE problem above has to do with bug in macroexpansion of multiple-value-bind.
-	(let* ((first-endtest
-		(hide-variable-reference
-		 (eq var listvar)
-		 listvar
-		 ;; the following should use `atom' instead of `endp', per
-		 ;; [bug2428]
-		 `(atom ,listvar)))
-	       (other-endtest first-endtest))
-	  (when (and constantp (listp list-value))
-	    (setq first-endtest (null list-value)))
-	  (cond ((eq var listvar)
-		 ;;Contour of the loop is different because we use the user's variable...
-		 `(() (,listvar ,(hide-variable-reference t listvar list-step)) ,other-endtest
-		   () () () ,first-endtest ()))
-		#+LOOP-Prefer-POP
-		((and step-function
-		      (let ((n (cdr (assoc step-function '((cdr . 1) (cddr . 2)
-							   (cdddr . 3) (cddddr . 4))))))
-			(and n (do ((l var (cdr l)) (i 0 (1+ i)))
-				   ((atom l) (and (null l) (= i n)))
-				 (declare (fixnum i))))))
-		 (let ((step (mapcan #'(lambda (x) (list x `(pop ,listvar))) var)))
-		   `(,other-endtest () () ,step ,first-endtest () () ,step)))
-		(t (let ((step `(,var ,listvar)) (pseudo `(,listvar ,list-step)))
-		     `(,other-endtest ,step () ,pseudo
-		       ,@(and (not (eq first-endtest other-endtest))
-			      `(,first-endtest ,step () ,pseudo)))))))))))
+        (declare #+(and (not LOOP-Prefer-POP) (not CLOE)) (ignore step-function))
+        ;;@@@@ The CLOE problem above has to do with bug in macroexpansion of multiple-value-bind.
+        (let* ((first-endtest
+                 (hide-variable-reference
+                  (eq var listvar)
+                  listvar
+                  ;; the following should use `atom' instead of `endp', per
+                  ;; [bug2428]
+                  `(atom ,listvar)))
+               (other-endtest first-endtest))
+          (when (and constantp (listp list-value))
+            (setq first-endtest (null list-value)))
+          (cond ((eq var listvar)
+                 ;;Contour of the loop is different because we use the user's variable...
+                 `(() (,listvar ,(hide-variable-reference t listvar list-step)) ,other-endtest
+                   () () () ,first-endtest ()))
+                #+LOOP-Prefer-POP
+                ((and step-function
+                      (let ((n (cdr (assoc step-function '((cdr . 1) (cddr . 2)
+                                                           (cdddr . 3) (cddddr . 4))))))
+                        (and n (do ((l var (cdr l)) (i 0 (1+ i)))
+                                   ((atom l) (and (null l) (= i n)))
+                                 (declare (fixnum i))))))
+                 (let ((step (mapcan #'(lambda (x) (list x `(pop ,listvar))) var)))
+                   `(,other-endtest () () ,step ,first-endtest () () ,step)))
+                (t (let ((step `(,var ,listvar)) (pseudo `(,listvar ,list-step)))
+                     `(,other-endtest ,step () ,pseudo
+                                      ,@(and (not (eq first-endtest other-endtest))
+                                             `(,first-endtest ,step () ,pseudo)))))))))))
 
 
 (defun loop-for-in (var val data-type)
@@ -1663,26 +1660,26 @@ collected result will be returned as the value of the LOOP."
       (loop-make-iteration-variable var nil data-type)
       (loop-make-variable listvar list 'list)
       (multiple-value-bind (list-step step-function) (loop-list-step listvar)
-	#-LOOP-Prefer-POP (declare (ignore step-function))
-	(let* ((first-endtest `(endp ,listvar))
-	       (other-endtest first-endtest)
-	       (step `(,var (car ,listvar)))
-	       (pseudo-step `(,listvar ,list-step)))
-	  (when (and constantp (listp list-value))
-	    (setq first-endtest (null list-value)))
-	  #+LOOP-Prefer-POP (when (eq step-function 'cdr)
-			      (setq step `(,var (pop ,listvar)) pseudo-step nil))
-	  `(,other-endtest ,step () ,pseudo-step
-	    ,@(and (not (eq first-endtest other-endtest))
-		   `(,first-endtest ,step () ,pseudo-step))))))))
+        #-LOOP-Prefer-POP (declare (ignore step-function))
+        (let* ((first-endtest `(endp ,listvar))
+               (other-endtest first-endtest)
+               (step `(,var (car ,listvar)))
+               (pseudo-step `(,listvar ,list-step)))
+          (when (and constantp (listp list-value))
+            (setq first-endtest (null list-value)))
+          #+LOOP-Prefer-POP (when (eq step-function 'cdr)
+                              (setq step `(,var (pop ,listvar)) pseudo-step nil))
+          `(,other-endtest ,step () ,pseudo-step
+                           ,@(and (not (eq first-endtest other-endtest))
+                                  `(,first-endtest ,step () ,pseudo-step))))))))
 
 
 ;;;; Iteration Paths
 
 
 (jscl::def!struct (loop-path
-	     (:copier nil)
-	     (:predicate nil))
+                   (:copier nil)
+                   (:predicate nil))
   names
   preposition-groups
   inclusive-permitted
@@ -1696,12 +1693,12 @@ collected result will be returned as the value of the LOOP."
   ;; #-(or Genera (and CLOE Source-Bootstrap))
   ;; (check-type universe loop-universe)
   (let ((ht (loop-universe-path-keywords universe))
-	(lp (make-loop-path
-	      :names (mapcar #'symbol-name names)
-	      :function function
-	      :user-data user-data
-	      :preposition-groups (mapcar #'(lambda (x) (if (listp x) x (list x))) preposition-groups)
-	      :inclusive-permitted inclusive-permitted)))
+        (lp (make-loop-path
+             :names (mapcar #'symbol-name names)
+             :function function
+             :user-data user-data
+             :preposition-groups (mapcar #'(lambda (x) (if (listp x) x (list x))) preposition-groups)
+             :inclusive-permitted inclusive-permitted)))
     (dolist (name names) (setf (gethash (symbol-name name) ht) lp))
     lp))
 
@@ -1712,46 +1709,46 @@ collected result will be returned as the value of the LOOP."
   ;; FOR var BEING each/the pathname prep-phrases using-stuff...
   ;; each/the = EACH or THE.  Not clear if it is optional, so I guess we'll warn.
   (let ((path nil)
-	(data nil)
-	(inclusive nil)
-	(stuff nil)
-	(initial-prepositions nil))
+        (data nil)
+        (inclusive nil)
+        (stuff nil)
+        (initial-prepositions nil))
     (cond ((loop-tmember val '(:each :the)) (setq path (loop-pop-source)))
-	  ((loop-tequal (car *loop-source-code*) :and)
-	   (loop-pop-source)
-	   (setq inclusive t)
-	   (unless (loop-tmember (car *loop-source-code*) '(:its :each :his :her))
-	     (loop-error "~S found where ITS or EACH expected in LOOP iteration path syntax."
-			 (car *loop-source-code*)))
-	   (loop-pop-source)
-	   (setq path (loop-pop-source))
-	   (setq initial-prepositions `((:in ,val))))
-	  (t (loop-error "Unrecognizable LOOP iteration path syntax.  Missing EACH or THE?")))
+          ((loop-tequal (car *loop-source-code*) :and)
+           (loop-pop-source)
+           (setq inclusive t)
+           (unless (loop-tmember (car *loop-source-code*) '(:its :each :his :her))
+             (loop-error "~S found where ITS or EACH expected in LOOP iteration path syntax."
+                         (car *loop-source-code*)))
+           (loop-pop-source)
+           (setq path (loop-pop-source))
+           (setq initial-prepositions `((:in ,val))))
+          (t (loop-error "Unrecognizable LOOP iteration path syntax.  Missing EACH or THE?")))
     (cond ((not (symbolp path))
-	   (loop-error "~S found where a LOOP iteration path name was expected." path))
-	  ((not (setq data (loop-lookup-keyword path (loop-universe-path-keywords *loop-universe*))))
-	   (loop-error "~S is not the name of a LOOP iteration path." path))
-	  ((and inclusive (not (loop-path-inclusive-permitted data)))
-	   (loop-error "\"Inclusive\" iteration is not possible with the ~S LOOP iteration path." path)))
+           (loop-error "~S found where a LOOP iteration path name was expected." path))
+          ((not (setq data (loop-lookup-keyword path (loop-universe-path-keywords *loop-universe*))))
+           (loop-error "~S is not the name of a LOOP iteration path." path))
+          ((and inclusive (not (loop-path-inclusive-permitted data)))
+           (loop-error "\"Inclusive\" iteration is not possible with the ~S LOOP iteration path." path)))
     (let ((fun (loop-path-function data))
-	  (preps (nconc initial-prepositions
-			(loop-collect-prepositional-phrases (loop-path-preposition-groups data) t)))
-	  (user-data (loop-path-user-data data)))
+          (preps (nconc initial-prepositions
+                        (loop-collect-prepositional-phrases (loop-path-preposition-groups data) t)))
+          (user-data (loop-path-user-data data)))
       (when (symbolp fun) (setq fun (symbol-function fun)))
       (setq stuff (if inclusive
-		      (apply fun var data-type preps :inclusive t user-data)
-		      (apply fun var data-type preps user-data))))
+                      (apply fun var data-type preps :inclusive t user-data)
+                      (apply fun var data-type preps user-data))))
     (when *loop-named-variables*
       (loop-error "Unused USING variables: ~S." *loop-named-variables*))
     ;; STUFF is now (bindings prologue-forms . stuff-to-pass-back).  Protect the system from the user
     ;; and the user from himself.
     (unless (member (length stuff) '(6 10))
       (loop-error "Value passed back by LOOP iteration path function for path ~S has invalid length."
-		  path))
+                  path))
     (do ((l (car stuff) (cdr l)) (x)) ((null l))
       (if (atom (setq x (car l)))
-	  (loop-make-iteration-variable x nil nil)
-	  (loop-make-iteration-variable (car x) (cadr x) (caddr x))))
+          (loop-make-iteration-variable x nil nil)
+          (loop-make-iteration-variable (car x) (cadr x) (caddr x))))
     (setq *loop-prologue* (nconc (reverse (cadr stuff)) *loop-prologue*))
     (cddr stuff)))
 
@@ -1763,158 +1760,158 @@ collected result will be returned as the value of the LOOP."
   (let ((tem (loop-tassoc name *loop-named-variables*)))
     (declare (list tem))
     (cond ((null tem) (values (loop-gentemp) nil))
-	  (t (setq *loop-named-variables* (delete tem *loop-named-variables*))
-	     (values (cdr tem) t)))))
+          (t (setq *loop-named-variables* (delete tem *loop-named-variables*))
+             (values (cdr tem) t)))))
 
 
 (defun loop-collect-prepositional-phrases (preposition-groups &optional USING-allowed initial-phrases)
   (flet ((in-group-p (x group) (car (loop-tmember x group))))
     (do ((token nil)
-	 (prepositional-phrases initial-phrases)
-	 (this-group nil nil)
-	 (this-prep nil nil)
-	 (disallowed-prepositions
-	   (mapcan #'(lambda (x)
-		       (loop-copylist*
-			 (find (car x) preposition-groups :test #'in-group-p)))
-		   initial-phrases))
-	 (used-prepositions (mapcar #'car initial-phrases)))
-	((null *loop-source-code*) (nreverse prepositional-phrases))
+         (prepositional-phrases initial-phrases)
+         (this-group nil nil)
+         (this-prep nil nil)
+         (disallowed-prepositions
+          (mapcan #'(lambda (x)
+                      (loop-copylist*
+                       (find (car x) preposition-groups :test #'in-group-p)))
+                  initial-phrases))
+         (used-prepositions (mapcar #'car initial-phrases)))
+        ((null *loop-source-code*) (nreverse prepositional-phrases))
       ;; FIXME: JSCL doen't support declarations at this context
       #+nil (declare (symbol this-prep))
       (setq token (car *loop-source-code*))
       (dolist (group preposition-groups)
-	(when (setq this-prep (in-group-p token group))
-	  (return (setq this-group group))))
+        (when (setq this-prep (in-group-p token group))
+          (return (setq this-group group))))
       (cond (this-group
-	     (when (member this-prep disallowed-prepositions)
-	       (loop-error
-		 (if (member this-prep used-prepositions)
-		     "A ~S prepositional phrase occurs multiply for some LOOP clause."
-		     "Preposition ~S used when some other preposition has subsumed it.")
-		 token))
-	     (setq used-prepositions (if (listp this-group)
-					 (append this-group used-prepositions)
-					 (cons this-group used-prepositions)))
-	     (loop-pop-source)
-	     (push (list this-prep (loop-get-form)) prepositional-phrases))
-	    ((and USING-allowed (loop-tequal token 'using))
-	     (loop-pop-source)
-	     (do ((z (loop-pop-source) (loop-pop-source)) (tem)) (nil)
-	       (when (or (atom z)
-			 (atom (cdr z))
-			 (not (null (cddr z)))
-			 (not (symbolp (car z)))
-			 (and (cadr z) (not (symbolp (cadr z)))))
-		 (loop-error "~S bad variable pair in path USING phrase." z))
-	       (when (cadr z)
-		 (if (setq tem (loop-tassoc (car z) *loop-named-variables*))
-		     (loop-error
-		       "The variable substitution for ~S occurs twice in a USING phrase,~@
-		        with ~S and ~S."
-		       (car z) (cadr z) (cadr tem))
-		     (push (cons (car z) (cadr z)) *loop-named-variables*)))
-	       (when (or (null *loop-source-code*) (symbolp (car *loop-source-code*)))
-		 (return nil))))
-	    (t (return (nreverse prepositional-phrases)))))))
+             (when (member this-prep disallowed-prepositions)
+               (loop-error
+                (if (member this-prep used-prepositions)
+                    "A ~S prepositional phrase occurs multiply for some LOOP clause."
+                    "Preposition ~S used when some other preposition has subsumed it.")
+                token))
+             (setq used-prepositions (if (listp this-group)
+                                         (append this-group used-prepositions)
+                                         (cons this-group used-prepositions)))
+             (loop-pop-source)
+             (push (list this-prep (loop-get-form)) prepositional-phrases))
+            ((and USING-allowed (loop-tequal token 'using))
+             (loop-pop-source)
+             (do ((z (loop-pop-source) (loop-pop-source)) (tem)) (nil)
+               (when (or (atom z)
+                         (atom (cdr z))
+                         (not (null (cddr z)))
+                         (not (symbolp (car z)))
+                         (and (cadr z) (not (symbolp (cadr z)))))
+                 (loop-error "~S bad variable pair in path USING phrase." z))
+               (when (cadr z)
+                 (if (setq tem (loop-tassoc (car z) *loop-named-variables*))
+                     (loop-error
+                      "The variable substitution for ~S occurs twice in a USING phrase,~@
+ with ~S and ~S."
+                      (car z) (cadr z) (cadr tem))
+                     (push (cons (car z) (cadr z)) *loop-named-variables*)))
+               (when (or (null *loop-source-code*) (symbolp (car *loop-source-code*)))
+                 (return nil))))
+            (t (return (nreverse prepositional-phrases)))))))
 
 
 ;;;; Master Sequencer Function
 
 
 (defun loop-sequencer (indexv indexv-type indexv-user-specified-p
-			  variable variable-type
-			  sequence-variable sequence-type
-			  step-hack default-top
-			  prep-phrases)
-   (let ((endform nil)				;Form (constant or variable) with limit value.
-	 (sequencep nil)			;T if sequence arg has been provided.
-	 (testfn nil)				;endtest function
-	 (test nil)				;endtest form.
-	 (stepby (1+ (or (loop-typed-init indexv-type) 0)))	;Our increment.
-	 (stepby-constantp t)
-	 (step nil)				;step form.
-	 (dir nil)				;Direction of stepping: NIL, :UP, :DOWN.
-	 (inclusive-iteration nil)		;T if include last index.
-	 (start-given nil)			;T when prep phrase has specified start
-	 (start-value nil)
-	 (start-constantp nil)
-	 (limit-given nil)			;T when prep phrase has specified end
-	 (limit-constantp nil)
-	 (limit-value nil)
-	 )
-     (when variable (loop-make-iteration-variable variable nil variable-type))
-     (do ((l prep-phrases (cdr l)) (prep) (form) (odir)) ((null l))
-       (setq prep (caar l) form (cadar l))
-       (case prep
-	 ((:of :in)
-	  (setq sequencep t)
-	  (loop-make-variable sequence-variable form sequence-type))
-	 ((:from :downfrom :upfrom)
-	  (setq start-given t)
-	  (cond ((eq prep :downfrom) (setq dir ':down))
-		((eq prep :upfrom) (setq dir ':up)))
-	  (multiple-value-setq (form start-constantp start-value)
-	    (loop-constant-fold-if-possible form indexv-type))
-	  (loop-make-iteration-variable indexv form indexv-type))
-	 ((:upto :to :downto :above :below)
-	  (cond ((loop-tequal prep :upto) (setq inclusive-iteration (setq dir ':up)))
-		((loop-tequal prep :to) (setq inclusive-iteration t))
-		((loop-tequal prep :downto) (setq inclusive-iteration (setq dir ':down)))
-		((loop-tequal prep :above) (setq dir ':down))
-		((loop-tequal prep :below) (setq dir ':up)))
-	  (setq limit-given t)
-	  (multiple-value-setq (form limit-constantp limit-value)
-	    (loop-constant-fold-if-possible form indexv-type))
-	  (setq endform (if limit-constantp
-			    `',limit-value
-			    (loop-make-variable
-			      (loop-gentemp 'loop-limit-) form indexv-type))))
-	 (:by
-	   (multiple-value-setq (form stepby-constantp stepby)
-	     (loop-constant-fold-if-possible form indexv-type))
-	   (unless stepby-constantp
-	     (loop-make-variable (setq stepby (loop-gentemp 'loop-step-by-)) form indexv-type)))
-	 (t (loop-error
-	      "~S invalid preposition in sequencing or sequence path.~@
-	       Invalid prepositions specified in iteration path descriptor or something?"
-	      prep)))
-       (when (and odir dir (not (eq dir odir)))
-	 (loop-error "Conflicting stepping directions in LOOP sequencing path"))
-       (setq odir dir))
-     (when (and sequence-variable (not sequencep))
-       (loop-error "Missing OF or IN phrase in sequence path"))
-     ;; Now fill in the defaults.
-     (unless start-given
-       (loop-make-iteration-variable
-	 indexv
-	 (setq start-constantp t start-value (or (loop-typed-init indexv-type) 0))
-	 indexv-type))
-     (cond ((member dir '(nil :up))
-	    (when (or limit-given default-top)
-	      (unless limit-given
-		(loop-make-variable (setq endform (loop-gentemp 'loop-seq-limit-))
-				    nil indexv-type)
-		(push `(setq ,endform ,default-top) *loop-prologue*))
-	      (setq testfn (if inclusive-iteration '> '>=)))
-	    (setq step (if (eql stepby 1) `(1+ ,indexv) `(+ ,indexv ,stepby))))
-	   (t (unless start-given
-		(unless default-top
-		  (loop-error "Don't know where to start stepping."))
-		(push `(setq ,indexv (1- ,default-top)) *loop-prologue*))
-	      (when (and default-top (not endform))
-		(setq endform (loop-typed-init indexv-type) inclusive-iteration t))
-	      (when endform (setq testfn (if inclusive-iteration  '< '<=)))
-	      (setq step (if (eql stepby 1) `(1- ,indexv) `(- ,indexv ,stepby)))))
-     (when testfn (setq test (hide-variable-reference t indexv `(,testfn ,indexv ,endform))))
-     (when step-hack
-       (setq step-hack `(,variable ,(hide-variable-reference indexv-user-specified-p indexv step-hack))))
-     (let ((first-test test) (remaining-tests test))
-       (when (and stepby-constantp start-constantp limit-constantp)
-	 (when (setq first-test (funcall (symbol-function testfn) start-value limit-value))
-	   (setq remaining-tests t)))
-       `(() (,indexv ,(hide-variable-reference t indexv step)) ,remaining-tests ,step-hack
-	 () () ,first-test ,step-hack))))
+                       variable variable-type
+                       sequence-variable sequence-type
+                       step-hack default-top
+                       prep-phrases)
+  (let ((endform nil)				;Form (constant or variable) with limit value.
+        (sequencep nil)			;T if sequence arg has been provided.
+        (testfn nil)				;endtest function
+        (test nil)				;endtest form.
+        (stepby (1+ (or (loop-typed-init indexv-type) 0)))	;Our increment.
+        (stepby-constantp t)
+        (step nil)				;step form.
+        (dir nil)				;Direction of stepping: NIL, :UP, :DOWN.
+        (inclusive-iteration nil)		;T if include last index.
+        (start-given nil)			;T when prep phrase has specified start
+        (start-value nil)
+        (start-constantp nil)
+        (limit-given nil)			;T when prep phrase has specified end
+        (limit-constantp nil)
+        (limit-value nil)
+        )
+    (when variable (loop-make-iteration-variable variable nil variable-type))
+    (do ((l prep-phrases (cdr l)) (prep) (form) (odir)) ((null l))
+      (setq prep (caar l) form (cadar l))
+      (case prep
+        ((:of :in)
+         (setq sequencep t)
+         (loop-make-variable sequence-variable form sequence-type))
+        ((:from :downfrom :upfrom)
+         (setq start-given t)
+         (cond ((eq prep :downfrom) (setq dir ':down))
+               ((eq prep :upfrom) (setq dir ':up)))
+         (multiple-value-setq (form start-constantp start-value)
+           (loop-constant-fold-if-possible form indexv-type))
+         (loop-make-iteration-variable indexv form indexv-type))
+        ((:upto :to :downto :above :below)
+         (cond ((loop-tequal prep :upto) (setq inclusive-iteration (setq dir ':up)))
+               ((loop-tequal prep :to) (setq inclusive-iteration t))
+               ((loop-tequal prep :downto) (setq inclusive-iteration (setq dir ':down)))
+               ((loop-tequal prep :above) (setq dir ':down))
+               ((loop-tequal prep :below) (setq dir ':up)))
+         (setq limit-given t)
+         (multiple-value-setq (form limit-constantp limit-value)
+           (loop-constant-fold-if-possible form indexv-type))
+         (setq endform (if limit-constantp
+                           `',limit-value
+                           (loop-make-variable
+                            (loop-gentemp 'loop-limit-) form indexv-type))))
+        (:by
+         (multiple-value-setq (form stepby-constantp stepby)
+           (loop-constant-fold-if-possible form indexv-type))
+         (unless stepby-constantp
+           (loop-make-variable (setq stepby (loop-gentemp 'loop-step-by-)) form indexv-type)))
+        (t (loop-error
+            "~S invalid preposition in sequencing or sequence path.~@
+ Invalid prepositions specified in iteration path descriptor or something?"
+            prep)))
+      (when (and odir dir (not (eq dir odir)))
+        (loop-error "Conflicting stepping directions in LOOP sequencing path"))
+      (setq odir dir))
+    (when (and sequence-variable (not sequencep))
+      (loop-error "Missing OF or IN phrase in sequence path"))
+    ;; Now fill in the defaults.
+    (unless start-given
+      (loop-make-iteration-variable
+       indexv
+       (setq start-constantp t start-value (or (loop-typed-init indexv-type) 0))
+       indexv-type))
+    (cond ((member dir '(nil :up))
+           (when (or limit-given default-top)
+             (unless limit-given
+               (loop-make-variable (setq endform (loop-gentemp 'loop-seq-limit-))
+                                   nil indexv-type)
+               (push `(setq ,endform ,default-top) *loop-prologue*))
+             (setq testfn (if inclusive-iteration '> '>=)))
+           (setq step (if (eql stepby 1) `(1+ ,indexv) `(+ ,indexv ,stepby))))
+          (t (unless start-given
+               (unless default-top
+                 (loop-error "Don't know where to start stepping."))
+               (push `(setq ,indexv (1- ,default-top)) *loop-prologue*))
+             (when (and default-top (not endform))
+               (setq endform (loop-typed-init indexv-type) inclusive-iteration t))
+             (when endform (setq testfn (if inclusive-iteration  '< '<=)))
+             (setq step (if (eql stepby 1) `(1- ,indexv) `(- ,indexv ,stepby)))))
+    (when testfn (setq test (hide-variable-reference t indexv `(,testfn ,indexv ,endform))))
+    (when step-hack
+      (setq step-hack `(,variable ,(hide-variable-reference indexv-user-specified-p indexv step-hack))))
+    (let ((first-test test) (remaining-tests test))
+      (when (and stepby-constantp start-constantp limit-constantp)
+        (when (setq first-test (funcall (symbol-function testfn) start-value limit-value))
+          (setq remaining-tests t)))
+      `(() (,indexv ,(hide-variable-reference t indexv step)) ,remaining-tests ,step-hack
+        () () ,first-test ,step-hack))))
 
 
 ;;;; Interfaces to the Master Sequencer
@@ -1923,30 +1920,30 @@ collected result will be returned as the value of the LOOP."
 
 (defun loop-for-arithmetic (var val data-type kwd)
   (loop-sequencer
-    var (loop-check-data-type data-type *loop-real-data-type*) t
-    nil nil nil nil nil nil
-    (loop-collect-prepositional-phrases
-      '((:from :upfrom :downfrom) (:to :upto :downto :above :below) (:by))
-      nil (list (list kwd val)))))
+   var (loop-check-data-type data-type *loop-real-data-type*) t
+   nil nil nil nil nil nil
+   (loop-collect-prepositional-phrases
+    '((:from :upfrom :downfrom) (:to :upto :downto :above :below) (:by))
+    nil (list (list kwd val)))))
 
 
 (defun loop-sequence-elements-path (variable data-type prep-phrases
-				    &key fetch-function size-function sequence-type element-type)
+                                    &key fetch-function size-function sequence-type element-type)
   (multiple-value-bind (indexv indexv-user-specified-p) (named-variable 'index)
     (let ((sequencev (named-variable 'sequence)))
       #+Genera (when (and sequencev
-			  (symbolp sequencev)
-			  sequence-type
-			  (subtypep sequence-type 'vector)
-			  (not (member (the symbol sequencev) *loop-nodeclare*)))
-		 (push `(sys:array-register ,sequencev) *loop-declarations*))
+                          (symbolp sequencev)
+                          sequence-type
+                          (subtypep sequence-type 'vector)
+                          (not (member (the symbol sequencev) *loop-nodeclare*)))
+                 (push `(sys:array-register ,sequencev) *loop-declarations*))
       (list* nil nil				; dummy bindings and prologue
-	     (loop-sequencer
-	       indexv 'fixnum indexv-user-specified-p
-	       variable (or data-type element-type)
-	       sequencev sequence-type
-	       `(,fetch-function ,sequencev ,indexv) `(,size-function ,sequencev)
-	       prep-phrases)))))
+             (loop-sequencer
+              indexv 'fixnum indexv-user-specified-p
+              variable (or data-type element-type)
+              sequencev sequence-type
+              `(,fetch-function ,sequencev ,indexv) `(,size-function ,sequencev)
+              prep-phrases)))))
 
 
 ;;;; Builtin LOOP Iteration Paths
@@ -1962,147 +1959,147 @@ collected result will be returned as the value of the LOOP."
 (defun loop-hash-table-iteration-path (variable data-type prep-phrases &key which)
   ;; (check-type which (member hash-key hash-value))
   (cond ((or (cdr prep-phrases) (not (member (caar prep-phrases) '(:in :of))))
-	 (loop-error "Too many prepositions!"))
-	((null prep-phrases) (loop-error "Missing OF or IN in ~S iteration path.")))
+         (loop-error "Too many prepositions!"))
+        ((null prep-phrases) (loop-error "Missing OF or IN in ~S iteration path.")))
   (let ((ht-var (loop-gentemp 'loop-hashtab-))
-	(next-fn (loop-gentemp 'loop-hashtab-next-))
-	(dummy-predicate-var nil)
-	(post-steps nil))
+        (next-fn (loop-gentemp 'loop-hashtab-next-))
+        (dummy-predicate-var nil)
+        (post-steps nil))
     (multiple-value-bind (other-var other-p)
-	(named-variable (if (eq which 'hash-key) 'hash-value 'hash-key))
+        (named-variable (if (eq which 'hash-key) 'hash-value 'hash-key))
       ;;@@@@ named-variable returns a second value of T if the name was actually
       ;; specified, so clever code can throw away the gensym'ed up variable if
       ;; it isn't really needed.
       ;;The following is for those implementations in which we cannot put dummy NILs
       ;; into multiple-value-setq variable lists.
       #-Genera (setq other-p t
-		     dummy-predicate-var (loop-when-it-variable))
+                     dummy-predicate-var (loop-when-it-variable))
       (let ((key-var nil)
-	    (val-var nil)
-	    (bindings `((,variable nil ,data-type)
-			(,ht-var ,(cadar prep-phrases))
-			,@(and other-p other-var `((,other-var nil))))))
-	(if (eq which 'hash-key)
-	    (setq key-var variable val-var (and other-p other-var))
-	    (setq key-var (and other-p other-var) val-var variable))
-	(push `(with-hash-table-iterator (,next-fn ,ht-var)) *loop-wrappers*)
-	(when (consp key-var)
-	  (setq post-steps `(,key-var ,(setq key-var (loop-gentemp 'loop-hash-key-temp-))
-			     ,@post-steps))
-	  (push `(,key-var nil) bindings))
-	(when (consp val-var)
-	  (setq post-steps `(,val-var ,(setq val-var (loop-gentemp 'loop-hash-val-temp-))
-			     ,@post-steps))
-	  (push `(,val-var nil) bindings))
-	`(,bindings				;bindings
-	  ()					;prologue
-	  ()					;pre-test
-	  ()					;parallel steps
-	  (not (multiple-value-setq (,dummy-predicate-var ,key-var ,val-var) (,next-fn)))	;post-test
-	  ,post-steps)))))
+            (val-var nil)
+            (bindings `((,variable nil ,data-type)
+                        (,ht-var ,(cadar prep-phrases))
+                        ,@(and other-p other-var `((,other-var nil))))))
+        (if (eq which 'hash-key)
+            (setq key-var variable val-var (and other-p other-var))
+            (setq key-var (and other-p other-var) val-var variable))
+        (push `(with-hash-table-iterator (,next-fn ,ht-var)) *loop-wrappers*)
+        (when (consp key-var)
+          (setq post-steps `(,key-var ,(setq key-var (loop-gentemp 'loop-hash-key-temp-))
+                                      ,@post-steps))
+          (push `(,key-var nil) bindings))
+        (when (consp val-var)
+          (setq post-steps `(,val-var ,(setq val-var (loop-gentemp 'loop-hash-val-temp-))
+                                      ,@post-steps))
+          (push `(,val-var nil) bindings))
+        `(,bindings				;bindings
+          ()					;prologue
+          ()					;pre-test
+          ()					;parallel steps
+          (not (multiple-value-setq (,dummy-predicate-var ,key-var ,val-var) (,next-fn)))	;post-test
+          ,post-steps)))))
 
 
 (defun loop-package-symbols-iteration-path (variable data-type prep-phrases &key symbol-types)
   (cond ((or (cdr prep-phrases) (not (member (caar prep-phrases) '(:in :of))))
-	 (loop-error "Too many prepositions!"))
-	((null prep-phrases) (loop-error "Missing OF or IN in ~S iteration path.")))
+         (loop-error "Too many prepositions!"))
+        ((null prep-phrases) (loop-error "Missing OF or IN in ~S iteration path.")))
   (unless (symbolp variable)
     (loop-error "Destructuring is not valid for package symbol iteration."))
   (let ((pkg-var (loop-gentemp 'loop-pkgsym-))
-	(next-fn (loop-gentemp 'loop-pkgsym-next-)))
+        (next-fn (loop-gentemp 'loop-pkgsym-next-)))
     (push `(with-package-iterator (,next-fn ,pkg-var ,@symbol-types)) *loop-wrappers*)
     `(((,variable nil ,data-type) (,pkg-var ,(cadar prep-phrases)))
       ()
       ()
       ()
       (not (multiple-value-setq (,(progn
-				    ;;@@@@ If an implementation can get away without actually
-				    ;; using a variable here, so much the better.
-				    #+Genera NIL
-				    #-Genera (loop-when-it-variable))
-				 ,variable)
-	     (,next-fn)))
+                                    ;;@@@@ If an implementation can get away without actually
+                                    ;; using a variable here, so much the better.
+                                    #+Genera NIL
+                                    #-Genera (loop-when-it-variable))
+                                 ,variable)
+             (,next-fn)))
       ())))
 
 ;;;; ANSI Loop
 
 (defun make-ansi-loop-universe (extended-p)
   (let ((w (make-standard-loop-universe
-	     :keywords `((named (loop-do-named))
-			 (initially (loop-do-initially))
-			 (finally (loop-do-finally))
-			 (do (loop-do-do))
-			 (doing (loop-do-do))
-			 (return (loop-do-return))
-			 (collect (loop-list-collection list))
-			 (collecting (loop-list-collection list))
-			 (append (loop-list-collection append))
-			 (appending (loop-list-collection append))
-			 (nconc (loop-list-collection nconc))
-			 (nconcing (loop-list-collection nconc))
-			 (count (loop-sum-collection count ,*loop-real-data-type* fixnum))
-			 (counting (loop-sum-collection count ,*loop-real-data-type* fixnum))
-			 (sum (loop-sum-collection sum number number))
-			 (summing (loop-sum-collection sum number number))
-			 (maximize (loop-maxmin-collection max))
-			 (minimize (loop-maxmin-collection min))
-			 (maximizing (loop-maxmin-collection max))
-			 (minimizing (loop-maxmin-collection min))
-			 (always (loop-do-always t nil))	; Normal, do always
-			 (never (loop-do-always t t))	; Negate the test on always.
-			 (thereis (loop-do-thereis t))
-			 (while (loop-do-while nil :while))	; Normal, do while
-			 (until (loop-do-while t :until))	; Negate the test on while
-			 (when (loop-do-if when nil))	; Normal, do when
-			 (if (loop-do-if if nil))	; synonymous
-			 (unless (loop-do-if unless t))	; Negate the test on when
-			 (with (loop-do-with)))
-	     :for-keywords '((= (loop-ansi-for-equals))
-			     (across (loop-for-across))
-			     (in (loop-for-in))
-			     (on (loop-for-on))
-			     (from (loop-for-arithmetic :from))
-			     (downfrom (loop-for-arithmetic :downfrom))
-			     (upfrom (loop-for-arithmetic :upfrom))
-			     (below (loop-for-arithmetic :below))
-			     (to (loop-for-arithmetic :to))
-			     (upto (loop-for-arithmetic :upto))
-			     (being (loop-for-being)))
-	     :iteration-keywords '((for (loop-do-for))
-				   (as (loop-do-for))
-				   (repeat (loop-do-repeat)))
-	     :type-symbols '(array atom bignum bit bit-vector character #| common |# compiled-function
-				   complex cons double-float fixnum float
-				   function hash-table integer keyword list long-float
-				   nil null number package pathname random-state
-				   ratio rational readtable sequence short-float
-				   simple-array simple-bit-vector simple-string
-				   simple-vector single-float standard-char
-				   stream string string-char
-				   symbol t vector)
-	     :type-keywords nil
-	     :ansi (if extended-p :extended t))))
+            :keywords `((named (loop-do-named))
+                        (initially (loop-do-initially))
+                        (finally (loop-do-finally))
+                        (do (loop-do-do))
+                        (doing (loop-do-do))
+                        (return (loop-do-return))
+                        (collect (loop-list-collection list))
+                        (collecting (loop-list-collection list))
+                        (append (loop-list-collection append))
+                        (appending (loop-list-collection append))
+                        (nconc (loop-list-collection nconc))
+                        (nconcing (loop-list-collection nconc))
+                        (count (loop-sum-collection count ,*loop-real-data-type* fixnum))
+                        (counting (loop-sum-collection count ,*loop-real-data-type* fixnum))
+                        (sum (loop-sum-collection sum number number))
+                        (summing (loop-sum-collection sum number number))
+                        (maximize (loop-maxmin-collection max))
+                        (minimize (loop-maxmin-collection min))
+                        (maximizing (loop-maxmin-collection max))
+                        (minimizing (loop-maxmin-collection min))
+                        (always (loop-do-always t nil))	; Normal, do always
+                        (never (loop-do-always t t))	; Negate the test on always.
+                        (thereis (loop-do-thereis t))
+                        (while (loop-do-while nil :while))	; Normal, do while
+                        (until (loop-do-while t :until))	; Negate the test on while
+                        (when (loop-do-if when nil))	; Normal, do when
+                        (if (loop-do-if if nil))	; synonymous
+                        (unless (loop-do-if unless t))	; Negate the test on when
+                        (with (loop-do-with)))
+            :for-keywords '((= (loop-ansi-for-equals))
+                            (across (loop-for-across))
+                            (in (loop-for-in))
+                            (on (loop-for-on))
+                            (from (loop-for-arithmetic :from))
+                            (downfrom (loop-for-arithmetic :downfrom))
+                            (upfrom (loop-for-arithmetic :upfrom))
+                            (below (loop-for-arithmetic :below))
+                            (to (loop-for-arithmetic :to))
+                            (upto (loop-for-arithmetic :upto))
+                            (being (loop-for-being)))
+            :iteration-keywords '((for (loop-do-for))
+                                  (as (loop-do-for))
+                                  (repeat (loop-do-repeat)))
+            :type-symbols '(array atom bignum bit bit-vector character #| common |# compiled-function
+                            complex cons double-float fixnum float
+                            function hash-table integer keyword list long-float
+                            nil null number package pathname random-state
+                            ratio rational readtable sequence short-float
+                            simple-array simple-bit-vector simple-string
+                            simple-vector single-float standard-char
+                            stream string string-char
+                            symbol t vector)
+            :type-keywords nil
+            :ansi (if extended-p :extended t))))
 
     (add-loop-path '(hash-key hash-keys) 'loop-hash-table-iteration-path w
-		   :preposition-groups '((:of :in))
-		   :inclusive-permitted nil
-		   :user-data '(:which hash-key))
+                   :preposition-groups '((:of :in))
+                   :inclusive-permitted nil
+                   :user-data '(:which hash-key))
     (add-loop-path '(hash-value hash-values) 'loop-hash-table-iteration-path w
-		   :preposition-groups '((:of :in))
-		   :inclusive-permitted nil
-		   :user-data '(:which hash-value))
+                   :preposition-groups '((:of :in))
+                   :inclusive-permitted nil
+                   :user-data '(:which hash-value))
     (add-loop-path '(symbol symbols) 'loop-package-symbols-iteration-path w
-		   :preposition-groups '((:of :in))
-		   :inclusive-permitted nil
-		   :user-data '(:symbol-types (:internal :external :inherited)))
+                   :preposition-groups '((:of :in))
+                   :inclusive-permitted nil
+                   :user-data '(:symbol-types (:internal :external :inherited)))
     (add-loop-path '(external-symbol external-symbols) 'loop-package-symbols-iteration-path w
-		   :preposition-groups '((:of :in))
-		   :inclusive-permitted nil
-		   :user-data '(:symbol-types (:external)))
+                   :preposition-groups '((:of :in))
+                   :inclusive-permitted nil
+                   :user-data '(:symbol-types (:external)))
     (add-loop-path '(present-symbol present-symbols) 'loop-package-symbols-iteration-path w
-		   :preposition-groups '((:of :in))
-		   :inclusive-permitted nil
-		   :user-data '(:symbol-types (:internal)))
+                   :preposition-groups '((:of :in))
+                   :inclusive-permitted nil
+                   :user-data '(:symbol-types (:internal)))
     w))
 
 
@@ -2123,7 +2120,7 @@ collected result will be returned as the value of the LOOP."
 ;; INTERFACE: ANSI
 (defmacro !loop (&rest keywords-and-forms)
   #+Genera (declare (compiler:do-not-record-macroexpansions)
-		    (zwei:indentation . zwei:indent-loop))
+                    (zwei:indentation . zwei:indent-loop))
   (loop-standard-expansion keywords-and-forms jscl::*environment* *loop-ansi-universe*))
 
 #+allegro
@@ -2131,7 +2128,6 @@ collected result will be returned as the value of the LOOP."
   (loop-standard-expansion body env *loop-ansi-universe*))
 
 
-
-;;; FIXME: Somehow the pacakge is not being bound properly in
+;;; FIXME: Somehow the package is not being bound properly in
 ;;; !compile-file.
 (in-package :cl)

--- a/src/ansiloop/ansi-loop.lisp
+++ b/src/ansiloop/ansi-loop.lisp
@@ -1416,9 +1416,10 @@ collected result will be returned as the value of the LOOP."
 		     ,(loop-construct-return *loop-when-it-variable*))))
 
 
-(defun loop-do-while (negate kwd &aux (form (loop-get-form)))
-  (loop-disallow-conditional kwd)
-  (loop-pseudo-body `(,(if negate 'when 'unless) ,form (go end-loop))))
+(defun loop-do-while (negate kwd)
+  (let ((form (loop-get-form)))
+    (loop-disallow-conditional kwd)
+    (loop-pseudo-body `(,(if negate 'when 'unless) ,form (go end-loop)))))
 
 
 (defun loop-do-with ()

--- a/src/ansiloop/ansi-loop.lisp
+++ b/src/ansiloop/ansi-loop.lisp
@@ -2080,7 +2080,7 @@ collected result will be returned as the value of the LOOP."
 
 
 (defparameter *loop-ansi-universe*
-  (make-ansi-loop-universe nil)))
+  (make-ansi-loop-universe nil))
 
 (defun loop-standard-expansion (keywords-and-forms environment universe)
   (if (and keywords-and-forms (symbolp (car keywords-and-forms)))

--- a/src/ansiloop/ansi-loop.lisp
+++ b/src/ansiloop/ansi-loop.lisp
@@ -896,173 +896,173 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
 	  (t (throw 'estimate-code-size nil)))))
 
 
-;; ;;;; Loop Errors
+;;;; Loop Errors
 
 
-;; (defun loop-context ()
-;;   (do ((l *loop-source-context* (cdr l)) (new nil (cons (car l) new)))
-;;       ((eq l (cdr *loop-source-code*)) (nreverse new))))
+(defun loop-context ()
+  (do ((l *loop-source-context* (cdr l)) (new nil (cons (car l) new)))
+      ((eq l (cdr *loop-source-code*)) (nreverse new))))
 
 
-;; (defun loop-error (format-string &rest format-args)
-;;   #+(or Genera CLOE) (declare (dbg:error-reporter))
-;;   #+Genera (setq format-args (copy-list format-args))	;Don't ask.
-;;   (error "~?~%Current LOOP context:~{ ~S~}." format-string format-args (loop-context)))
+(defun loop-error (format-string &rest format-args)
+  #+(or Genera CLOE) (declare (dbg:error-reporter))
+  #+Genera (setq format-args (copy-list format-args))	;Don't ask.
+  (error "~?~%Current LOOP context:~{ ~S~}." format-string format-args (loop-context)))
 
 
-;; (defun loop-warn (format-string &rest format-args)
-;;   (warn "~?~%Current LOOP context:~{ ~S~}." format-string format-args (loop-context)))
+(defun loop-warn (format-string &rest format-args)
+  (warn "~?~%Current LOOP context:~{ ~S~}." format-string format-args (loop-context)))
 
 
-;; (defun loop-check-data-type (specified-type required-type
-;; 			     &optional (default-type required-type))
-;;   (if (null specified-type)
-;;       default-type
-;;       (multiple-value-bind (a b) (subtypep specified-type required-type)
-;; 	(cond ((not b)
-;; 	       (loop-warn "LOOP couldn't verify that ~S is a subtype of the required type ~S."
-;; 			  specified-type required-type))
-;; 	      ((not a)
-;; 	       (loop-error "Specified data type ~S is not a subtype of ~S."
-;; 			   specified-type required-type)))
-;; 	specified-type)))
-;; 
+(defun loop-check-data-type (specified-type required-type
+			     &optional (default-type required-type))
+  (if (null specified-type)
+      default-type
+      (multiple-value-bind (a b) (subtypep specified-type required-type)
+	(cond ((not b)
+	       (loop-warn "LOOP couldn't verify that ~S is a subtype of the required type ~S."
+			  specified-type required-type))
+	      ((not a)
+	       (loop-error "Specified data type ~S is not a subtype of ~S."
+			   specified-type required-type)))
+	specified-type)))
+
 
-;; ;;;INTERFACE: Traditional, ANSI, Lucid.
-;; (defmacro loop-finish () 
-;;   "Causes the iteration to terminate \"normally\", the same as implicit
-;; termination by an iteration driving clause, or by use of WHILE or
-;; UNTIL -- the epilogue code (if any) will be run, and any implicitly
-;; collected result will be returned as the value of the LOOP."
-;;   '(go end-loop))
-
-
-;; 
-
-;; (defun loop-translate (*loop-source-code* *loop-macro-environment* *loop-universe*)
-;;   (let ((*loop-original-source-code* *loop-source-code*)
-;; 	(*loop-source-context* nil)
-;; 	(*loop-iteration-variables* nil)
-;; 	(*loop-variables* nil)
-;; 	(*loop-nodeclare* nil)
-;; 	(*loop-named-variables* nil)
-;; 	(*loop-declarations* nil)
-;; 	(*loop-desetq-crocks* nil)
-;; 	(*loop-bind-stack* nil)
-;; 	(*loop-prologue* nil)
-;; 	(*loop-wrappers* nil)
-;; 	(*loop-before-loop* nil)
-;; 	(*loop-body* nil)
-;; 	(*loop-emitted-body* nil)
-;; 	(*loop-after-body* nil)
-;; 	(*loop-epilogue* nil)
-;; 	(*loop-after-epilogue* nil)
-;; 	(*loop-final-value-culprit* nil)
-;; 	(*loop-inside-conditional* nil)
-;; 	(*loop-when-it-variable* nil)
-;; 	(*loop-never-stepped-variable* nil)
-;; 	(*loop-names* nil)
-;; 	(*loop-collection-cruft* nil))
-;;     (loop-iteration-driver)
-;;     (loop-bind-block)
-;;     (let ((answer `(loop-body
-;; 		     ,(nreverse *loop-prologue*)
-;; 		     ,(nreverse *loop-before-loop*)
-;; 		     ,(nreverse *loop-body*)
-;; 		     ,(nreverse *loop-after-body*)
-;; 		     ,(nreconc *loop-epilogue* (nreverse *loop-after-epilogue*)))))
-;;       (do () (nil)
-;; 	(setq answer `(block ,(pop *loop-names*) ,answer))
-;; 	(unless *loop-names* (return nil)))
-;;       (dolist (entry *loop-bind-stack*)
-;; 	(let ((vars (first entry))
-;; 	      (dcls (second entry))
-;; 	      (crocks (third entry))
-;; 	      (wrappers (fourth entry)))
-;; 	  (dolist (w wrappers)
-;; 	    (setq answer (append w (list answer))))
-;; 	  (when (or vars dcls crocks)
-;; 	    (let ((forms (list answer)))
-;; 	      ;;(when crocks (push crocks forms))
-;; 	      (when dcls (push `(declare ,@dcls) forms))
-;; 	      (setq answer `(,(cond ((not vars) 'locally)
-;; 				    (*loop-destructuring-hooks* (first *loop-destructuring-hooks*))
-;; 				    (t 'let))
-;; 			     ,vars
-;; 			     ,@(if crocks
-;; 				   `((destructuring-bind ,@crocks
-;; 					 ,@forms))
-;; 				 forms)))))))
-;;       answer)))
+;;;INTERFACE: Traditional, ANSI, Lucid.
+(defmacro loop-finish () 
+  "Causes the iteration to terminate \"normally\", the same as implicit
+termination by an iteration driving clause, or by use of WHILE or
+UNTIL -- the epilogue code (if any) will be run, and any implicitly
+collected result will be returned as the value of the LOOP."
+  '(go end-loop))
 
 
-;; (defun loop-iteration-driver ()
-;;   (do () ((null *loop-source-code*))
-;;     (let ((keyword (car *loop-source-code*)) (tem nil))
-;;       (cond ((not (symbolp keyword))
-;; 	     (loop-error "~S found where LOOP keyword expected." keyword))
-;; 	    (t (setq *loop-source-context* *loop-source-code*)
-;; 	       (loop-pop-source)
-;; 	       (cond ((setq tem (loop-lookup-keyword keyword (loop-universe-keywords *loop-universe*)))
-;; 		      ;;It's a "miscellaneous" toplevel LOOP keyword (do, collect, named, etc.)
-;; 		      (apply (symbol-function (first tem)) (rest tem)))
-;; 		     ((setq tem (loop-lookup-keyword keyword (loop-universe-iteration-keywords *loop-universe*)))
-;; 		      (loop-hack-iteration tem))
-;; 		     ((loop-tmember keyword '(and else))
-;; 		      ;; Alternative is to ignore it, ie let it go around to the next keyword...
-;; 		      (loop-error "Secondary clause misplaced at top level in LOOP macro: ~S ~S ~S ..."
-;; 				  keyword (car *loop-source-code*) (cadr *loop-source-code*)))
-;; 		     (t (loop-error "~S is an unknown keyword in LOOP macro." keyword))))))))
-;; 
+
+
+(defun loop-translate (*loop-source-code* *loop-macro-environment* *loop-universe*)
+  (let ((*loop-original-source-code* *loop-source-code*)
+	(*loop-source-context* nil)
+	(*loop-iteration-variables* nil)
+	(*loop-variables* nil)
+	(*loop-nodeclare* nil)
+	(*loop-named-variables* nil)
+	(*loop-declarations* nil)
+	(*loop-desetq-crocks* nil)
+	(*loop-bind-stack* nil)
+	(*loop-prologue* nil)
+	(*loop-wrappers* nil)
+	(*loop-before-loop* nil)
+	(*loop-body* nil)
+	(*loop-emitted-body* nil)
+	(*loop-after-body* nil)
+	(*loop-epilogue* nil)
+	(*loop-after-epilogue* nil)
+	(*loop-final-value-culprit* nil)
+	(*loop-inside-conditional* nil)
+	(*loop-when-it-variable* nil)
+	(*loop-never-stepped-variable* nil)
+	(*loop-names* nil)
+	(*loop-collection-cruft* nil))
+    (loop-iteration-driver)
+    (loop-bind-block)
+    (let ((answer `(loop-body
+		     ,(nreverse *loop-prologue*)
+		     ,(nreverse *loop-before-loop*)
+		     ,(nreverse *loop-body*)
+		     ,(nreverse *loop-after-body*)
+		     ,(nreconc *loop-epilogue* (nreverse *loop-after-epilogue*)))))
+      (do () (nil)
+	(setq answer `(block ,(pop *loop-names*) ,answer))
+	(unless *loop-names* (return nil)))
+      (dolist (entry *loop-bind-stack*)
+	(let ((vars (first entry))
+	      (dcls (second entry))
+	      (crocks (third entry))
+	      (wrappers (fourth entry)))
+	  (dolist (w wrappers)
+	    (setq answer (append w (list answer))))
+	  (when (or vars dcls crocks)
+	    (let ((forms (list answer)))
+	      ;;(when crocks (push crocks forms))
+	      (when dcls (push `(declare ,@dcls) forms))
+	      (setq answer `(,(cond ((not vars) 'locally)
+				    (*loop-destructuring-hooks* (first *loop-destructuring-hooks*))
+				    (t 'let))
+			     ,vars
+			     ,@(if crocks
+				   `((destructuring-bind ,@crocks
+					 ,@forms))
+				 forms)))))))
+      answer)))
 
 
-;; (defun loop-pop-source ()
-;;   (if *loop-source-code*
-;;       (pop *loop-source-code*)
-;;       (loop-error "LOOP source code ran out when another token was expected.")))
+(defun loop-iteration-driver ()
+  (do () ((null *loop-source-code*))
+    (let ((keyword (car *loop-source-code*)) (tem nil))
+      (cond ((not (symbolp keyword))
+	     (loop-error "~S found where LOOP keyword expected." keyword))
+	    (t (setq *loop-source-context* *loop-source-code*)
+	       (loop-pop-source)
+	       (cond ((setq tem (loop-lookup-keyword keyword (loop-universe-keywords *loop-universe*)))
+		      ;;It's a "miscellaneous" toplevel LOOP keyword (do, collect, named, etc.)
+		      (apply (symbol-function (first tem)) (rest tem)))
+		     ((setq tem (loop-lookup-keyword keyword (loop-universe-iteration-keywords *loop-universe*)))
+		      (loop-hack-iteration tem))
+		     ((loop-tmember keyword '(and else))
+		      ;; Alternative is to ignore it, ie let it go around to the next keyword...
+		      (loop-error "Secondary clause misplaced at top level in LOOP macro: ~S ~S ~S ..."
+				  keyword (car *loop-source-code*) (cadr *loop-source-code*)))
+		     (t (loop-error "~S is an unknown keyword in LOOP macro." keyword))))))))
+
 
 
-;; (defun loop-get-progn ()
-;;   (do ((forms (list (loop-pop-source)) (cons (loop-pop-source) forms))
-;;        (nextform (car *loop-source-code*) (car *loop-source-code*)))
-;;       ((atom nextform)
-;;        (if (null (cdr forms)) (car forms) (cons 'progn (nreverse forms))))))
+(defun loop-pop-source ()
+  (if *loop-source-code*
+      (pop *loop-source-code*)
+      (loop-error "LOOP source code ran out when another token was expected.")))
 
 
-;; (defun loop-get-form ()
-;;   (if *loop-source-code*
-;;       (loop-pop-source)
-;;       (loop-error "LOOP code ran out where a form was expected.")))
+(defun loop-get-progn ()
+  (do ((forms (list (loop-pop-source)) (cons (loop-pop-source) forms))
+       (nextform (car *loop-source-code*) (car *loop-source-code*)))
+      ((atom nextform)
+       (if (null (cdr forms)) (car forms) (cons 'progn (nreverse forms))))))
 
 
-;; (defun loop-construct-return (form)
-;;   `(return-from ,(car *loop-names*) ,form))
+(defun loop-get-form ()
+  (if *loop-source-code*
+      (loop-pop-source)
+      (loop-error "LOOP code ran out where a form was expected.")))
 
 
-;; (defun loop-pseudo-body (form)
-;;   (cond ((or *loop-emitted-body* *loop-inside-conditional*) (push form *loop-body*))
-;; 	(t (push form *loop-before-loop*) (push form *loop-after-body*))))
-
-;; (defun loop-emit-body (form)
-;;   (setq *loop-emitted-body* t)
-;;   (loop-pseudo-body form))
-
-;; (defun loop-emit-final-value (form)
-;;   (push (loop-construct-return form) *loop-after-epilogue*)
-;;   (when *loop-final-value-culprit*
-;;     (loop-warn "LOOP clause is providing a value for the iteration,~@
-;; 	        however one was already established by a ~S clause."
-;; 	       *loop-final-value-culprit*))
-;;   (setq *loop-final-value-culprit* (car *loop-source-context*)))
+(defun loop-construct-return (form)
+  `(return-from ,(car *loop-names*) ,form))
 
 
-;; (defun loop-disallow-conditional (&optional kwd)
-;;   #+(or Genera CLOE) (declare (dbg:error-reporter))
-;;   (when *loop-inside-conditional*
-;;     (loop-error "~:[This LOOP~;The LOOP ~:*~S~] clause is not permitted inside a conditional." kwd)))
-;; 
+(defun loop-pseudo-body (form)
+  (cond ((or *loop-emitted-body* *loop-inside-conditional*) (push form *loop-body*))
+	(t (push form *loop-before-loop*) (push form *loop-after-body*))))
 
-;; ;;;; Loop Types
+(defun loop-emit-body (form)
+  (setq *loop-emitted-body* t)
+  (loop-pseudo-body form))
+
+(defun loop-emit-final-value (form)
+  (push (loop-construct-return form) *loop-after-epilogue*)
+  (when *loop-final-value-culprit*
+    (loop-warn "LOOP clause is providing a value for the iteration,~@
+	        however one was already established by a ~S clause."
+	       *loop-final-value-culprit*))
+  (setq *loop-final-value-culprit* (car *loop-source-context*)))
+
+
+(defun loop-disallow-conditional (&optional kwd)
+  #+(or Genera CLOE) (declare (dbg:error-reporter))
+  (when *loop-inside-conditional*
+    (loop-error "~:[This LOOP~;The LOOP ~:*~S~] clause is not permitted inside a conditional." kwd)))
+
+
+;;;; Loop Types
 
 
 ;; (defun loop-typed-init (data-type)

--- a/src/ansiloop/ansi-loop.lisp
+++ b/src/ansiloop/ansi-loop.lisp
@@ -1667,7 +1667,7 @@ collected result will be returned as the value of the LOOP."
 (defun add-loop-path (names function universe &key preposition-groups inclusive-permitted user-data)
   (unless (listp names) (setq names (list names)))
   ;; Can't do this due to CLOS bootstrapping problems.
-  #-(or Genera (and CLOE Source-Bootstrap))
+  ;; #-(or Genera (and CLOE Source-Bootstrap))
   ;; (check-type universe loop-universe)
   (let ((ht (loop-universe-path-keywords universe))
 	(lp (make-loop-path

--- a/src/ansiloop/extended-loop.lisp
+++ b/src/ansiloop/extended-loop.lisp
@@ -1,0 +1,121 @@
+;;;   -*- Mode: LISP; Syntax: Common-lisp; Package: ANSI-LOOP; Base: 10; Lowercase:T -*-
+;;;>
+;;;> Portions of LOOP are Copyright (c) 1986 by the Massachusetts Institute of Technology.
+;;;> All Rights Reserved.
+;;;> 
+;;;> Permission to use, copy, modify and distribute this software and its
+;;;> documentation for any purpose and without fee is hereby granted,
+;;;> provided that the M.I.T. copyright notice appear in all copies and that
+;;;> both that copyright notice and this permission notice appear in
+;;;> supporting documentation.  The names "M.I.T." and "Massachusetts
+;;;> Institute of Technology" may not be used in advertising or publicity
+;;;> pertaining to distribution of the software without specific, written
+;;;> prior permission.  Notice must be given in supporting documentation that
+;;;> copying distribution is by permission of M.I.T.  M.I.T. makes no
+;;;> representations about the suitability of this software for any purpose.
+;;;> It is provided "as is" without express or implied warranty.
+;;;> 
+;;;>      Massachusetts Institute of Technology
+;;;>      77 Massachusetts Avenue
+;;;>      Cambridge, Massachusetts  02139
+;;;>      United States of America
+;;;>      +1-617-253-1000
+;;;>
+;;;> Portions of LOOP are Copyright (c) 1989, 1990, 1991, 1992 by Symbolics, Inc.
+;;;> All Rights Reserved.
+;;;> 
+;;;> Permission to use, copy, modify and distribute this software and its
+;;;> documentation for any purpose and without fee is hereby granted,
+;;;> provided that the Symbolics copyright notice appear in all copies and
+;;;> that both that copyright notice and this permission notice appear in
+;;;> supporting documentation.  The name "Symbolics" may not be used in
+;;;> advertising or publicity pertaining to distribution of the software
+;;;> without specific, written prior permission.  Notice must be given in
+;;;> supporting documentation that copying distribution is by permission of
+;;;> Symbolics.  Symbolics makes no representations about the suitability of
+;;;> this software for any purpose.  It is provided "as is" without express
+;;;> or implied warranty.
+;;;> 
+;;;> Symbolics, CLOE Runtime, and Minima are trademarks, and CLOE, Genera,
+;;;> and Zetalisp are registered trademarks of Symbolics, Inc.
+;;;>
+;;;>      Symbolics, Inc.
+;;;>      8 New England Executive Park, East
+;;;>      Burlington, Massachusetts  01803
+;;;>      United States of America
+;;;>      +1-617-221-1000
+
+
+(in-package :ansi-loop)
+
+
+#+Cloe-Runtime					;Don't ask.
+(car (push "%Z% %M% %I% %E% %U%" system::*module-identifications*))
+
+
+;;; The following code could be used to set up the SYMBOLICS-LOOP package
+;;; as it is expected to be.  At Symbolics, in both Genera and CLOE, the
+;;; package setup is done elsewhere.   
+
+
+#-Symbolics
+(unless (find-package 'symbolics-loop)
+  (make-package 'symbolics-loop :use nil))
+
+#-Symbolics
+(import 'ansi-loop::loop-finish (find-package 'symbolics-loop))
+
+#-Symbolics
+(export '(symbolics-loop::loop
+		   symbolics-loop::loop-finish
+		   symbolics-loop::define-loop-iteration-path
+		   symbolics-loop::define-loop-sequence-path
+		   )
+	(find-package 'symbolics-loop))
+
+
+
+;;;This is our typical "extensible" universe, which should be a proper superset of the ansi universe.
+(defvar *loop-default-universe* (make-ansi-loop-universe t))
+
+
+
+
+
+
+
+
+(defmacro symbolics-loop:define-loop-iteration-path (path-name function
+						     &key alternate-names preposition-groups
+						     inclusive-permitted user-data (loop-universe '*loop-default-universe*))
+  `(eval-when (eval compile load)
+     (add-loop-path '(,path-name ,@alternate-names) ,function ,loop-universe
+		    :preposition-groups ',preposition-groups
+		    :inclusive-permitted ',inclusive-permitted
+		    :user-data ',user-data)))
+
+
+(defmacro symbolics-loop:define-loop-sequence-path (path-name-or-names fetch-function size-function
+						    &optional sequence-type element-type)
+  "Defines a sequence iteration path.  PATH-NAME-OR-NAMES is either an
+atomic path name or a list of path names.  FETCHFUN is a function of
+two arguments, the sequence and the index of the item to be fetched.
+Indexing is assumed to be zero-origined.  SIZEFUN is a function of
+one argument, the sequence; it should return the number of elements in
+the sequence.  SEQUENCE-TYPE is the name of the data-type of the
+sequence, and ELEMENT-TYPE is the name of the data-type of the elements
+of the sequence."
+  `(eval-when (eval compile load)
+     (add-loop-path ',path-name-or-names 'loop-sequence-elements-path *loop-default-universe*
+		    :preposition-groups '((:of :in) (:from :downfrom :upfrom) (:to :downto :below :above) (:by))
+		    :inclusive-permitted nil
+		    :user-data '(:fetch-function ,fetch-function
+				 :size-function ,size-function
+				 :sequence-type ,sequence-type
+				 :element-type ,element-type))))
+
+
+(defmacro symbolics-loop:loop (&environment env &rest keywords-and-forms)
+  #+Genera (declare (compiler:do-not-record-macroexpansions)
+		    (zwei:indentation . zwei:indent-loop))
+  (loop-standard-expansion keywords-and-forms env *loop-default-universe*))

--- a/src/ansiloop/extended-loop.lisp
+++ b/src/ansiloop/extended-loop.lisp
@@ -1,49 +1,51 @@
 ;;;   -*- Mode: LISP; Syntax: Common-lisp; Package: ANSI-LOOP; Base: 10; Lowercase:T -*-
-;;;>
-;;;> Portions of LOOP are Copyright (c) 1986 by the Massachusetts Institute of Technology.
-;;;> All Rights Reserved.
-;;;> 
-;;;> Permission to use, copy, modify and distribute this software and its
-;;;> documentation for any purpose and without fee is hereby granted,
-;;;> provided that the M.I.T. copyright notice appear in all copies and that
-;;;> both that copyright notice and this permission notice appear in
-;;;> supporting documentation.  The names "M.I.T." and "Massachusetts
-;;;> Institute of Technology" may not be used in advertising or publicity
-;;;> pertaining to distribution of the software without specific, written
-;;;> prior permission.  Notice must be given in supporting documentation that
-;;;> copying distribution is by permission of M.I.T.  M.I.T. makes no
-;;;> representations about the suitability of this software for any purpose.
-;;;> It is provided "as is" without express or implied warranty.
-;;;> 
-;;;>      Massachusetts Institute of Technology
-;;;>      77 Massachusetts Avenue
-;;;>      Cambridge, Massachusetts  02139
-;;;>      United States of America
-;;;>      +1-617-253-1000
-;;;>
-;;;> Portions of LOOP are Copyright (c) 1989, 1990, 1991, 1992 by Symbolics, Inc.
-;;;> All Rights Reserved.
-;;;> 
-;;;> Permission to use, copy, modify and distribute this software and its
-;;;> documentation for any purpose and without fee is hereby granted,
-;;;> provided that the Symbolics copyright notice appear in all copies and
-;;;> that both that copyright notice and this permission notice appear in
-;;;> supporting documentation.  The name "Symbolics" may not be used in
-;;;> advertising or publicity pertaining to distribution of the software
-;;;> without specific, written prior permission.  Notice must be given in
-;;;> supporting documentation that copying distribution is by permission of
-;;;> Symbolics.  Symbolics makes no representations about the suitability of
-;;;> this software for any purpose.  It is provided "as is" without express
-;;;> or implied warranty.
-;;;> 
-;;;> Symbolics, CLOE Runtime, and Minima are trademarks, and CLOE, Genera,
-;;;> and Zetalisp are registered trademarks of Symbolics, Inc.
-;;;>
-;;;>      Symbolics, Inc.
-;;;>      8 New England Executive Park, East
-;;;>      Burlington, Massachusetts  01803
-;;;>      United States of America
-;;;>      +1-617-221-1000
+;;; 
+;;;  Portions  of  LOOP are  Copyright  (c)  1986 by  the  Massachusetts
+;;;  Institute of Technology. All Rights Reserved.
+;;;  
+;;;  Permission to  use, copy, modify  and distribute this  software and
+;;;  its  documentation  for  any  purpose and  without  fee  is  hereby
+;;;  granted, provided  that the M.I.T.  copyright notice appear  in all
+;;;  copies  and that  both that  copyright notice  and this  permission
+;;;  notice appear  in supporting documentation. The  names "M.I.T." and
+;;;  "Massachusetts  Institute  of  Technology"   may  not  be  used  in
+;;;  advertising or publicity pertaining to distribution of the software
+;;;  without specific, written prior permission. Notice must be given in
+;;;  supporting documentation that copying distribution is by permission
+;;;  of M.I.T. M.I.T. makes no  representations about the suitability of
+;;;  this  software for  any purpose.  It  is provided  "as is"  without
+;;;  express or implied warranty.
+;;;  
+;;;       Massachusetts Institute of Technology
+;;;       77 Massachusetts Avenue
+;;;       Cambridge, Massachusetts  02139
+;;;       United States of America
+;;;       +1-617-253-1000
+;;; 
+;;;  Portions  of LOOP  are  Copyright  (c) 1989,  1990,  1991, 1992  by
+;;;  Symbolics, Inc. All Rights Reserved.
+;;;  
+;;;  Permission to  use, copy, modify  and distribute this  software and
+;;;  its  documentation  for  any  purpose and  without  fee  is  hereby
+;;;  granted, provided that the Symbolics copyright notice appear in all
+;;;  copies  and that  both that  copyright notice  and this  permission
+;;;  notice appear in supporting documentation. The name "Symbolics" may
+;;;  not be used in advertising  or publicity pertaining to distribution
+;;;  of  the  software  without   specific,  written  prior  permission.
+;;;  Notice  must  be given  in  supporting  documentation that  copying
+;;;  distribution  is by  permission  of Symbolics.  Symbolics makes  no
+;;;  representations  about the  suitability  of this  software for  any
+;;;  purpose.   It   is   provided    "as   is"   without   express   or
+;;;  implied warranty.
+;;;  
+;;;  Symbolics,  CLOE  Runtime, and  Minima  are  trademarks, and  CLOE,
+;;;  Genera, and Zetalisp are registered trademarks of Symbolics, Inc.
+;;; 
+;;;       Symbolics, Inc.
+;;;       8 New England Executive Park, East
+;;;       Burlington, Massachusetts  01803
+;;;       United States of America
+;;;       +1-617-221-1000
 
 
 (in-package :ansi-loop)
@@ -67,11 +69,11 @@
 
 #-Symbolics
 (export '(symbolics-loop::loop
-		   symbolics-loop::loop-finish
-		   symbolics-loop::define-loop-iteration-path
-		   symbolics-loop::define-loop-sequence-path
-		   )
-	(find-package 'symbolics-loop))
+          symbolics-loop::loop-finish
+          symbolics-loop::define-loop-iteration-path
+          symbolics-loop::define-loop-sequence-path
+          )
+        (find-package 'symbolics-loop))
 
 
 
@@ -86,17 +88,17 @@
 
 
 (defmacro symbolics-loop:define-loop-iteration-path (path-name function
-						     &key alternate-names preposition-groups
-						     inclusive-permitted user-data (loop-universe '*loop-default-universe*))
+                                                     &key alternate-names preposition-groups
+                                                          inclusive-permitted user-data (loop-universe '*loop-default-universe*))
   `(eval-when (eval compile load)
      (add-loop-path '(,path-name ,@alternate-names) ,function ,loop-universe
-		    :preposition-groups ',preposition-groups
-		    :inclusive-permitted ',inclusive-permitted
-		    :user-data ',user-data)))
+                    :preposition-groups ',preposition-groups
+                    :inclusive-permitted ',inclusive-permitted
+                    :user-data ',user-data)))
 
 
 (defmacro symbolics-loop:define-loop-sequence-path (path-name-or-names fetch-function size-function
-						    &optional sequence-type element-type)
+                                                    &optional sequence-type element-type)
   "Defines a sequence iteration path.  PATH-NAME-OR-NAMES is either an
 atomic path name or a list of path names.  FETCHFUN is a function of
 two arguments, the sequence and the index of the item to be fetched.
@@ -107,15 +109,15 @@ sequence, and ELEMENT-TYPE is the name of the data-type of the elements
 of the sequence."
   `(eval-when (eval compile load)
      (add-loop-path ',path-name-or-names 'loop-sequence-elements-path *loop-default-universe*
-		    :preposition-groups '((:of :in) (:from :downfrom :upfrom) (:to :downto :below :above) (:by))
-		    :inclusive-permitted nil
-		    :user-data '(:fetch-function ,fetch-function
-				 :size-function ,size-function
-				 :sequence-type ,sequence-type
-				 :element-type ,element-type))))
+                    :preposition-groups '((:of :in) (:from :downfrom :upfrom) (:to :downto :below :above) (:by))
+                    :inclusive-permitted nil
+                    :user-data '(:fetch-function ,fetch-function
+                                 :size-function ,size-function
+                                 :sequence-type ,sequence-type
+                                 :element-type ,element-type))))
 
 
 (defmacro symbolics-loop:loop (&environment env &rest keywords-and-forms)
   #+Genera (declare (compiler:do-not-record-macroexpansions)
-		    (zwei:indentation . zwei:indent-loop))
+                    (zwei:indentation . zwei:indent-loop))
   (loop-standard-expansion keywords-and-forms env *loop-default-universe*))

--- a/src/ansiloop/test-suite/base-tests.lisp
+++ b/src/ansiloop/test-suite/base-tests.lisp
@@ -1,0 +1,644 @@
+;;;   -*- Mode: LISP; Syntax: Common-lisp; Package: ANSI-LOOP; Base: 10; Lowercase:T -*-
+;;;>
+;;;> Portions of LOOP are Copyright (c) 1986 by the Massachusetts Institute of Technology.
+;;;> All Rights Reserved.
+;;;> 
+;;;> Permission to use, copy, modify and distribute this software and its
+;;;> documentation for any purpose and without fee is hereby granted,
+;;;> provided that the M.I.T. copyright notice appear in all copies and that
+;;;> both that copyright notice and this permission notice appear in
+;;;> supporting documentation.  The names "M.I.T." and "Massachusetts
+;;;> Institute of Technology" may not be used in advertising or publicity
+;;;> pertaining to distribution of the software without specific, written
+;;;> prior permission.  Notice must be given in supporting documentation that
+;;;> copying distribution is by permission of M.I.T.  M.I.T. makes no
+;;;> representations about the suitability of this software for any purpose.
+;;;> It is provided "as is" without express or implied warranty.
+;;;> 
+;;;>      Massachusetts Institute of Technology
+;;;>      77 Massachusetts Avenue
+;;;>      Cambridge, Massachusetts  02139
+;;;>      United States of America
+;;;>      +1-617-253-1000
+;;;>
+;;;> Portions of LOOP are Copyright (c) 1989, 1990, 1991, 1992 by Symbolics, Inc.
+;;;> All Rights Reserved.
+;;;> 
+;;;> Permission to use, copy, modify and distribute this software and its
+;;;> documentation for any purpose and without fee is hereby granted,
+;;;> provided that the Symbolics copyright notice appear in all copies and
+;;;> that both that copyright notice and this permission notice appear in
+;;;> supporting documentation.  The name "Symbolics" may not be used in
+;;;> advertising or publicity pertaining to distribution of the software
+;;;> without specific, written prior permission.  Notice must be given in
+;;;> supporting documentation that copying distribution is by permission of
+;;;> Symbolics.  Symbolics makes no representations about the suitability of
+;;;> this software for any purpose.  It is provided "as is" without express
+;;;> or implied warranty.
+;;;> 
+;;;> Symbolics, CLOE Runtime, and Minima are trademarks, and CLOE, Genera,
+;;;> and Zetalisp are registered trademarks of Symbolics, Inc.
+;;;>
+;;;>      Symbolics, Inc.
+;;;>      8 New England Executive Park, East
+;;;>      Burlington, Massachusetts  01803
+;;;>      United States of America
+;;;>      +1-617-221-1000
+
+(in-package "ANSI-LOOP")
+
+
+
+(test "from/=/collect"
+      ()
+      (loop for x from 1 to 10
+	    for y = nil then x
+	    collect (list x y))
+  (() ((1 nil) (2 2) (3 3) (4 4) (5 5) (6 6) (7 7) (8 8) (9 9) (10 10))))
+
+(test "from/=/colllect/variable"
+      (lo hi)
+      (loop for x from lo to hi
+	    for y = nil then x
+	    collect (list x y))
+  ((1 10) ((1 nil) (2 2) (3 3) (4 4) (5 5) (6 6) (7 7) (8 8) (9 9) (10 10))))
+
+(test "exercise loop-body flagvar"
+      (lo hi)
+      (loop for x from lo to hi
+	    ;; test flagvar stuff in loop-body
+	    as z = (list x x x x x x x x x x x x x x x x x x x x x x x x x)
+	    for y = nil then x
+	    collect (list x y)
+	    do (unless (equal z (list x x x x x x x x x x x x x x x x x x x x x x x x x))
+		 (error "oops")))
+  ((1 10) ((1 nil) (2 2) (3 3) (4 4) (5 5) (6 6) (7 7) (8 8) (9 9) (10 10))))
+
+(test "add fixnum dcl"
+      (lo hi)
+      (loop for x of-type fixnum from lo to hi
+	    for y = nil then x
+	    collect (list x y))
+  ((1 10) ((1 nil) (2 2) (3 3) (4 4) (5 5) (6 6) (7 7) (8 8) (9 9) (10 10))))
+
+(test "add fixnum keyword"
+      (lo hi)
+      (loop for x fixnum from lo to hi
+	    for y = nil then x
+	    collect (list x y))
+  ((1 10) ((1 nil) (2 2) (3 3) (4 4) (5 5) (6 6) (7 7) (8 8) (9 9) (10 10))))
+
+(test "simple parallel constant arguments"
+      ()
+      (loop for x from 1 to 10 and y = nil then x
+	    collect (list x y))
+  (() ((1 nil) (2 1) (3 2) (4 3) (5 4) (6 5) (7 6) (8 7) (9 8) (10 9))))
+
+(test "simple parallel variable arguments"
+      (lo hi)
+      (loop for x from lo to hi and y = nil then x
+	    collect (list x y))
+  ((1 10) ((1 nil) (2 1) (3 2) (4 3) (5 4) (6 5) (7 6) (8 7) (9 8) (10 9))))
+
+(test "AS constant args"
+      ()
+      (loop as i from 1 to 3
+	    collect i)
+  (() (1 2 3)))
+
+(test "AS variable args"
+      (lo hi)
+      (loop as i from lo to hi
+	    collect i)
+  ((1 3) (1 2 3)))
+
+(test "step downto constant args"
+      ()
+      (loop for i from 10 downto 1 by 3
+	    collect i)
+  (() (10 7 4 1)))
+
+(test "step downto variable args constant step"
+      (hi lo)
+      (loop for i from hi downto lo by 3
+	    collect i)
+  ((10 1) (10 7 4 1)))
+
+(test "step downto variable args"
+      (hi lo step)
+      (loop for i from hi downto lo by step
+	    collect i)
+  ((10 1 3) (10 7 4 1))
+  ((10 2 3) (10 7 4))
+  ((10 3 3) (10 7 4))
+  ((10 4 3) (10 7 4))
+  ((10 5 3) (10 7))
+  )
+
+(test "step above variable args"
+      (hi lo step)
+      (loop for i from hi above lo by step
+	    collect i)
+  ((10 1 3) (10 7 4))
+  ((10 2 3) (10 7 4))
+  ((10 3 3) (10 7 4))
+  ((10 4 3) (10 7))
+  )
+
+(test "AS BELOW constant limit"
+      ()
+      (loop as i below 3
+	    collect i)
+  (() (0 1 2)))
+
+(test "AS BELOW variable limit"
+      (limit)
+      (loop as i below limit
+	    collect i)
+  ((3) (0 1 2)))
+
+
+(test "IN constant list"
+      ()
+      (loop for item in '(1 2 3)
+	    collect item)
+  (() (1 2 3)))
+
+(test "IN variable list"
+      (l)
+      (loop for item in l collect item)
+  ((nil) nil)
+  (((foo)) (foo)))
+
+(test "IN constant list with step"
+      ()
+      (loop for item in '(1 2 3 4 5) by #'cddr
+	    collect item)
+  (() (1 3 5)))
+
+(test "IN different constant list with step"
+      ()
+      (loop for item in '(1 2 3 4) by #'cddr
+	    collect item)
+  (() (1 3)))
+
+(test "IN variable list with step"
+      (l)
+      (loop for item in l by #'cddr
+	    collect item)
+  (((1 2 3 4 5)) (1 3 5))
+  (((1 2 3 4)) (1 3)))
+
+(test "IN destructured typedeclared constant list"
+      ()
+      (loop for (item . x) (t . fixnum) in '((a . 1) (b . 2) (c . 3))
+	    unless (eq item 'b) sum x)
+  (() 4))
+
+(test "IN destructured type-declared variable list"
+      (l)
+      (loop for (item . x) (t . fixnum) in l
+	    unless (eq item 'b) sum x)
+  ((((a . 1) (b . 2) (c . 3))) 4))
+
+(test "ON constant list"
+      ()
+      (loop for sublist on '(a b c d)
+	    collect sublist)
+  (() ((a b c d) (b c d) (c d) (d))))
+
+(test "ON variable list"
+      (l)
+      (loop for sublist on l
+	    collect sublist)
+  (((a b c d)) ((a b c d) (b c d) (c d) (d))))
+
+(test "ON destructured"
+      (l)
+      (loop for (item) on l
+	    collect item)
+  (((a b c d)) (a b c d)))
+
+
+(test "ON destructured (item) with step"
+      (l)
+      (loop for (item) on l by #'cddr
+	    collect item)
+  (((a b c d)) (a c)))
+
+(test "ON destructured (x y) with step"
+      (l)
+      (loop for (x y) on l by #'cddr
+	    collect (cons x y))
+  (((a b c d)) ((a . b) (c . d))))
+
+(test "ON destructured (x y . z) with step"
+      (l)
+      (loop for (x y . z) on l by #'cddr
+	    collect (list x y z))
+  (((a b c d)) ((a b (c d)) (c d nil))))
+
+
+(test "miscellaneous sequential iteration"
+      ()
+      (loop for item = 1 then (+ item 10)
+	    for iteration from 1 to 5
+	    collect item)
+  (() (1 11 21 31 41)))
+
+(test "ACROSS constant arg"
+      ()
+      (loop for char across "foobar" collect char)
+  (() (#\f #\o #\o #\b #\a #\r)))
+
+(test "ACROSS declared variable arg"
+      (s)
+      (loop for char of-type character across (the simple-string s) collect char)
+  (("foobar") (#\f #\o #\o #\b #\a #\r)))
+
+
+(test "REPEAT sequencing, constant arg"
+      (l)
+      (loop repeat 3
+	    for x in l
+	    collect x)
+  ((nil) nil)
+  (((1)) (1))
+  (((1 2)) (1 2))
+  (((1 2 3)) (1 2 3))
+  (((1 2 3 4)) (1 2 3)))
+
+(test "REPEAT sequencing 2, constant arg"
+      (l)
+      (loop for x in l
+	    repeat 3
+	    collect x)
+  ((nil) nil)
+  (((1)) (1))
+  (((1 2)) (1 2))
+  (((1 2 3)) (1 2 3))
+  (((1 2 3 4)) (1 2 3)))
+
+(test "REPEAT sequencing, variable arg"
+      (n l)
+      (loop repeat n
+	    for x in l
+	    collect x)
+  ((3 nil) nil)
+  ((3 (1)) (1))
+  ((3 (1 2)) (1 2))
+  ((3 (1 2 3)) (1 2 3))
+  ((3 (1 2 3 4)) (1 2 3)))
+
+(test "REPEAT sequencing 2, variable arg"
+      (n l)
+      (loop for x in l
+	    repeat n
+	    collect x)
+  ((3 nil) nil)
+  ((3 (1)) (1))
+  ((3 (1 2)) (1 2))
+  ((3 (1 2 3)) (1 2 3))
+  ((3 (1 2 3 4)) (1 2 3)))
+
+(test "WHILE sequencing"
+      (stack)
+      (loop while stack
+	    for item = (length stack) then (pop stack)
+	    collect item)
+  (((a b c d e f)) (6 a b c d e f))
+  (((a)) (1 a))
+  ((()) ()))
+
+(test "WHILE sequencing 2"
+      ()
+      (loop for i fixnum from 3
+	    when (oddp i) collect i
+	    while (< i 5))
+  (() (3 5)))
+
+(test "simple always"
+      (n)
+      (loop for i from 0 to n
+	    always (< i 11))
+  ((10) t)
+  ((11) nil))
+
+(test "always runs epilogue"
+      (n)
+      (loop for i from 0 to n
+	    always (< i 3)
+	    finally (return 'overriding-value))
+  ((5) nil)
+  ((2) overriding-value))
+
+(test "simple never"
+      (n)
+      (loop for i from n to (+ n 3)
+	    never (> i 11))
+  ((8) t)
+  ((9) nil))
+
+(test "never runs epilogue"
+      (n)
+      (loop for i from n to (+ n 3)
+	    never (< i 3)
+	    finally (return 'overriding-value))
+  ((0) nil)
+  ((3) overriding-value))
+
+(defun oddsq (x)
+  (cond ((not (numberp x)) (error "not a number"))
+	((oddp x) (* x x))
+	(t nil)))
+
+(test "simple thereis"
+      (l)
+      (loop for x in l
+	    thereis (oddsq x))
+  (((1 2 3)) 1)
+  (((2 4 6)) nil)
+  (((2 4 6 7)) 49))
+
+(test "thereis runs epilogue"
+      (l)
+      (loop for x in l
+	    thereis (oddsq x)
+	    finally (return 'overriding-value))
+  (((2 3 4)) 9)
+  (((2 4 6)) overriding-value))
+
+(test "loop-finish"
+      ()
+      (loop for i in '(1 2 3 stop-here 4 5 6)
+	    when (symbolp i) do (loop-finish)
+	    count i)
+  (() 3))
+
+(test "count"
+      ()
+      (loop for i in '(1 2 3 stop-here 4 5 6)
+	    until (symbolp i)
+	    count i)
+  (() 3))
+
+
+(test "multiple collection"
+      (l)
+      (loop for x in l
+	    collect x
+	    collecting x
+	    nconc (list x)
+	    nconcing (list x)
+	    append (list x)
+	    appending (list x))
+  (((a b)) (a a a a a a b b b b b b)))
+
+(test "nconc 1"
+      (l)
+      (loop for x in l
+	    nconc (copy-list x))
+  ((((a) (b c) () (d e))) (a b c d e)))
+
+(test "more multiple collection"
+      ()
+      (loop for name in '(fred sue alice joe june)
+	    for kids in '((bob ken) () () (kris sunshine) ())
+	    collect name
+	    append kids)
+  (() (fred bob ken sue alice joe kris sunshine june)))
+
+
+(test "multiple collection with INTO"
+      ()
+      (loop for name in '(fred sue alice joe june)
+	    as age in '(22 26 19 20 10)
+	    append (list name age) into name-and-age-list
+	    counting name into name-count
+	    sum age into total-age
+	    finally (return (values (round total-age name-count)
+				    name-and-age-list)))
+  (() 19 (fred 22 sue 26 alice 19 joe 20 june 10)))
+
+(test "gratuitous multiple collection"
+      ()
+      (loop for i in '(bird 3 4 turtle (1 . 4) horse cat)
+	    when (symbolp i) collect i)
+  (() (bird turtle horse cat)))
+
+(test "collection sequencing"
+      ()
+      (loop for i from 1 to 10
+	    if (oddp i) collect i)
+  (() (1 3 5 7 9)))
+
+(test "more collecting into"
+      ()
+      (loop for i in '(a b c d) by #'cddr
+	    collect i into my-list
+	    finally (return (values 'foo my-list 'bar)))
+  (() foo (a c) bar))
+
+
+(test "append 1"
+      ()
+      (loop for x in '((a) (b) ((c)))
+	    append x)
+  (() (a b (c))))
+
+(test "nconc 2"
+      ()
+      (loop for i upfrom 0
+	    as x in '(a b (c))
+	    nconc (if (evenp i) (list x) nil))
+  (() (a (c))))
+
+(test "count simple variable arg"
+      ()
+      (loop for i in '(a b nil c nil d e)
+	    count i)
+  (() 5))
+
+
+(test "simple sum"
+      ()
+      (loop for i fixnum in '(1 2 3 4 5)
+	    sum i)
+  (() 15))
+
+(test "sum fixnum keyword"
+      ()
+      (loop for i fixnum in '(1 2 3 4 5)
+	    sum i fixnum)
+  (() 15))
+
+(test "sum fixnum declaration"
+      ()
+      (loop for i fixnum in '(1 2 3 4 5)
+	    summing i of-type fixnum)
+  (() 15))
+
+#|| Too dangerous with floating point equality.
+(test "sum floating point series"
+      (series)
+      (loop for v in series
+	    sum (* 2.0 v))
+  (((1.2 4.3 5.7)) 22.4))
+||#
+
+(test "simple maximize"
+      ()
+      (loop for i in '(2 1 5 3 4)
+	    maximize i)
+  (() 5))
+
+(test "simple minimize"
+      ()
+      (loop for i in '(2 1 5 3 4)
+	    minimize i)
+  (() 1))
+
+(test "maximize fixnum keyword"
+      (series)
+      (loop for v in series
+	    maximizing (round v) fixnum)
+  (((1.2 4.3 5.7)) 6))
+
+(test "minimize into fixnum keyword"
+      (series)
+      (loop for v float in series
+	    minimizing (round v) into result fixnum
+	    finally (return result))
+  (((1.2 4.3 5.7)) 1))
+
+(test "mimimize declared fixnum"
+      (series)
+      (loop for v single-float in series
+	    minimizing (round v) of-type fixnum)
+  (((1.2 4.3 5.7)) 1))
+
+
+(test "sequential with"
+      ()
+      (loop with a = 1
+	    with b = (+ a 2)
+	    with c = (+ b 3)
+	    return (list a b c))
+  (() (1 3 6)))
+
+
+(test "parallel with"
+      ()
+      (loop with a = 1 and b = 2 and c = 3
+	    return (list a b c))
+  (() (1 2 3)))
+
+
+
+(test "parallel with 2"
+      (a b)
+      (loop with a = 1 and b = (+ a 2) and c = (+ b 3)
+	    return (list a b c))
+  ((5 10) (1 7 13)))
+
+(test "destructuring type-keyworded with"
+      ()
+      (loop with (a b c d e f) (float integer short-float single-float double-float long-float)
+	    return (list a b c d e f))
+  (() (0.f0 0 0.0s0 0.0f0 0.0d0 0.0l0)))
+
+(test "single-type-keyword destructured WITH"
+      ()
+      (loop with (a b c) float
+	    return (list a b c))
+  (() (0.f0 0.f0 0.f0)))
+
+
+(test "hairy conditional nesting"
+      ()
+      (loop with gubbish
+	    for i in '(1 2 3 4 5 6)
+	    when (oddp i)
+	      do (push i gubbish)
+	      and collect i into odd-numbers
+	      and do (push i gubbish)
+	    else
+	      collect i into even-numbers
+	    finally (return (values odd-numbers even-numbers gubbish)))
+  (() (1 3 5) (2 4 6) (5 5 3 3 1 1)))
+
+(test "collecting IT"
+      ()
+      (loop for i in '(1 2 3 4 5 6)
+	    when (and (> i 3) i)
+	    collect it)
+  (() (4 5 6)))
+
+(test "returning IT"
+      ()
+      (loop for i in '(1 2 3 4 5 6)
+	    when (and (> i 3) i)
+	    return it)
+  (() 4))
+
+(test "THEREIS 3"
+      ()
+      (loop for i in '(1 2 3 4 5 6)
+	    thereis (and (> i 3) i))
+  (() 4))
+
+
+(test "another multiple collection hairy conditional structure"
+      ()
+      (loop for i in `(,(1+ most-positive-fixnum) 1 2 buckle-my-shoe 3 4 shut-the-door (foo))
+	    when (numberp i)
+	      when (typep i 'bignum)
+	        collect i into big-numbers
+	      else
+	        collect i into other-numbers
+	    else
+	      when (symbolp i)
+	        collect i into symbol-list
+	      else collect i into other-list
+	    finally (return (list big-numbers other-numbers symbol-list other-list)))
+  (() ((#.(1+ most-positive-fixnum)) (1 2 3 4) (buckle-my-shoe shut-the-door) ((foo)))))
+
+(test "more conditional structure"
+      ()
+      (with-output-to-string (s)
+	(loop for x from 0 to 3
+	      do (format s ":~d " x)
+	      if (zerop (mod x 2))
+	        do (princ " a" s)
+		and if (zerop (floor x 2))
+		     do (princ " b" s)
+		     end
+		and do (princ " c" s)))
+  (() ":0  a b c:1 :2  a c:3 "))
+
+
+(test "more type-declared destructuring"
+      ()
+      (loop for (a b c) (integer integer float) in '((1 2 4.0) (5 6 8.3) (8 9 10.4))
+	    collect (list c b a))
+  (() ((4.0 2 1) (8.3 6 5) (10.4 9 8))))
+
+(test "even more type-declared destructuring"
+      ()
+      (loop for (a b c) float in '((1.0 2.0 4.0) (5.0 6.0 8.3) (8.0 9.0 10.4))
+	    collect (list c b a))
+  (() ((4.0 2.0 1.0) (8.3 6.0 5.0) (10.4 9.0 8.0))))
+
+
+(test "hash-keys"
+      ()
+      (let ((ht (make-hash-table :test #'equal)))
+	(loop for i from 0 below 10
+	      do (loop for j from 0 below 10
+		       do (setf (gethash (cons i j) ht) (cons (+ i j) (* i j)))))
+	(loop for (i . j) of-type (fixnum . fixnum) being the hash-keys of ht using (hash-value pair)
+	      as (sum . product) of-type fixnum = pair
+	      always (and (= (+ i j) sum) (= (* i j) product))
+	      count t into count
+	      finally (return (= count 100))))
+  (() t))

--- a/src/ansiloop/test-suite/base-tests.lisp
+++ b/src/ansiloop/test-suite/base-tests.lisp
@@ -1,49 +1,47 @@
-;;;   -*- Mode: LISP; Syntax: Common-lisp; Package: ANSI-LOOP; Base: 10; Lowercase:T -*-
-;;;>
-;;;> Portions of LOOP are Copyright (c) 1986 by the Massachusetts Institute of Technology.
-;;;> All Rights Reserved.
-;;;> 
-;;;> Permission to use, copy, modify and distribute this software and its
-;;;> documentation for any purpose and without fee is hereby granted,
-;;;> provided that the M.I.T. copyright notice appear in all copies and that
-;;;> both that copyright notice and this permission notice appear in
-;;;> supporting documentation.  The names "M.I.T." and "Massachusetts
-;;;> Institute of Technology" may not be used in advertising or publicity
-;;;> pertaining to distribution of the software without specific, written
-;;;> prior permission.  Notice must be given in supporting documentation that
-;;;> copying distribution is by permission of M.I.T.  M.I.T. makes no
-;;;> representations about the suitability of this software for any purpose.
-;;;> It is provided "as is" without express or implied warranty.
-;;;> 
-;;;>      Massachusetts Institute of Technology
-;;;>      77 Massachusetts Avenue
-;;;>      Cambridge, Massachusetts  02139
-;;;>      United States of America
-;;;>      +1-617-253-1000
-;;;>
-;;;> Portions of LOOP are Copyright (c) 1989, 1990, 1991, 1992 by Symbolics, Inc.
-;;;> All Rights Reserved.
-;;;> 
-;;;> Permission to use, copy, modify and distribute this software and its
-;;;> documentation for any purpose and without fee is hereby granted,
-;;;> provided that the Symbolics copyright notice appear in all copies and
-;;;> that both that copyright notice and this permission notice appear in
-;;;> supporting documentation.  The name "Symbolics" may not be used in
-;;;> advertising or publicity pertaining to distribution of the software
-;;;> without specific, written prior permission.  Notice must be given in
-;;;> supporting documentation that copying distribution is by permission of
-;;;> Symbolics.  Symbolics makes no representations about the suitability of
-;;;> this software for any purpose.  It is provided "as is" without express
-;;;> or implied warranty.
-;;;> 
-;;;> Symbolics, CLOE Runtime, and Minima are trademarks, and CLOE, Genera,
-;;;> and Zetalisp are registered trademarks of Symbolics, Inc.
-;;;>
-;;;>      Symbolics, Inc.
-;;;>      8 New England Executive Park, East
-;;;>      Burlington, Massachusetts  01803
-;;;>      United States of America
-;;;>      +1-617-221-1000
+;;;   -*- Mode: LISP; Syntax: Common-lisp; Package: ANSI-LOOP; Base: 10;
+;;;   -*- Lowercase:T -*-
+;;;
+;;;  Portions  of  LOOP are  Copyright  (c)  1986 by  the  Massachusetts
+;;;  Institute of Technology. All Rights Reserved.
+;;;
+;;;  Permission to  use, copy, modify  and distribute this  software and
+;;;  its  documentation  for  any  purpose and  without  fee  is  hereby
+;;;  granted, provided  that the M.I.T.  copyright notice appear  in all
+;;;  copies  and that  both that  copyright notice  and this  permission
+;;;  notice appear  in supporting documentation. The  names "M.I.T." and
+;;;  "Massachusetts  Institute  of  Technology"   may  not  be  used  in
+;;;  advertising or publicity pertaining to distribution of the software
+;;;  without specific, written prior permission. Notice must be given in
+;;;  supporting documentation that copying distribution is by permission
+;;;  of M.I.T. M.I.T. makes no  representations about the suitability of
+;;;  this  software for  any purpose.  It  is provided  "as is"  without
+;;;  express or implied warranty.
+;;;
+;;;       Massachusetts Institute of  Technology 77 Massachusetts Avenue
+;;;       Cambridge,  Massachusetts  02139   United  States  of  America
+;;;       +1-617-253-1000
+;;;
+;;;  Portions  of LOOP  are  Copyright  (c) 1989,  1990,  1991, 1992  by
+;;;  Symbolics, Inc. All Rights Reserved.
+;;;
+;;;  Permission to  use, copy, modify  and distribute this  software and
+;;;  its  documentation  for  any  purpose and  without  fee  is  hereby
+;;;  granted, provided that the Symbolics copyright notice appear in all
+;;;  copies  and that  both that  copyright notice  and this  permission
+;;;  notice appear in supporting documentation. The name "Symbolics" may
+;;;  not be used in advertising  or publicity pertaining to distribution
+;;;  of  the  software  without   specific,  written  prior  permission.
+;;;  Notice  must  be given  in  supporting  documentation that  copying
+;;;  distribution  is by  permission  of Symbolics.  Symbolics makes  no
+;;;  representations  about the  suitability  of this  software for  any
+;;;  purpose.   It   is   provided    "as   is"   without   express   or
+;;;  implied warranty.
+;;;
+;;;  Symbolics,  CLOE  Runtime, and  Minima  are  trademarks, and  CLOE,
+;;;  Genera, and Zetalisp are registered trademarks of Symbolics, Inc.
+;;;
+;;;       Symbolics, Inc. 8 New England Executive Park, East Burlington,
+;;;       Massachusetts 01803 United States of America +1-617-221-1000
 
 (in-package "ANSI-LOOP")
 
@@ -52,593 +50,593 @@
 (test "from/=/collect"
       ()
       (loop for x from 1 to 10
-	    for y = nil then x
-	    collect (list x y))
-  (() ((1 nil) (2 2) (3 3) (4 4) (5 5) (6 6) (7 7) (8 8) (9 9) (10 10))))
+            for y = nil then x
+            collect (list x y))
+      (() ((1 nil) (2 2) (3 3) (4 4) (5 5) (6 6) (7 7) (8 8) (9 9) (10 10))))
 
 (test "from/=/colllect/variable"
       (lo hi)
       (loop for x from lo to hi
-	    for y = nil then x
-	    collect (list x y))
-  ((1 10) ((1 nil) (2 2) (3 3) (4 4) (5 5) (6 6) (7 7) (8 8) (9 9) (10 10))))
+            for y = nil then x
+            collect (list x y))
+      ((1 10) ((1 nil) (2 2) (3 3) (4 4) (5 5) (6 6) (7 7) (8 8) (9 9) (10 10))))
 
 (test "exercise loop-body flagvar"
       (lo hi)
       (loop for x from lo to hi
-	    ;; test flagvar stuff in loop-body
-	    as z = (list x x x x x x x x x x x x x x x x x x x x x x x x x)
-	    for y = nil then x
-	    collect (list x y)
-	    do (unless (equal z (list x x x x x x x x x x x x x x x x x x x x x x x x x))
-		 (error "oops")))
-  ((1 10) ((1 nil) (2 2) (3 3) (4 4) (5 5) (6 6) (7 7) (8 8) (9 9) (10 10))))
+            ;; test flagvar stuff in loop-body
+            as z = (list x x x x x x x x x x x x x x x x x x x x x x x x x)
+            for y = nil then x
+            collect (list x y)
+            do (unless (equal z (list x x x x x x x x x x x x x x x x x x x x x x x x x))
+                 (error "oops")))
+      ((1 10) ((1 nil) (2 2) (3 3) (4 4) (5 5) (6 6) (7 7) (8 8) (9 9) (10 10))))
 
 (test "add fixnum dcl"
       (lo hi)
       (loop for x of-type fixnum from lo to hi
-	    for y = nil then x
-	    collect (list x y))
-  ((1 10) ((1 nil) (2 2) (3 3) (4 4) (5 5) (6 6) (7 7) (8 8) (9 9) (10 10))))
+            for y = nil then x
+            collect (list x y))
+      ((1 10) ((1 nil) (2 2) (3 3) (4 4) (5 5) (6 6) (7 7) (8 8) (9 9) (10 10))))
 
 (test "add fixnum keyword"
       (lo hi)
       (loop for x fixnum from lo to hi
-	    for y = nil then x
-	    collect (list x y))
-  ((1 10) ((1 nil) (2 2) (3 3) (4 4) (5 5) (6 6) (7 7) (8 8) (9 9) (10 10))))
+            for y = nil then x
+            collect (list x y))
+      ((1 10) ((1 nil) (2 2) (3 3) (4 4) (5 5) (6 6) (7 7) (8 8) (9 9) (10 10))))
 
 (test "simple parallel constant arguments"
       ()
       (loop for x from 1 to 10 and y = nil then x
-	    collect (list x y))
-  (() ((1 nil) (2 1) (3 2) (4 3) (5 4) (6 5) (7 6) (8 7) (9 8) (10 9))))
+            collect (list x y))
+      (() ((1 nil) (2 1) (3 2) (4 3) (5 4) (6 5) (7 6) (8 7) (9 8) (10 9))))
 
 (test "simple parallel variable arguments"
       (lo hi)
       (loop for x from lo to hi and y = nil then x
-	    collect (list x y))
-  ((1 10) ((1 nil) (2 1) (3 2) (4 3) (5 4) (6 5) (7 6) (8 7) (9 8) (10 9))))
+            collect (list x y))
+      ((1 10) ((1 nil) (2 1) (3 2) (4 3) (5 4) (6 5) (7 6) (8 7) (9 8) (10 9))))
 
 (test "AS constant args"
       ()
       (loop as i from 1 to 3
-	    collect i)
-  (() (1 2 3)))
+            collect i)
+      (() (1 2 3)))
 
 (test "AS variable args"
       (lo hi)
       (loop as i from lo to hi
-	    collect i)
-  ((1 3) (1 2 3)))
+            collect i)
+      ((1 3) (1 2 3)))
 
 (test "step downto constant args"
       ()
       (loop for i from 10 downto 1 by 3
-	    collect i)
-  (() (10 7 4 1)))
+            collect i)
+      (() (10 7 4 1)))
 
 (test "step downto variable args constant step"
       (hi lo)
       (loop for i from hi downto lo by 3
-	    collect i)
-  ((10 1) (10 7 4 1)))
+            collect i)
+      ((10 1) (10 7 4 1)))
 
 (test "step downto variable args"
       (hi lo step)
       (loop for i from hi downto lo by step
-	    collect i)
-  ((10 1 3) (10 7 4 1))
-  ((10 2 3) (10 7 4))
-  ((10 3 3) (10 7 4))
-  ((10 4 3) (10 7 4))
-  ((10 5 3) (10 7))
-  )
+            collect i)
+      ((10 1 3) (10 7 4 1))
+      ((10 2 3) (10 7 4))
+      ((10 3 3) (10 7 4))
+      ((10 4 3) (10 7 4))
+      ((10 5 3) (10 7))
+      )
 
 (test "step above variable args"
       (hi lo step)
       (loop for i from hi above lo by step
-	    collect i)
-  ((10 1 3) (10 7 4))
-  ((10 2 3) (10 7 4))
-  ((10 3 3) (10 7 4))
-  ((10 4 3) (10 7))
-  )
+            collect i)
+      ((10 1 3) (10 7 4))
+      ((10 2 3) (10 7 4))
+      ((10 3 3) (10 7 4))
+      ((10 4 3) (10 7))
+      )
 
 (test "AS BELOW constant limit"
       ()
       (loop as i below 3
-	    collect i)
-  (() (0 1 2)))
+            collect i)
+      (() (0 1 2)))
 
 (test "AS BELOW variable limit"
       (limit)
       (loop as i below limit
-	    collect i)
-  ((3) (0 1 2)))
+            collect i)
+      ((3) (0 1 2)))
 
 
 (test "IN constant list"
       ()
       (loop for item in '(1 2 3)
-	    collect item)
-  (() (1 2 3)))
+            collect item)
+      (() (1 2 3)))
 
 (test "IN variable list"
       (l)
       (loop for item in l collect item)
-  ((nil) nil)
-  (((foo)) (foo)))
+      ((nil) nil)
+      (((foo)) (foo)))
 
 (test "IN constant list with step"
       ()
       (loop for item in '(1 2 3 4 5) by #'cddr
-	    collect item)
-  (() (1 3 5)))
+            collect item)
+      (() (1 3 5)))
 
 (test "IN different constant list with step"
       ()
       (loop for item in '(1 2 3 4) by #'cddr
-	    collect item)
-  (() (1 3)))
+            collect item)
+      (() (1 3)))
 
 (test "IN variable list with step"
       (l)
       (loop for item in l by #'cddr
-	    collect item)
-  (((1 2 3 4 5)) (1 3 5))
-  (((1 2 3 4)) (1 3)))
+            collect item)
+      (((1 2 3 4 5)) (1 3 5))
+      (((1 2 3 4)) (1 3)))
 
 (test "IN destructured typedeclared constant list"
       ()
       (loop for (item . x) (t . fixnum) in '((a . 1) (b . 2) (c . 3))
-	    unless (eq item 'b) sum x)
-  (() 4))
+            unless (eq item 'b) sum x)
+      (() 4))
 
 (test "IN destructured type-declared variable list"
       (l)
       (loop for (item . x) (t . fixnum) in l
-	    unless (eq item 'b) sum x)
-  ((((a . 1) (b . 2) (c . 3))) 4))
+            unless (eq item 'b) sum x)
+      ((((a . 1) (b . 2) (c . 3))) 4))
 
 (test "ON constant list"
       ()
       (loop for sublist on '(a b c d)
-	    collect sublist)
-  (() ((a b c d) (b c d) (c d) (d))))
+            collect sublist)
+      (() ((a b c d) (b c d) (c d) (d))))
 
 (test "ON variable list"
       (l)
       (loop for sublist on l
-	    collect sublist)
-  (((a b c d)) ((a b c d) (b c d) (c d) (d))))
+            collect sublist)
+      (((a b c d)) ((a b c d) (b c d) (c d) (d))))
 
 (test "ON destructured"
       (l)
       (loop for (item) on l
-	    collect item)
-  (((a b c d)) (a b c d)))
+            collect item)
+      (((a b c d)) (a b c d)))
 
 
 (test "ON destructured (item) with step"
       (l)
       (loop for (item) on l by #'cddr
-	    collect item)
-  (((a b c d)) (a c)))
+            collect item)
+      (((a b c d)) (a c)))
 
 (test "ON destructured (x y) with step"
       (l)
       (loop for (x y) on l by #'cddr
-	    collect (cons x y))
-  (((a b c d)) ((a . b) (c . d))))
+            collect (cons x y))
+      (((a b c d)) ((a . b) (c . d))))
 
 (test "ON destructured (x y . z) with step"
       (l)
       (loop for (x y . z) on l by #'cddr
-	    collect (list x y z))
-  (((a b c d)) ((a b (c d)) (c d nil))))
+            collect (list x y z))
+      (((a b c d)) ((a b (c d)) (c d nil))))
 
 
 (test "miscellaneous sequential iteration"
       ()
       (loop for item = 1 then (+ item 10)
-	    for iteration from 1 to 5
-	    collect item)
-  (() (1 11 21 31 41)))
+            for iteration from 1 to 5
+            collect item)
+      (() (1 11 21 31 41)))
 
 (test "ACROSS constant arg"
       ()
       (loop for char across "foobar" collect char)
-  (() (#\f #\o #\o #\b #\a #\r)))
+      (() (#\f #\o #\o #\b #\a #\r)))
 
 (test "ACROSS declared variable arg"
       (s)
       (loop for char of-type character across (the simple-string s) collect char)
-  (("foobar") (#\f #\o #\o #\b #\a #\r)))
+      (("foobar") (#\f #\o #\o #\b #\a #\r)))
 
 
 (test "REPEAT sequencing, constant arg"
       (l)
       (loop repeat 3
-	    for x in l
-	    collect x)
-  ((nil) nil)
-  (((1)) (1))
-  (((1 2)) (1 2))
-  (((1 2 3)) (1 2 3))
-  (((1 2 3 4)) (1 2 3)))
+            for x in l
+            collect x)
+      ((nil) nil)
+      (((1)) (1))
+      (((1 2)) (1 2))
+      (((1 2 3)) (1 2 3))
+      (((1 2 3 4)) (1 2 3)))
 
 (test "REPEAT sequencing 2, constant arg"
       (l)
       (loop for x in l
-	    repeat 3
-	    collect x)
-  ((nil) nil)
-  (((1)) (1))
-  (((1 2)) (1 2))
-  (((1 2 3)) (1 2 3))
-  (((1 2 3 4)) (1 2 3)))
+            repeat 3
+            collect x)
+      ((nil) nil)
+      (((1)) (1))
+      (((1 2)) (1 2))
+      (((1 2 3)) (1 2 3))
+      (((1 2 3 4)) (1 2 3)))
 
 (test "REPEAT sequencing, variable arg"
       (n l)
       (loop repeat n
-	    for x in l
-	    collect x)
-  ((3 nil) nil)
-  ((3 (1)) (1))
-  ((3 (1 2)) (1 2))
-  ((3 (1 2 3)) (1 2 3))
-  ((3 (1 2 3 4)) (1 2 3)))
+            for x in l
+            collect x)
+      ((3 nil) nil)
+      ((3 (1)) (1))
+      ((3 (1 2)) (1 2))
+      ((3 (1 2 3)) (1 2 3))
+      ((3 (1 2 3 4)) (1 2 3)))
 
 (test "REPEAT sequencing 2, variable arg"
       (n l)
       (loop for x in l
-	    repeat n
-	    collect x)
-  ((3 nil) nil)
-  ((3 (1)) (1))
-  ((3 (1 2)) (1 2))
-  ((3 (1 2 3)) (1 2 3))
-  ((3 (1 2 3 4)) (1 2 3)))
+            repeat n
+            collect x)
+      ((3 nil) nil)
+      ((3 (1)) (1))
+      ((3 (1 2)) (1 2))
+      ((3 (1 2 3)) (1 2 3))
+      ((3 (1 2 3 4)) (1 2 3)))
 
 (test "WHILE sequencing"
       (stack)
       (loop while stack
-	    for item = (length stack) then (pop stack)
-	    collect item)
-  (((a b c d e f)) (6 a b c d e f))
-  (((a)) (1 a))
-  ((()) ()))
+            for item = (length stack) then (pop stack)
+            collect item)
+      (((a b c d e f)) (6 a b c d e f))
+      (((a)) (1 a))
+      ((()) ()))
 
 (test "WHILE sequencing 2"
       ()
       (loop for i fixnum from 3
-	    when (oddp i) collect i
-	    while (< i 5))
-  (() (3 5)))
+            when (oddp i) collect i
+              while (< i 5))
+      (() (3 5)))
 
 (test "simple always"
       (n)
       (loop for i from 0 to n
-	    always (< i 11))
-  ((10) t)
-  ((11) nil))
+            always (< i 11))
+      ((10) t)
+      ((11) nil))
 
 (test "always runs epilogue"
       (n)
       (loop for i from 0 to n
-	    always (< i 3)
-	    finally (return 'overriding-value))
-  ((5) nil)
-  ((2) overriding-value))
+            always (< i 3)
+            finally (return 'overriding-value))
+      ((5) nil)
+      ((2) overriding-value))
 
 (test "simple never"
       (n)
       (loop for i from n to (+ n 3)
-	    never (> i 11))
-  ((8) t)
-  ((9) nil))
+            never (> i 11))
+      ((8) t)
+      ((9) nil))
 
 (test "never runs epilogue"
       (n)
       (loop for i from n to (+ n 3)
-	    never (< i 3)
-	    finally (return 'overriding-value))
-  ((0) nil)
-  ((3) overriding-value))
+            never (< i 3)
+            finally (return 'overriding-value))
+      ((0) nil)
+      ((3) overriding-value))
 
 (defun oddsq (x)
   (cond ((not (numberp x)) (error "not a number"))
-	((oddp x) (* x x))
-	(t nil)))
+        ((oddp x) (* x x))
+        (t nil)))
 
 (test "simple thereis"
       (l)
       (loop for x in l
-	    thereis (oddsq x))
-  (((1 2 3)) 1)
-  (((2 4 6)) nil)
-  (((2 4 6 7)) 49))
+              thereis (oddsq x))
+      (((1 2 3)) 1)
+      (((2 4 6)) nil)
+      (((2 4 6 7)) 49))
 
 (test "thereis runs epilogue"
       (l)
       (loop for x in l
-	    thereis (oddsq x)
-	    finally (return 'overriding-value))
-  (((2 3 4)) 9)
-  (((2 4 6)) overriding-value))
+              thereis (oddsq x)
+            finally (return 'overriding-value))
+      (((2 3 4)) 9)
+      (((2 4 6)) overriding-value))
 
 (test "loop-finish"
       ()
       (loop for i in '(1 2 3 stop-here 4 5 6)
-	    when (symbolp i) do (loop-finish)
-	    count i)
-  (() 3))
+            when (symbolp i) do (loop-finish)
+              count i)
+      (() 3))
 
 (test "count"
       ()
       (loop for i in '(1 2 3 stop-here 4 5 6)
-	    until (symbolp i)
-	    count i)
-  (() 3))
+            until (symbolp i)
+            count i)
+      (() 3))
 
 
 (test "multiple collection"
       (l)
       (loop for x in l
-	    collect x
-	    collecting x
-	    nconc (list x)
-	    nconcing (list x)
-	    append (list x)
-	    appending (list x))
-  (((a b)) (a a a a a a b b b b b b)))
+            collect x
+            collecting x
+            nconc (list x)
+            nconcing (list x)
+            append (list x)
+            appending (list x))
+      (((a b)) (a a a a a a b b b b b b)))
 
 (test "nconc 1"
       (l)
       (loop for x in l
-	    nconc (copy-list x))
-  ((((a) (b c) () (d e))) (a b c d e)))
+            nconc (copy-list x))
+      ((((a) (b c) () (d e))) (a b c d e)))
 
 (test "more multiple collection"
       ()
       (loop for name in '(fred sue alice joe june)
-	    for kids in '((bob ken) () () (kris sunshine) ())
-	    collect name
-	    append kids)
-  (() (fred bob ken sue alice joe kris sunshine june)))
+            for kids in '((bob ken) () () (kris sunshine) ())
+            collect name
+            append kids)
+      (() (fred bob ken sue alice joe kris sunshine june)))
 
 
 (test "multiple collection with INTO"
       ()
       (loop for name in '(fred sue alice joe june)
-	    as age in '(22 26 19 20 10)
-	    append (list name age) into name-and-age-list
-	    counting name into name-count
-	    sum age into total-age
-	    finally (return (values (round total-age name-count)
-				    name-and-age-list)))
-  (() 19 (fred 22 sue 26 alice 19 joe 20 june 10)))
+            as age in '(22 26 19 20 10)
+            append (list name age) into name-and-age-list
+            counting name into name-count
+            sum age into total-age
+            finally (return (values (round total-age name-count)
+                                    name-and-age-list)))
+      (() 19 (fred 22 sue 26 alice 19 joe 20 june 10)))
 
 (test "gratuitous multiple collection"
       ()
       (loop for i in '(bird 3 4 turtle (1 . 4) horse cat)
-	    when (symbolp i) collect i)
-  (() (bird turtle horse cat)))
+            when (symbolp i) collect i)
+      (() (bird turtle horse cat)))
 
 (test "collection sequencing"
       ()
       (loop for i from 1 to 10
-	    if (oddp i) collect i)
-  (() (1 3 5 7 9)))
+            if (oddp i) collect i)
+      (() (1 3 5 7 9)))
 
 (test "more collecting into"
       ()
       (loop for i in '(a b c d) by #'cddr
-	    collect i into my-list
-	    finally (return (values 'foo my-list 'bar)))
-  (() foo (a c) bar))
+            collect i into my-list
+            finally (return (values 'foo my-list 'bar)))
+      (() foo (a c) bar))
 
 
 (test "append 1"
       ()
       (loop for x in '((a) (b) ((c)))
-	    append x)
-  (() (a b (c))))
+            append x)
+      (() (a b (c))))
 
 (test "nconc 2"
       ()
       (loop for i upfrom 0
-	    as x in '(a b (c))
-	    nconc (if (evenp i) (list x) nil))
-  (() (a (c))))
+            as x in '(a b (c))
+            nconc (if (evenp i) (list x) nil))
+      (() (a (c))))
 
 (test "count simple variable arg"
       ()
       (loop for i in '(a b nil c nil d e)
-	    count i)
-  (() 5))
+            count i)
+      (() 5))
 
 
 (test "simple sum"
       ()
       (loop for i fixnum in '(1 2 3 4 5)
-	    sum i)
-  (() 15))
+            sum i)
+      (() 15))
 
 (test "sum fixnum keyword"
       ()
       (loop for i fixnum in '(1 2 3 4 5)
-	    sum i fixnum)
-  (() 15))
+            sum i fixnum)
+      (() 15))
 
 (test "sum fixnum declaration"
       ()
       (loop for i fixnum in '(1 2 3 4 5)
-	    summing i of-type fixnum)
-  (() 15))
+            summing i of-type fixnum)
+      (() 15))
 
 #|| Too dangerous with floating point equality.
 (test "sum floating point series"
       (series)
       (loop for v in series
-	    sum (* 2.0 v))
-  (((1.2 4.3 5.7)) 22.4))
+            sum (* 2.0 v))
+      (((1.2 4.3 5.7)) 22.4))
 ||#
 
 (test "simple maximize"
       ()
       (loop for i in '(2 1 5 3 4)
-	    maximize i)
-  (() 5))
+            maximize i)
+      (() 5))
 
 (test "simple minimize"
       ()
       (loop for i in '(2 1 5 3 4)
-	    minimize i)
-  (() 1))
+            minimize i)
+      (() 1))
 
 (test "maximize fixnum keyword"
       (series)
       (loop for v in series
-	    maximizing (round v) fixnum)
-  (((1.2 4.3 5.7)) 6))
+            maximizing (round v) fixnum)
+      (((1.2 4.3 5.7)) 6))
 
 (test "minimize into fixnum keyword"
       (series)
       (loop for v float in series
-	    minimizing (round v) into result fixnum
-	    finally (return result))
-  (((1.2 4.3 5.7)) 1))
+            minimizing (round v) into result fixnum
+            finally (return result))
+      (((1.2 4.3 5.7)) 1))
 
 (test "mimimize declared fixnum"
       (series)
       (loop for v single-float in series
-	    minimizing (round v) of-type fixnum)
-  (((1.2 4.3 5.7)) 1))
+            minimizing (round v) of-type fixnum)
+      (((1.2 4.3 5.7)) 1))
 
 
 (test "sequential with"
       ()
       (loop with a = 1
-	    with b = (+ a 2)
-	    with c = (+ b 3)
-	    return (list a b c))
-  (() (1 3 6)))
+            with b = (+ a 2)
+            with c = (+ b 3)
+            return (list a b c))
+      (() (1 3 6)))
 
 
 (test "parallel with"
       ()
       (loop with a = 1 and b = 2 and c = 3
-	    return (list a b c))
-  (() (1 2 3)))
+            return (list a b c))
+      (() (1 2 3)))
 
 
 
 (test "parallel with 2"
       (a b)
       (loop with a = 1 and b = (+ a 2) and c = (+ b 3)
-	    return (list a b c))
-  ((5 10) (1 7 13)))
+            return (list a b c))
+      ((5 10) (1 7 13)))
 
 (test "destructuring type-keyworded with"
       ()
       (loop with (a b c d e f) (float integer short-float single-float double-float long-float)
-	    return (list a b c d e f))
-  (() (0.f0 0 0.0s0 0.0f0 0.0d0 0.0l0)))
+            return (list a b c d e f))
+      (() (0.f0 0 0.0s0 0.0f0 0.0d0 0.0l0)))
 
 (test "single-type-keyword destructured WITH"
       ()
       (loop with (a b c) float
-	    return (list a b c))
-  (() (0.f0 0.f0 0.f0)))
+            return (list a b c))
+      (() (0.f0 0.f0 0.f0)))
 
 
 (test "hairy conditional nesting"
       ()
       (loop with gubbish
-	    for i in '(1 2 3 4 5 6)
-	    when (oddp i)
-	      do (push i gubbish)
-	      and collect i into odd-numbers
-	      and do (push i gubbish)
-	    else
-	      collect i into even-numbers
-	    finally (return (values odd-numbers even-numbers gubbish)))
-  (() (1 3 5) (2 4 6) (5 5 3 3 1 1)))
+            for i in '(1 2 3 4 5 6)
+            when (oddp i)
+              do (push i gubbish)
+              and collect i into odd-numbers
+              and do (push i gubbish)
+            else
+              collect i into even-numbers
+            finally (return (values odd-numbers even-numbers gubbish)))
+      (() (1 3 5) (2 4 6) (5 5 3 3 1 1)))
 
 (test "collecting IT"
       ()
       (loop for i in '(1 2 3 4 5 6)
-	    when (and (> i 3) i)
-	    collect it)
-  (() (4 5 6)))
+            when (and (> i 3) i)
+              collect it)
+      (() (4 5 6)))
 
 (test "returning IT"
       ()
       (loop for i in '(1 2 3 4 5 6)
-	    when (and (> i 3) i)
-	    return it)
-  (() 4))
+            when (and (> i 3) i)
+              return it)
+      (() 4))
 
 (test "THEREIS 3"
       ()
       (loop for i in '(1 2 3 4 5 6)
-	    thereis (and (> i 3) i))
-  (() 4))
+              thereis (and (> i 3) i))
+      (() 4))
 
 
 (test "another multiple collection hairy conditional structure"
       ()
       (loop for i in `(,(1+ most-positive-fixnum) 1 2 buckle-my-shoe 3 4 shut-the-door (foo))
-	    when (numberp i)
-	      when (typep i 'bignum)
-	        collect i into big-numbers
-	      else
-	        collect i into other-numbers
-	    else
-	      when (symbolp i)
-	        collect i into symbol-list
-	      else collect i into other-list
-	    finally (return (list big-numbers other-numbers symbol-list other-list)))
-  (() ((#.(1+ most-positive-fixnum)) (1 2 3 4) (buckle-my-shoe shut-the-door) ((foo)))))
+            when (numberp i)
+              when (typep i 'bignum)
+                collect i into big-numbers
+            else
+              collect i into other-numbers
+            else
+              when (symbolp i)
+                collect i into symbol-list
+            else collect i into other-list
+            finally (return (list big-numbers other-numbers symbol-list other-list)))
+      (() ((#.(1+ most-positive-fixnum)) (1 2 3 4) (buckle-my-shoe shut-the-door) ((foo)))))
 
 (test "more conditional structure"
       ()
       (with-output-to-string (s)
-	(loop for x from 0 to 3
-	      do (format s ":~d " x)
-	      if (zerop (mod x 2))
-	        do (princ " a" s)
-		and if (zerop (floor x 2))
-		     do (princ " b" s)
-		     end
-		and do (princ " c" s)))
-  (() ":0  a b c:1 :2  a c:3 "))
+        (loop for x from 0 to 3
+              do (format s ":~d " x)
+              if (zerop (mod x 2))
+                do (princ " a" s)
+                and if (zerop (floor x 2))
+                      do (princ " b" s)
+              end
+              and do (princ " c" s)))
+      (() ":0  a b c:1 :2  a c:3 "))
 
 
 (test "more type-declared destructuring"
       ()
       (loop for (a b c) (integer integer float) in '((1 2 4.0) (5 6 8.3) (8 9 10.4))
-	    collect (list c b a))
-  (() ((4.0 2 1) (8.3 6 5) (10.4 9 8))))
+            collect (list c b a))
+      (() ((4.0 2 1) (8.3 6 5) (10.4 9 8))))
 
 (test "even more type-declared destructuring"
       ()
       (loop for (a b c) float in '((1.0 2.0 4.0) (5.0 6.0 8.3) (8.0 9.0 10.4))
-	    collect (list c b a))
-  (() ((4.0 2.0 1.0) (8.3 6.0 5.0) (10.4 9.0 8.0))))
+            collect (list c b a))
+      (() ((4.0 2.0 1.0) (8.3 6.0 5.0) (10.4 9.0 8.0))))
 
 
 (test "hash-keys"
       ()
       (let ((ht (make-hash-table :test #'equal)))
-	(loop for i from 0 below 10
-	      do (loop for j from 0 below 10
-		       do (setf (gethash (cons i j) ht) (cons (+ i j) (* i j)))))
-	(loop for (i . j) of-type (fixnum . fixnum) being the hash-keys of ht using (hash-value pair)
-	      as (sum . product) of-type fixnum = pair
-	      always (and (= (+ i j) sum) (= (* i j) product))
-	      count t into count
-	      finally (return (= count 100))))
-  (() t))
+        (loop for i from 0 below 10
+              do (loop for j from 0 below 10
+                       do (setf (gethash (cons i j) ht) (cons (+ i j) (* i j)))))
+        (loop for (i . j) of-type (fixnum . fixnum) being the hash-keys of ht using (hash-value pair)
+              as (sum . product) of-type fixnum = pair
+              always (and (= (+ i j) sum) (= (* i j) product))
+              count t into count
+              finally (return (= count 100))))
+      (() t))

--- a/src/ansiloop/test-suite/extended-tests.lisp
+++ b/src/ansiloop/test-suite/extended-tests.lisp
@@ -1,0 +1,123 @@
+;;;   -*- Mode: LISP; Syntax: Common-lisp; Package: EXTENDED-LOOP-TEST-PACKAGE; Base: 10; Lowercase:T -*-
+;;;>
+;;;> Portions of LOOP are Copyright (c) 1986 by the Massachusetts Institute of Technology.
+;;;> All Rights Reserved.
+;;;> 
+;;;> Permission to use, copy, modify and distribute this software and its
+;;;> documentation for any purpose and without fee is hereby granted,
+;;;> provided that the M.I.T. copyright notice appear in all copies and that
+;;;> both that copyright notice and this permission notice appear in
+;;;> supporting documentation.  The names "M.I.T." and "Massachusetts
+;;;> Institute of Technology" may not be used in advertising or publicity
+;;;> pertaining to distribution of the software without specific, written
+;;;> prior permission.  Notice must be given in supporting documentation that
+;;;> copying distribution is by permission of M.I.T.  M.I.T. makes no
+;;;> representations about the suitability of this software for any purpose.
+;;;> It is provided "as is" without express or implied warranty.
+;;;> 
+;;;>      Massachusetts Institute of Technology
+;;;>      77 Massachusetts Avenue
+;;;>      Cambridge, Massachusetts  02139
+;;;>      United States of America
+;;;>      +1-617-253-1000
+;;;>
+;;;> Portions of LOOP are Copyright (c) 1989, 1990, 1991, 1992 by Symbolics, Inc.
+;;;> All Rights Reserved.
+;;;> 
+;;;> Permission to use, copy, modify and distribute this software and its
+;;;> documentation for any purpose and without fee is hereby granted,
+;;;> provided that the Symbolics copyright notice appear in all copies and
+;;;> that both that copyright notice and this permission notice appear in
+;;;> supporting documentation.  The name "Symbolics" may not be used in
+;;;> advertising or publicity pertaining to distribution of the software
+;;;> without specific, written prior permission.  Notice must be given in
+;;;> supporting documentation that copying distribution is by permission of
+;;;> Symbolics.  Symbolics makes no representations about the suitability of
+;;;> this software for any purpose.  It is provided "as is" without express
+;;;> or implied warranty.
+;;;> 
+;;;> Symbolics, CLOE Runtime, and Minima are trademarks, and CLOE, Genera,
+;;;> and Zetalisp are registered trademarks of Symbolics, Inc.
+;;;>
+;;;>      Symbolics, Inc.
+;;;>      8 New England Executive Park, East
+;;;>      Burlington, Massachusetts  01803
+;;;>      United States of America
+;;;>      +1-617-221-1000
+
+
+(in-package 'extended-loop-test-package)
+
+(test "simple named"
+      ()
+      (loop named foo
+	    thereis 'return-this-value
+	    finally (return-from foo 'this-is-not-returned))
+  (() return-this-value))
+
+
+(test "named / return clause"
+      ()
+      (block nil
+	(1+ (loop named hieronymous
+		  return 5)))
+  (() 6))
+
+(test "named / return function"
+      ()
+      (block nil
+	(1+ (loop named hieronymous
+		  do (return 5))))
+  (() 6))
+
+(test "named / return-from"
+      ()
+      (block nil
+	(1+ (loop named hieronymous
+		  do (return-from hieronymous 5))))
+  (() 6))
+
+
+(define-loop-iteration-path cdrs 'loop-cdr-iteration-path
+  :alternate-names (cdr)
+  :inclusive-permitted t
+  :preposition-groups ((:of :in)))
+
+(defun loop-cdr-iteration-path (var type preps &key inclusive)
+  (assert (and preps (null (cdr preps)) (member (caar preps) '(:in :of))))
+  (let ((val (second (first preps))))
+    (if (listp var)
+	(let ((listv (gensym)))
+	  (if inclusive
+	      `(((,listv ,val) (,var nil ,type))
+		nil
+		(atom ,listv) () () (,listv (cdr ,listv) ,var ,listv)
+		() () () (,var ,listv))
+	      `(((,listv ,val) (,var nil ,type))
+		nil
+		(atom ,listv) () () (,listv (cdr ,listv) ,var ,listv))))
+	`(((,var ,val ,type)) nil
+	  (atom ,var) (,var (cdr ,var)) () ()
+	  ,@(and inclusive '(() () () ()))))))
+
+
+(test "sample iteration path"
+      (l)
+      (loop for x being the cdrs in l
+	    collect x)
+  (((a b c d)) ((b c d) (c d) (d) ()))
+  ((nil) ()))
+
+(test "alternate syntax iteration path"
+      ()
+      (loop for x being the cdrs of '(a b c d)
+	    collect x)
+  (() ((b c d) (c d) (d) ())))
+
+(test "inclusive iteration interation path"
+      (l)
+      (loop for x being l and its cdrs
+	    collect x)
+  (((a b c d)) ((a b c d) (b c d) (c d) (d) ()))
+  ((nil) (nil)))
+

--- a/src/ansiloop/test-suite/extended-tests.lisp
+++ b/src/ansiloop/test-suite/extended-tests.lisp
@@ -1,49 +1,47 @@
-;;;   -*- Mode: LISP; Syntax: Common-lisp; Package: EXTENDED-LOOP-TEST-PACKAGE; Base: 10; Lowercase:T -*-
-;;;>
-;;;> Portions of LOOP are Copyright (c) 1986 by the Massachusetts Institute of Technology.
-;;;> All Rights Reserved.
-;;;> 
-;;;> Permission to use, copy, modify and distribute this software and its
-;;;> documentation for any purpose and without fee is hereby granted,
-;;;> provided that the M.I.T. copyright notice appear in all copies and that
-;;;> both that copyright notice and this permission notice appear in
-;;;> supporting documentation.  The names "M.I.T." and "Massachusetts
-;;;> Institute of Technology" may not be used in advertising or publicity
-;;;> pertaining to distribution of the software without specific, written
-;;;> prior permission.  Notice must be given in supporting documentation that
-;;;> copying distribution is by permission of M.I.T.  M.I.T. makes no
-;;;> representations about the suitability of this software for any purpose.
-;;;> It is provided "as is" without express or implied warranty.
-;;;> 
-;;;>      Massachusetts Institute of Technology
-;;;>      77 Massachusetts Avenue
-;;;>      Cambridge, Massachusetts  02139
-;;;>      United States of America
-;;;>      +1-617-253-1000
-;;;>
-;;;> Portions of LOOP are Copyright (c) 1989, 1990, 1991, 1992 by Symbolics, Inc.
-;;;> All Rights Reserved.
-;;;> 
-;;;> Permission to use, copy, modify and distribute this software and its
-;;;> documentation for any purpose and without fee is hereby granted,
-;;;> provided that the Symbolics copyright notice appear in all copies and
-;;;> that both that copyright notice and this permission notice appear in
-;;;> supporting documentation.  The name "Symbolics" may not be used in
-;;;> advertising or publicity pertaining to distribution of the software
-;;;> without specific, written prior permission.  Notice must be given in
-;;;> supporting documentation that copying distribution is by permission of
-;;;> Symbolics.  Symbolics makes no representations about the suitability of
-;;;> this software for any purpose.  It is provided "as is" without express
-;;;> or implied warranty.
-;;;> 
-;;;> Symbolics, CLOE Runtime, and Minima are trademarks, and CLOE, Genera,
-;;;> and Zetalisp are registered trademarks of Symbolics, Inc.
-;;;>
-;;;>      Symbolics, Inc.
-;;;>      8 New England Executive Park, East
-;;;>      Burlington, Massachusetts  01803
-;;;>      United States of America
-;;;>      +1-617-221-1000
+;;;   -*- Mode:      LISP;       Syntax:      Common-lisp;      Package:
+;;;   -*- EXTENDED-LOOP-TEST-PACKAGE; Base: 10; Lowercase:T -*-
+;;;
+;;;  Portions  of  LOOP are  Copyright  (c)  1986 by  the  Massachusetts
+;;;  Institute of Technology. All Rights Reserved.
+;;;
+;;;  Permission to  use, copy, modify  and distribute this  software and
+;;;  its  documentation  for  any  purpose and  without  fee  is  hereby
+;;;  granted, provided  that the M.I.T.  copyright notice appear  in all
+;;;  copies  and that  both that  copyright notice  and this  permission
+;;;  notice appear  in supporting documentation. The  names "M.I.T." and
+;;;  "Massachusetts  Institute  of  Technology"   may  not  be  used  in
+;;;  advertising or publicity pertaining to distribution of the software
+;;;  without specific, written prior permission. Notice must be given in
+;;;  supporting documentation that copying distribution is by permission
+;;;  of M.I.T. M.I.T. makes no  representations about the suitability of
+;;;  this  software for  any purpose.  It  is provided  "as is"  without
+;;;  express or implied warranty.
+;;;
+;;;       Massachusetts Institute of  Technology 77 Massachusetts Avenue
+;;;       Cambridge,  Massachusetts  02139   United  States  of  America
+;;;       +1-617-253-1000
+;;;
+;;;  Portions  of LOOP  are  Copyright  (c) 1989,  1990,  1991, 1992  by
+;;;  Symbolics, Inc. All Rights Reserved.
+;;;
+;;;  Permission to  use, copy, modify  and distribute this  software and
+;;;  its  documentation  for  any  purpose and  without  fee  is  hereby
+;;;  granted, provided that the Symbolics copyright notice appear in all
+;;;  copies  and that  both that  copyright notice  and this  permission
+;;;  notice appear in supporting documentation. The name "Symbolics" may
+;;;  not be used in advertising  or publicity pertaining to distribution
+;;;  of  the  software  without   specific,  written  prior  permission.
+;;;  Notice  must  be given  in  supporting  documentation that  copying
+;;;  distribution  is by  permission  of Symbolics.  Symbolics makes  no
+;;;  representations  about the  suitability  of this  software for  any
+;;;  purpose.   It   is   provided    "as   is"   without   express   or
+;;;  implied warranty.
+;;;
+;;;  Symbolics,  CLOE  Runtime, and  Minima  are  trademarks, and  CLOE,
+;;;  Genera, and Zetalisp are registered trademarks of Symbolics, Inc.
+;;;
+;;;       Symbolics, Inc. 8 New England Executive Park, East Burlington,
+;;;       Massachusetts 01803 United States of America +1-617-221-1000
 
 
 (in-package 'extended-loop-test-package)
@@ -51,31 +49,31 @@
 (test "simple named"
       ()
       (loop named foo
-	    thereis 'return-this-value
-	    finally (return-from foo 'this-is-not-returned))
-  (() return-this-value))
+              thereis 'return-this-value
+            finally (return-from foo 'this-is-not-returned))
+      (() return-this-value))
 
 
 (test "named / return clause"
       ()
       (block nil
-	(1+ (loop named hieronymous
-		  return 5)))
-  (() 6))
+        (1+ (loop named hieronymous
+                  return 5)))
+      (() 6))
 
 (test "named / return function"
       ()
       (block nil
-	(1+ (loop named hieronymous
-		  do (return 5))))
-  (() 6))
+        (1+ (loop named hieronymous
+                  do (return 5))))
+      (() 6))
 
 (test "named / return-from"
       ()
       (block nil
-	(1+ (loop named hieronymous
-		  do (return-from hieronymous 5))))
-  (() 6))
+        (1+ (loop named hieronymous
+                  do (return-from hieronymous 5))))
+      (() 6))
 
 
 (define-loop-iteration-path cdrs 'loop-cdr-iteration-path
@@ -87,37 +85,36 @@
   (assert (and preps (null (cdr preps)) (member (caar preps) '(:in :of))))
   (let ((val (second (first preps))))
     (if (listp var)
-	(let ((listv (gensym)))
-	  (if inclusive
-	      `(((,listv ,val) (,var nil ,type))
-		nil
-		(atom ,listv) () () (,listv (cdr ,listv) ,var ,listv)
-		() () () (,var ,listv))
-	      `(((,listv ,val) (,var nil ,type))
-		nil
-		(atom ,listv) () () (,listv (cdr ,listv) ,var ,listv))))
-	`(((,var ,val ,type)) nil
-	  (atom ,var) (,var (cdr ,var)) () ()
-	  ,@(and inclusive '(() () () ()))))))
+        (let ((listv (gensym)))
+          (if inclusive
+              `(((,listv ,val) (,var nil ,type))
+                nil
+                (atom ,listv) () () (,listv (cdr ,listv) ,var ,listv)
+                () () () (,var ,listv))
+              `(((,listv ,val) (,var nil ,type))
+                nil
+                (atom ,listv) () () (,listv (cdr ,listv) ,var ,listv))))
+        `(((,var ,val ,type)) nil
+          (atom ,var) (,var (cdr ,var)) () ()
+          ,@(and inclusive '(() () () ()))))))
 
 
 (test "sample iteration path"
       (l)
       (loop for x being the cdrs in l
-	    collect x)
-  (((a b c d)) ((b c d) (c d) (d) ()))
-  ((nil) ()))
+            collect x)
+      (((a b c d)) ((b c d) (c d) (d) ()))
+      ((nil) ()))
 
 (test "alternate syntax iteration path"
       ()
       (loop for x being the cdrs of '(a b c d)
-	    collect x)
-  (() ((b c d) (c d) (d) ())))
+            collect x)
+      (() ((b c d) (c d) (d) ())))
 
 (test "inclusive iteration interation path"
       (l)
       (loop for x being l and its cdrs
-	    collect x)
-  (((a b c d)) ((a b c d) (b c d) (c d) (d) ()))
-  ((nil) (nil)))
-
+            collect x)
+      (((a b c d)) ((a b c d) (b c d) (c d) (d) ()))
+      ((nil) (nil)))

--- a/src/ansiloop/test-suite/validate.lisp
+++ b/src/ansiloop/test-suite/validate.lisp
@@ -1,0 +1,138 @@
+;;;   -*- Mode: LISP; Syntax: Common-lisp; Package: ANSI-LOOP; Base: 10; Lowercase:T -*-
+;;;>
+;;;> Portions of LOOP are Copyright (c) 1986 by the Massachusetts Institute of Technology.
+;;;> All Rights Reserved.
+;;;> 
+;;;> Permission to use, copy, modify and distribute this software and its
+;;;> documentation for any purpose and without fee is hereby granted,
+;;;> provided that the M.I.T. copyright notice appear in all copies and that
+;;;> both that copyright notice and this permission notice appear in
+;;;> supporting documentation.  The names "M.I.T." and "Massachusetts
+;;;> Institute of Technology" may not be used in advertising or publicity
+;;;> pertaining to distribution of the software without specific, written
+;;;> prior permission.  Notice must be given in supporting documentation that
+;;;> copying distribution is by permission of M.I.T.  M.I.T. makes no
+;;;> representations about the suitability of this software for any purpose.
+;;;> It is provided "as is" without express or implied warranty.
+;;;> 
+;;;>      Massachusetts Institute of Technology
+;;;>      77 Massachusetts Avenue
+;;;>      Cambridge, Massachusetts  02139
+;;;>      United States of America
+;;;>      +1-617-253-1000
+;;;>
+;;;> Portions of LOOP are Copyright (c) 1989, 1990, 1991, 1992 by Symbolics, Inc.
+;;;> All Rights Reserved.
+;;;> 
+;;;> Permission to use, copy, modify and distribute this software and its
+;;;> documentation for any purpose and without fee is hereby granted,
+;;;> provided that the Symbolics copyright notice appear in all copies and
+;;;> that both that copyright notice and this permission notice appear in
+;;;> supporting documentation.  The name "Symbolics" may not be used in
+;;;> advertising or publicity pertaining to distribution of the software
+;;;> without specific, written prior permission.  Notice must be given in
+;;;> supporting documentation that copying distribution is by permission of
+;;;> Symbolics.  Symbolics makes no representations about the suitability of
+;;;> this software for any purpose.  It is provided "as is" without express
+;;;> or implied warranty.
+;;;> 
+;;;> Symbolics, CLOE Runtime, and Minima are trademarks, and CLOE, Genera,
+;;;> and Zetalisp are registered trademarks of Symbolics, Inc.
+;;;>
+;;;>      Symbolics, Inc.
+;;;>      8 New England Executive Park, East
+;;;>      Burlington, Massachusetts  01803
+;;;>      United States of America
+;;;>      +1-617-221-1000
+
+
+(in-package :ansi-loop)
+
+
+(defvar *slow-test*
+	nil)
+
+
+(defvar *loop-lisp-package*
+	(let ((p (car (last (package-use-list (find-package 'ansi-loop))))))
+	  (format t "~&Assuming the ``LISP'' package used by LOOP is ~s.~@
+		       If not, you must preset ANSI-LOOP::*LOOP-LISP-PACKAGE*.~%"
+		  p)
+	  p))
+
+
+(defmacro test (short-desc lambda-list form &body params-and-answers)
+  `(test1 ,short-desc ',form ',lambda-list
+	  #'(lambda ,lambda-list ,form)
+	  ',params-and-answers))
+
+
+(defun test1 (short-desc form lambda-list interpreted params-and-answers &aux (slow *slow-test*))
+  (declare (ignore short-desc))
+  (dolist (pair params-and-answers)
+    (let ((params (first pair)) (answers (rest pair)) yow)
+      (unless (equal (setq yow (multiple-value-list (apply interpreted params))) answers)
+	(cerror "Continue."
+		"Interpreted LOOP form gave incorrect answer.~@
+	     ~@[Bindings: ~S~%~]~
+		Form:     ~S~@
+		Right:	  ~{~S~^ ; ~}~@
+		Wrong:	  ~{~S~^ ; ~}"
+		(and params (mapcar #'list lambda-list params))
+		form answers yow))
+      (unless (equal (setq yow (multiple-value-list
+				 (apply (compile nil `(lambda ,lambda-list
+							(declare (optimize (compilation-speed 0)))
+							,form))
+					params)))
+		     answers)
+	(setq slow nil)
+	(cerror (if *slow-test*
+		    "Continue (exhaustive optimization setting tests will be omitted)."
+		    "Continue.")
+		"Compiled LOOP form gave incorrect answer.~@
+	       ~@[Bindings: ~S~%~]~
+		  Form:     ~S~@
+		  Right:    ~{~S~^ ; ~}~@
+		  Wrong:    ~{~S~^ ; ~}"
+		(and params (mapcar #'list lambda-list params))
+		form answers yow))))
+  (when slow
+    (dotimes (speed 3)
+      (dotimes (space 3)
+	(dotimes (compilation-speed 3)
+	  (dotimes (safety 3)
+	    (let ((fn (compile nil `(lambda ,lambda-list
+				      (declare
+					(optimize
+					  (speed ,speed)
+					  (space ,space)
+					  (safety ,safety)
+					  (compilation-speed ,compilation-speed)))
+				      ,form))))
+	      (dolist (pair params-and-answers)
+		(let ((params (first pair)) (answers (rest pair)) yow)
+		  (unless (equal (setq yow (multiple-value-list (apply fn params))) answers)
+		    (cerror "Continue."
+			    "Compiled LOOP form gave incorrect answer at Speed=~D space=~D CompSpeed=~D Safety=~D.~@
+			~@[Bindings: ~S~%~]~
+			   Form:     ~S~@
+			   Right:    ~{~S~^ ; ~}~@
+			   Wrong:    ~{~S~^ ; ~}"
+			    speed space compilation-speed safety
+			    (and params (mapcar #'list lambda-list params))
+			    form answers yow)))))))))))
+
+
+(unless (find-package 'extended-loop-test-package)
+  (let ((p (make-package 'extended-loop-test-package :use (list ansi-loop::*loop-lisp-package*))))
+    (shadowing-import 'symbolics-loop:loop p)
+    (use-package (find-package 'symbolics-loop) p)
+    p))
+
+
+(in-package :extended-loop-test-package)
+
+
+(defmacro test (&rest args)
+  `(ansi-loop::test ,@args))

--- a/src/ansiloop/test-suite/validate.lisp
+++ b/src/ansiloop/test-suite/validate.lisp
@@ -1,70 +1,68 @@
-;;;   -*- Mode: LISP; Syntax: Common-lisp; Package: ANSI-LOOP; Base: 10; Lowercase:T -*-
-;;;>
-;;;> Portions of LOOP are Copyright (c) 1986 by the Massachusetts Institute of Technology.
-;;;> All Rights Reserved.
-;;;> 
-;;;> Permission to use, copy, modify and distribute this software and its
-;;;> documentation for any purpose and without fee is hereby granted,
-;;;> provided that the M.I.T. copyright notice appear in all copies and that
-;;;> both that copyright notice and this permission notice appear in
-;;;> supporting documentation.  The names "M.I.T." and "Massachusetts
-;;;> Institute of Technology" may not be used in advertising or publicity
-;;;> pertaining to distribution of the software without specific, written
-;;;> prior permission.  Notice must be given in supporting documentation that
-;;;> copying distribution is by permission of M.I.T.  M.I.T. makes no
-;;;> representations about the suitability of this software for any purpose.
-;;;> It is provided "as is" without express or implied warranty.
-;;;> 
-;;;>      Massachusetts Institute of Technology
-;;;>      77 Massachusetts Avenue
-;;;>      Cambridge, Massachusetts  02139
-;;;>      United States of America
-;;;>      +1-617-253-1000
-;;;>
-;;;> Portions of LOOP are Copyright (c) 1989, 1990, 1991, 1992 by Symbolics, Inc.
-;;;> All Rights Reserved.
-;;;> 
-;;;> Permission to use, copy, modify and distribute this software and its
-;;;> documentation for any purpose and without fee is hereby granted,
-;;;> provided that the Symbolics copyright notice appear in all copies and
-;;;> that both that copyright notice and this permission notice appear in
-;;;> supporting documentation.  The name "Symbolics" may not be used in
-;;;> advertising or publicity pertaining to distribution of the software
-;;;> without specific, written prior permission.  Notice must be given in
-;;;> supporting documentation that copying distribution is by permission of
-;;;> Symbolics.  Symbolics makes no representations about the suitability of
-;;;> this software for any purpose.  It is provided "as is" without express
-;;;> or implied warranty.
-;;;> 
-;;;> Symbolics, CLOE Runtime, and Minima are trademarks, and CLOE, Genera,
-;;;> and Zetalisp are registered trademarks of Symbolics, Inc.
-;;;>
-;;;>      Symbolics, Inc.
-;;;>      8 New England Executive Park, East
-;;;>      Burlington, Massachusetts  01803
-;;;>      United States of America
-;;;>      +1-617-221-1000
+;;;;   -*- Mode:  LISP; Syntax:  Common-lisp; Package:  ANSI-LOOP; Base:
+;;;;   -*- 10; Lowercase:T -*-
+;;;
+;;;  Portions  of  LOOP are  Copyright  (c)  1986 by  the  Massachusetts
+;;;  Institute of Technology. All Rights Reserved.
+;;;
+;;;  Permission to  use, copy, modify  and distribute this  software and
+;;;  its  documentation  for  any  purpose and  without  fee  is  hereby
+;;;  granted, provided  that the M.I.T.  copyright notice appear  in all
+;;;  copies  and that  both that  copyright notice  and this  permission
+;;;  notice appear  in supporting documentation. The  names "M.I.T." and
+;;;  "Massachusetts  Institute  of  Technology"   may  not  be  used  in
+;;;  advertising or publicity pertaining to distribution of the software
+;;;  without specific, written prior permission. Notice must be given in
+;;;  supporting documentation that copying distribution is by permission
+;;;  of M.I.T. M.I.T. makes no  representations about the suitability of
+;;;  this  software for  any purpose.  It  is provided  "as is"  without
+;;;  express or implied warranty.
+;;;
+;;;       Massachusetts Institute of  Technology 77 Massachusetts Avenue
+;;;       Cambridge,  Massachusetts  02139   United  States  of  America
+;;;       +1-617-253-1000
+;;;
+;;;  Portions  of LOOP  are  Copyright  (c) 1989,  1990,  1991, 1992  by
+;;;  Symbolics, Inc. All Rights Reserved.
+;;;
+;;;  Permission to  use, copy, modify  and distribute this  software and
+;;;  its  documentation  for  any  purpose and  without  fee  is  hereby
+;;;  granted, provided that the Symbolics copyright notice appear in all
+;;;  copies  and that  both that  copyright notice  and this  permission
+;;;  notice appear in supporting documentation. The name "Symbolics" may
+;;;  not be used in advertising  or publicity pertaining to distribution
+;;;  of  the  software  without   specific,  written  prior  permission.
+;;;  Notice  must  be given  in  supporting  documentation that  copying
+;;;  distribution  is by  permission  of Symbolics.  Symbolics makes  no
+;;;  representations  about the  suitability  of this  software for  any
+;;;  purpose.   It   is   provided    "as   is"   without   express   or
+;;;  implied warranty.
+;;;
+;;;  Symbolics,  CLOE  Runtime, and  Minima  are  trademarks, and  CLOE,
+;;;  Genera, and Zetalisp are registered trademarks of Symbolics, Inc.
+;;;
+;;;       Symbolics, Inc. 8 New England Executive Park, East Burlington,
+;;;       Massachusetts 01803 United States of America +1-617-221-1000
 
 
 (in-package :ansi-loop)
 
 
 (defvar *slow-test*
-	nil)
+  nil)
 
 
 (defvar *loop-lisp-package*
-	(let ((p (car (last (package-use-list (find-package 'ansi-loop))))))
-	  (format t "~&Assuming the ``LISP'' package used by LOOP is ~s.~@
+  (let ((p (car (last (package-use-list (find-package 'ansi-loop))))))
+    (format t "~&Assuming the ``LISP'' package used by LOOP is ~s.~@
 		       If not, you must preset ANSI-LOOP::*LOOP-LISP-PACKAGE*.~%"
-		  p)
-	  p))
+            p)
+    p))
 
 
 (defmacro test (short-desc lambda-list form &body params-and-answers)
   `(test1 ,short-desc ',form ',lambda-list
-	  #'(lambda ,lambda-list ,form)
-	  ',params-and-answers))
+          #'(lambda ,lambda-list ,form)
+          ',params-and-answers))
 
 
 (defun test1 (short-desc form lambda-list interpreted params-and-answers &aux (slow *slow-test*))
@@ -72,56 +70,56 @@
   (dolist (pair params-and-answers)
     (let ((params (first pair)) (answers (rest pair)) yow)
       (unless (equal (setq yow (multiple-value-list (apply interpreted params))) answers)
-	(cerror "Continue."
-		"Interpreted LOOP form gave incorrect answer.~@
-	     ~@[Bindings: ~S~%~]~
-		Form:     ~S~@
-		Right:	  ~{~S~^ ; ~}~@
-		Wrong:	  ~{~S~^ ; ~}"
-		(and params (mapcar #'list lambda-list params))
-		form answers yow))
+        (cerror "Continue."
+                "Interpreted LOOP form gave incorrect answer.~@
+ ~@[Bindings: ~S~%~]~
+ Form:     ~S~@
+ Right:	  ~{~S~^ ; ~}~@
+ Wrong:	  ~{~S~^ ; ~}"
+                (and params (mapcar #'list lambda-list params))
+                form answers yow))
       (unless (equal (setq yow (multiple-value-list
-				 (apply (compile nil `(lambda ,lambda-list
-							(declare (optimize (compilation-speed 0)))
-							,form))
-					params)))
-		     answers)
-	(setq slow nil)
-	(cerror (if *slow-test*
-		    "Continue (exhaustive optimization setting tests will be omitted)."
-		    "Continue.")
-		"Compiled LOOP form gave incorrect answer.~@
-	       ~@[Bindings: ~S~%~]~
-		  Form:     ~S~@
-		  Right:    ~{~S~^ ; ~}~@
-		  Wrong:    ~{~S~^ ; ~}"
-		(and params (mapcar #'list lambda-list params))
-		form answers yow))))
+                                (apply (compile nil `(lambda ,lambda-list
+                                                       (declare (optimize (compilation-speed 0)))
+                                                       ,form))
+                                       params)))
+                     answers)
+        (setq slow nil)
+        (cerror (if *slow-test*
+                    "Continue (exhaustive optimization setting tests will be omitted)."
+                    "Continue.")
+                "Compiled LOOP form gave incorrect answer.~@
+ ~@[Bindings: ~S~%~]~
+ Form:     ~S~@
+ Right:    ~{~S~^ ; ~}~@
+ Wrong:    ~{~S~^ ; ~}"
+                (and params (mapcar #'list lambda-list params))
+                form answers yow))))
   (when slow
     (dotimes (speed 3)
       (dotimes (space 3)
-	(dotimes (compilation-speed 3)
-	  (dotimes (safety 3)
-	    (let ((fn (compile nil `(lambda ,lambda-list
-				      (declare
-					(optimize
-					  (speed ,speed)
-					  (space ,space)
-					  (safety ,safety)
-					  (compilation-speed ,compilation-speed)))
-				      ,form))))
-	      (dolist (pair params-and-answers)
-		(let ((params (first pair)) (answers (rest pair)) yow)
-		  (unless (equal (setq yow (multiple-value-list (apply fn params))) answers)
-		    (cerror "Continue."
-			    "Compiled LOOP form gave incorrect answer at Speed=~D space=~D CompSpeed=~D Safety=~D.~@
-			~@[Bindings: ~S~%~]~
-			   Form:     ~S~@
-			   Right:    ~{~S~^ ; ~}~@
-			   Wrong:    ~{~S~^ ; ~}"
-			    speed space compilation-speed safety
-			    (and params (mapcar #'list lambda-list params))
-			    form answers yow)))))))))))
+        (dotimes (compilation-speed 3)
+          (dotimes (safety 3)
+            (let ((fn (compile nil `(lambda ,lambda-list
+                                      (declare
+                                       (optimize
+                                        (speed ,speed)
+                                        (space ,space)
+                                        (safety ,safety)
+                                        (compilation-speed ,compilation-speed)))
+                                      ,form))))
+              (dolist (pair params-and-answers)
+                (let ((params (first pair)) (answers (rest pair)) yow)
+                  (unless (equal (setq yow (multiple-value-list (apply fn params))) answers)
+                    (cerror "Continue."
+                            "Compiled LOOP form gave incorrect answer at Speed=~D space=~D CompSpeed=~D Safety=~D.~@
+ ~@[Bindings: ~S~%~]~
+ Form:     ~S~@
+ Right:    ~{~S~^ ; ~}~@
+ Wrong:    ~{~S~^ ; ~}"
+                            speed space compilation-speed safety
+                            (and params (mapcar #'list lambda-list params))
+                            form answers yow)))))))))))
 
 
 (unless (find-package 'extended-loop-test-package)

--- a/src/array.lisp
+++ b/src/array.lisp
@@ -1,15 +1,17 @@
 ;;; arrays.lisp
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading array.lisp!")
 

--- a/src/backquote.lisp
+++ b/src/backquote.lisp
@@ -1,25 +1,28 @@
 ;;; backquote.lisp ---
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading backquote.lisp!")
 
 ;;; Backquote implementation.
 ;;;
-;;;    Author: Guy L. Steele Jr. Date: 27 December 1985 Tested under Symbolics Common Lisp and Lucid
-;;;    Common Lisp. This software is in the public domain.
+;;;    Author: Guy  L. Steele  Jr. Date: 27  December 1985  Tested under
+;;;    Symbolics Common Lisp and Lucid  Common Lisp. This software is in
+;;;    the public domain.
 
-;;;    The following are unique  tokens used during processing. They need not  be symbols; they need
-;;;    not even be atoms.
+;;;    The following are unique tokens used during processing. They need
+;;;    not be symbols; they need not even be atoms.
 (defvar *comma* 'unquote)
 (defvar *comma-atsign* 'unquote-splicing)
 
@@ -31,10 +34,11 @@
 (defvar *bq-quote* (make-symbol "BQ-QUOTE"))
 (defvar *bq-quote-nil* (list *bq-quote* nil))
 
-;;; BACKQUOTE is an ordinary macro (not a read-macro) that processes the expression foo, looking for
-;;; occurrences of #:COMMA, #:COMMA-ATSIGN, and #:COMMA-DOT. It constructs code in strict accordance
-;;; with the  rules on pages 349-350  of the first edition  (pages 528-529 of this  second edition).
-;;; It then optionally applies a code simplifier.
+;;; BACKQUOTE is an ordinary macro (not a read-macro) that processes the
+;;; expression foo, looking for  occurrences of #:COMMA, #:COMMA-ATSIGN,
+;;; and #:COMMA-DOT.  It constructs code  in strict accordance  with the
+;;; rules on pages  349-350 of the first edition (pages  528-529 of this
+;;; second edition). It then optionally applies a code simplifier.
 
 ;;; If the value of *BQ-SIMPLIFY* is non-NIL, then BACKQUOTE processing applies the code simplifier.
 ;;; If the  value is NIL, then  the code resulting from  BACKQUOTE is exactly that  specified by the

--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -124,6 +124,9 @@
 (defun apply (function arg &rest args)
   (apply function (apply #'list* arg args)))
 
+(defun symbol-name (x)
+  (symbol-name x))
+
 ;; Basic macros
 
 (defmacro dolist ((var list &optional result) &body body)

--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -363,6 +363,7 @@
                      (if (find (car c) '(t otherwise))
                          `(t ,@(rest c))
                          `((,(ecase (car c)
+                                    (fixnum 'integerp)
                                     (integer 'integerp)
                                     (cons 'consp)
                                     (list 'listp)

--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -442,3 +442,17 @@
   `(multiple-value-call (lambda (&rest values)
                           (nth ,n values))
      ,form))
+
+
+(defun constantp (x)
+  ;; TODO: Consider quoted forms, &environment and many other
+  ;; semantics of this function.
+  (cond
+    ((symbolp x)
+     (cond
+       ((eq x t) t)
+       ((setq x nil) t)))
+    ((atom x)
+     t)
+    (t
+     nil)))

--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -357,6 +357,21 @@
   `(multiple-value-call #'list ,value-from))
 
 
+(defmacro multiple-value-setq ((&rest vars) &rest form)
+  (let ((gvars (mapcar (lambda (x) (gensym)) vars))
+        (setqs '()))
+
+    (do ((vars vars (cdr vars))
+         (gvars gvars (cdr gvars)))
+        ((or (null vars) (null gvars)))
+      (push `(setq ,(car vars) ,(car gvars))
+            setqs))
+    (setq setqs (reverse setqs))
+
+    `(multiple-value-call (lambda ,gvars ,@setqs)
+       ,@form)))
+
+
 ;; Incorrect typecase, but used in NCONC.
 (defmacro typecase (x &rest clausules)
   (let ((value (gensym)))

--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -394,6 +394,11 @@
          ,@clausules
          (t (error "~S fell through etypecase expression." ,g!x))))))
 
+
+;;; No type system is implemented yet.
+(defun subtypep (type1 type2)
+  (values nil nil))
+
 (defun notany (fn seq)
   (not (some fn seq)))
 

--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -2,46 +2,49 @@
 
 ;; Copyright (C) 2012, 2013 David Vazquez Copyright (C) 2012 Raimon Grau
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
-;;; This code is executed when JSCL compiles  this file itself. The compiler provides compilation of
-;;; some special forms, as well as funcalls and  macroexpansion, but no functions. So, we define the
-;;; Lisp world  from scratch. This  code has to  define enough language to  the compiler to  be able
-;;; to run.
+;;; This  code  is  executed  when   JSCL  compiles  this  file  itself.
+;;; The compiler provides compilation of  some special forms, as well as
+;;; funcalls and  macroexpansion, but  no functions.  So, we  define the
+;;; Lisp world from scratch. This code  has to define enough language to
+;;; the compiler to be able to run.
 
 (/debug "loading boot.lisp!")
 
 (eval-when (:compile-toplevel)
   (let ((defmacro-macroexpander
-         '#'(lambda (form)
-              (destructuring-bind (name args &body body)
-                  form
-                (let* ((whole (gensym))
-                       (expander `(function
-                                   (lambda (,whole)
-                                    (block ,name
-                                      (destructuring-bind ,args ,whole
-                                        ,@body))))))
+          '#'(lambda (form)
+               (destructuring-bind (name args &body body)
+                   form
+                 (let* ((whole (gensym))
+                        (expander `(function
+                                    (lambda (,whole)
+                                     (block ,name
+                                       (destructuring-bind ,args ,whole
+                                         ,@body))))))
 
-                  ;; If we  are boostrapping JSCL, we  need to quote the  macroexpander, because the
-                  ;; macroexpander will need to be dumped in the final environment somehow.
-                  (when (find :jscl-xc *features*)
-                    (setq expander `(quote ,expander)))
-                  
-                  `(eval-when (:compile-toplevel :execute)
-                     (%compile-defmacro ',name ,expander))
+                   ;; If we  are boostrapping JSCL, we  need to quote the  macroexpander, because the
+                   ;; macroexpander will need to be dumped in the final environment somehow.
+                   (when (find :jscl-xc *features*)
+                     (setq expander `(quote ,expander)))
 
-                  )))))
-    
+                   `(eval-when (:compile-toplevel :execute)
+                      (%compile-defmacro ',name ,expander))
+
+                   )))))
+
     (%compile-defmacro 'defmacro defmacro-macroexpander)))
 
 (defmacro declaim (&rest decls)
@@ -248,7 +251,7 @@
   `(block nil
      (let ,(mapcar (lambda (x) (if (symbolp x)
                                    (list x nil)
-                                 (list (first x) (second x)))) varlist)
+                                   (list (first x) (second x)))) varlist)
        (while t
          (when ,(car endlist)
            (return (progn ,@(cdr endlist))))
@@ -265,7 +268,7 @@
   `(block nil
      (let* ,(mapcar (lambda (x1) (if (symbolp x1)
                                      (list x1 nil)
-                                   (list (first x1) (second x1)))) varlist)
+                                     (list (first x1) (second x1)))) varlist)
        (while t
          (when ,(car endlist)
            (return (progn ,@(cdr endlist))))
@@ -414,24 +417,24 @@ macro cache is so aggressive that it cannot be redefined."
                      (if (find (car c) '(t otherwise))
                          `(t ,@(rest c))
                          `((,(ecase (car c)
-                                    (number 'numberp)
-                                    (fixnum 'integerp)
-                                    (integer 'integerp)
-                                    (cons 'consp)
-                                    (list 'listp)
-                                    (vector 'vectorp)
-                                    (character 'characterp)
-                                    (sequence 'sequencep)
-                                    (symbol 'symbolp)
-                                    (keyword 'keywordp)
-                                    (function 'functionp)
-                                    (float 'floatp)
-                                    (array 'arrayp)
-                                    (string 'stringp)
-                                    (atom 'atom)
-                                    (null 'null)
-                                    (package 'packagep))
-                             ,value)
+                               (number 'numberp)
+                               (fixnum 'integerp)
+                               (integer 'integerp)
+                               (cons 'consp)
+                               (list 'listp)
+                               (vector 'vectorp)
+                               (character 'characterp)
+                               (sequence 'sequencep)
+                               (symbol 'symbolp)
+                               (keyword 'keywordp)
+                               (function 'functionp)
+                               (float 'floatp)
+                               (array 'arrayp)
+                               (string 'stringp)
+                               (atom 'atom)
+                               (null 'null)
+                               (package 'packagep))
+                            ,value)
                            ,@(or (rest c)
                                  (list nil)))))
                    clausules)))))

--- a/src/char.lisp
+++ b/src/char.lisp
@@ -1,6 +1,7 @@
 (/debug "loading char.lisp!")
 
-;; These comparison functions heavily borrowed from SBCL/CMUCL (public domain).
+;; These comparison  functions heavily borrowed from  SBCL/CMUCL (public
+;; domain).
 
 (defun char= (character &rest more-characters)
   (dolist (c more-characters t)
@@ -205,7 +206,7 @@ For the first 32 characters ('C0 controls'), the first
     (if (<= code 127)
         (aref +ascii-names+ code)
         (format nil #-jscl "U+~4,'0x" ; HACK until padding works right.
-                #+jscl "U+~x" code))))
+                    #+jscl "U+~x" code))))
 
 (defun name-char (name)
   (let ((name (string name)))

--- a/src/compat.lisp
+++ b/src/compat.lisp
@@ -2,16 +2,18 @@
 
 ;; Copyright (C) 2012, 2013 David Vazquez Copyright (C) 2012 Raimon Grau
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Duplicate from boot.lisp by now
 (defmacro while (condition &body body)
@@ -35,6 +37,6 @@
   (declare (ignorable subchar arg))
   (assert (char= #\: (read-char stream nil :eof)) nil "FFI descriptor must start with a semicolon.")
   (loop :for ch := (read-char stream nil #\Space)
-     :until (terminalp ch)))
+        :until (terminalp ch)))
 
 (set-dispatch-macro-character #\# #\J #'j-reader)

--- a/src/compiler/codegen.lisp
+++ b/src/compiler/codegen.lisp
@@ -131,7 +131,7 @@
   (multiple-value-bind (string valid)
       (valid-js-identifier string-designator)
     (unless valid
-      (error "~S is not a valid Javascript identifier." string))
+      (error "~S is not a valid Javascript identifier." string-designator))
     (js-format "~a" string)))
 
 (defun js-primary-expr (form)
@@ -187,8 +187,12 @@
   (when wrap-p
     (js-format ")")))
 
-(defun js-function (arguments &rest body)
-  (js-format "function(")
+(defun js-function (name arguments &rest body)
+  (js-format "function")
+  (when name
+    (js-format " ")
+    (js-identifier name))
+  (js-format "(")
   (when arguments
     (js-identifier (car arguments))
     (dolist (arg (cdr arguments))
@@ -270,6 +274,10 @@
        (js-object-initializer args))
       ;; Function expressions
       (function
+       (js-format "(")
+       (apply #'js-function nil args)
+       (js-format ")"))
+      (named-function
        (js-format "(")
        (apply #'js-function args)
        (js-format ")"))

--- a/src/compiler/codegen.lisp
+++ b/src/compiler/codegen.lisp
@@ -2,23 +2,26 @@
 
 ;; Copyright (C) 2013, 2014 David Vazquez
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 
-;;; This code  generator takes  as input  a S-expression  representation of  the Javascript  AST and
-;;; generates Javascript code without redundant syntax constructions like extra parenthesis.
+;;; This code generator takes as  input a S-expression representation of
+;;; the Javascript  AST and generates Javascript  code without redundant
+;;; syntax constructions like extra parenthesis.
 ;;;
-;;; It is intended to be used with the new compiler. However, it is quite independent so it has been
-;;; integrated early in JSCL.
+;;; It is  intended to  be used  with the new  compiler. However,  it is
+;;; quite independent so it has been integrated early in JSCL.
 
 (/debug "loading compiler-codegen.lisp!")
 
@@ -507,8 +510,8 @@
                 (js-stmt false))))
            (group
             (let ((in-group-p
-                   (or (null parent)
-                       (and (consp parent) (eq (car parent) 'group)))))
+                    (or (null parent)
+                        (and (consp parent) (eq (car parent) 'group)))))
               (unless  in-group-p (js-format "{"))
               (mapc #'js-stmt (cdr form))
               (unless in-group-p (js-format "}"))))

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -950,6 +950,10 @@
     (progn ,@(mapcar #'convert forms))
     (return args)))
 
+(define-compilation the (value-type form)
+  (convert form *multiple-value-p*))
+
+
 (define-transformation backquote (form)
   (bq-completely-process form))
 

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1457,20 +1457,21 @@
           expander)
         nil)))
 
-(defun !macroexpand-1 (form)
-  (cond
-    ((symbolp form)
-     (let ((b (lookup-in-lexenv form *environment* 'variable)))
-       (if (and b (eq (binding-type b) 'macro))
-           (values (binding-value b) t)
-           (values form nil))))
-    ((and (consp form) (symbolp (car form)))
-     (let ((macrofun (!macro-function (car form))))
-       (if macrofun
-           (values (funcall macrofun (cdr form)) t)
-           (values form nil))))
-    (t
-     (values form nil))))
+(defun !macroexpand-1 (form &optional env)
+  (let ((*environment* (or env *environment*)))
+    (cond
+      ((symbolp form)
+       (let ((b (lookup-in-lexenv form *environment* 'variable)))
+         (if (and b (eq (binding-type b) 'macro))
+             (values (binding-value b) t)
+             (values form nil))))
+      ((and (consp form) (symbolp (car form)))
+       (let ((macrofun (!macro-function (car form))))
+         (if macrofun
+             (values (funcall macrofun (cdr form)) t)
+             (values form nil))))
+      (t
+       (values form nil)))))
 
 #+jscl
 (fset 'macroexpand-1 #'!macroexpand-1)

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1476,6 +1476,15 @@
 #+jscl
 (fset 'macroexpand-1 #'!macroexpand-1)
 
+(defun !macroexpand (form &optional env)
+  (let ((continue t))
+    (while continue
+      (multiple-value-setq (form continue) (!macroexpand-1 form env)))
+    form))
+#+jscl
+(fset 'macroexpand #'!macroexpand)
+
+
 
 (defun compile-funcall (function args)
   (let* ((arglist (cons (if *multiple-value-p* '|values| '(internal |pv|))

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1460,6 +1460,10 @@
     (t
      (values form nil))))
 
+#+jscl
+(fset 'macroexpand-1 #'!macroexpand-1)
+
+
 (defun compile-funcall (function args)
   (let* ((arglist (cons (if *multiple-value-p* '|values| '(internal |pv|))
 			(mapcar #'convert args))))

--- a/src/conditions.lisp
+++ b/src/conditions.lisp
@@ -1,19 +1,22 @@
 ;;; conditions.lisp ---
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 
-;;; Follow here a straighforward implementation of the  condition system of Common Lisp, except that
-;;; any value will work as a condition. Because, well, we do not have conditions at this point.
+;;; Follow here a straighforward  implementation of the condition system
+;;; of Common  Lisp, except  that any  value will  work as  a condition.
+;;; Because, well, we do not have conditions at this point.
 
 
 (defvar *handler-bindings* nil)
@@ -64,7 +67,7 @@
          (let (,datum)
            (tagbody
               (%handler-bind ,(mapcar #'translate-case cases)
-                             (return-from ,nlx ,form))
+                (return-from ,nlx ,form))
               ,@(reverse tagbody-content)))))))
 
 
@@ -80,7 +83,7 @@
                  (block ,normal-return
                    (return-from ,error-return
                      (%handler-case-1 (return-from ,normal-return ,form)
-                                      ,@(butlast cases))))))))
+                       ,@(butlast cases))))))))
         `(%handler-case-1 ,form ,@cases))))
 
 
@@ -89,7 +92,7 @@
 ;;; final implementation would require CLOS.
 
 (def!struct !condition
-    type
+  type
   args)
 
 (defun condition-type-p (x type)

--- a/src/defstruct.lisp
+++ b/src/defstruct.lisp
@@ -18,54 +18,83 @@
 ;; A very simple defstruct built on lists. It supports just slot with
 ;; an optional default initform, and it will create a constructor,
 ;; predicate and accessors for you.
-(defmacro def!struct (name &rest slots)
-  (unless (symbolp name)
-    (error "It is not a full defstruct implementation."))
-  (let* ((name-string (symbol-name name))
-         (slot-descriptions
-          (mapcar (lambda (sd)
-                    (cond
-                      ((symbolp sd)
-                       (list sd))
-                      ((and (listp sd) (car sd) (null (cddr sd)))
-                       sd)
-                      (t
-                       (error "Bad slot description `~S'." sd))))
-                  slots))
-         (predicate (intern (concat name-string "-P"))))
-    `(progn
-       ;; Constructor
-       (defun ,(intern (concat "MAKE-" name-string)) (&key ,@slot-descriptions)
-         (list ',name ,@(mapcar #'car slot-descriptions)))
-       ;; Predicate
-       (defun ,predicate (x)
-         (and (consp x) (eq (car x) ',name)))
-       ;; Copier
-       (defun ,(intern (concat "COPY-" name-string)) (x)
-         (copy-list x))
-       ;; Slot accessors
-       ,@(with-collect
-          (let ((index 1))
-            (dolist (slot slot-descriptions)
-              (let* ((name (car slot))
-                     (accessor-name (intern (concat name-string "-" (string name)))))
-                (collect
-                    `(defun ,accessor-name (x)
-                       (unless (,predicate x)
-                         (error "The object `~S' is not of type `~S'" x ,name-string))
-                       (nth ,index x)))
-                ;; TODO: Implement this with a higher level
-                ;; abstraction like defsetf or (defun (setf ..))
-                (collect
-                    `(define-setf-expander ,accessor-name (x)
-                       (let ((object (gensym))
-                             (new-value (gensym)))
-                         (values (list object)
-                                 (list x)
-                                 (list new-value)
-                                 `(progn
-                                    (rplaca (nthcdr ,',index ,object) ,new-value) 
-                                    ,new-value)
-                                 `(,',accessor-name ,object)))))
-                (incf index)))))
-       ',name)))
+(defmacro def!struct (name-and-options &rest slots)
+  (let* ((name-and-options (ensure-list name-and-options))
+         (name (first name-and-options))
+         (name-string (symbol-name name))
+         (options (rest name-and-options))
+         (constructor (if (assoc :constructor options)
+                          (second (assoc :constructor options))
+                          (intern (concat "MAKE-" name-string))))
+         (predicate (if (assoc :predicate options)
+                        (second (assoc :predicate options))
+                        (intern (concat name-string "-P"))))
+         (copier (if (assoc :copier options)
+                     (second (assoc :copier options))
+                     (intern (concat "COPY-" name-string)))))
+
+
+    (unless predicate
+      (setq predicate (gensym "PREDICATE")))
+
+    (let* ((slot-descriptions
+            (mapcar (lambda (sd)
+                      (cond
+                        ((symbolp sd)
+                         (list sd))
+                        ((and (listp sd) (car sd) (null (cddr sd)))
+                         sd)
+                        (t
+                         (error "Bad slot description `~S'." sd))))
+                    slots))
+
+           constructor-expansion
+           predicate-expansion
+           copier-expansion)
+      
+
+      (when constructor
+        (setq constructor-expansion
+              `(defun ,constructor (&key ,@slot-descriptions)
+                 (list ',name ,@(mapcar #'car slot-descriptions)))))
+
+      (when predicate
+        (setq predicate-expansion
+              `(defun ,predicate (x)
+                 (and (consp x) (eq (car x) ',name)))))
+
+      (when copier
+        (setq copier-expansion
+              `(defun ,copier (x)
+                 (copy-list x))))
+
+      `(progn
+         ,constructor-expansion
+         ,predicate-expansion
+         ,copier-expansion
+         ;; Slot accessors
+         ,@(with-collect
+             (let ((index 1))
+               (dolist (slot slot-descriptions)
+                 (let* ((name (car slot))
+                        (accessor-name (intern (concat name-string "-" (string name)))))
+                   (collect
+                       `(defun ,accessor-name (x)
+                          (unless (,predicate x)
+                            (error "The object `~S' is not of type `~S'" x ,name-string))
+                          (nth ,index x)))
+                   ;; TODO: Implement this with a higher level
+                   ;; abstraction like defsetf or (defun (setf ..))
+                   (collect
+                       `(define-setf-expander ,accessor-name (x)
+                          (let ((object (gensym))
+                                (new-value (gensym)))
+                            (values (list object)
+                                    (list x)
+                                    (list new-value)
+                                    `(progn
+                                       (rplaca (nthcdr ,',index ,object) ,new-value) 
+                                       ,new-value)
+                                    `(,',accessor-name ,object)))))
+                   (incf index)))))
+         ',name))))

--- a/src/defstruct.lisp
+++ b/src/defstruct.lisp
@@ -1,20 +1,22 @@
-;;; defstruct.lisp --- 
+;;; defstruct.lisp ---
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading defstruct.lisp!")
 
-;; A very simple defstruct built on lists. It supports just slot with
-;; an optional default initform, and it will create a constructor,
+;; A very simple defstruct built on lists. It supports just slot with an
+;; optional  default  initform,  and   it  will  create  a  constructor,
 ;; predicate and accessors for you.
 (defmacro def!struct (name-and-options &rest slots)
   (let* ((name-and-options (ensure-list name-and-options))
@@ -36,20 +38,20 @@
       (setq predicate (gensym "PREDICATE")))
 
     (let* ((slot-descriptions
-          (mapcar (lambda (sd)
-                    (cond
-                      ((symbolp sd)
-                       (list sd))
-                      ((and (listp sd) (car sd) (null (cddr sd)))
-                       sd)
-                      (t
-                       (error "Bad slot description `~S'." sd))))
-                  slots))
+             (mapcar (lambda (sd)
+                       (cond
+                         ((symbolp sd)
+                          (list sd))
+                         ((and (listp sd) (car sd) (null (cddr sd)))
+                          sd)
+                         (t
+                          (error "Bad slot description `~S'." sd))))
+                     slots))
 
            constructor-expansion
            predicate-expansion
            copier-expansion)
-      
+
 
       (when constructor
         (setq constructor-expansion
@@ -66,33 +68,33 @@
               `(defun ,copier (x)
                  (copy-list x))))
 
-    `(progn
+      `(progn
          ,constructor-expansion
          ,predicate-expansion
          ,copier-expansion
-       ;; Slot accessors
-       ,@(with-collect
-          (let ((index 1))
-            (dolist (slot slot-descriptions)
-              (let* ((name (car slot))
-                     (accessor-name (intern (concat name-string "-" (string name)))))
-                (collect
-                    `(defun ,accessor-name (x)
-                       (unless (,predicate x)
-                         (error "The object `~S' is not of type `~S'" x ,name-string))
-                       (nth ,index x)))
-                ;; TODO: Implement this with a higher level
-                ;; abstraction like defsetf or (defun (setf ..))
-                (collect
-                    `(define-setf-expander ,accessor-name (x)
-                       (let ((object (gensym))
-                             (new-value (gensym)))
-                         (values (list object)
-                                 (list x)
-                                 (list new-value)
-                                 `(progn
-                                    (rplaca (nthcdr ,',index ,object) ,new-value) 
-                                    ,new-value)
-                                 `(,',accessor-name ,object)))))
-                (incf index)))))
+         ;; Slot accessors
+         ,@(with-collect
+             (let ((index 1))
+               (dolist (slot slot-descriptions)
+                 (let* ((name (car slot))
+                        (accessor-name (intern (concat name-string "-" (string name)))))
+                   (collect
+                       `(defun ,accessor-name (x)
+                          (unless (,predicate x)
+                            (error "The object `~S' is not of type `~S'" x ,name-string))
+                          (nth ,index x)))
+                   ;; TODO: Implement this with a higher level
+                   ;; abstraction like defsetf or (defun (setf ..))
+                   (collect
+                       `(define-setf-expander ,accessor-name (x)
+                          (let ((object (gensym))
+                                (new-value (gensym)))
+                            (values (list object)
+                                    (list x)
+                                    (list new-value)
+                                    `(progn
+                                       (rplaca (nthcdr ,',index ,object) ,new-value)
+                                       ,new-value)
+                                    `(,',accessor-name ,object)))))
+                   (incf index)))))
          ',name))))

--- a/src/early-char.lisp
+++ b/src/early-char.lisp
@@ -1,21 +1,25 @@
-;;; early-char.lisp --- Character things needed early in the cross-compilation
+;;; early-char.lisp   ---  Character   things   needed   early  in   the
+;;; cross-compilation
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading early-char.lisp!")
 
-;; This list comes from SBCL: everything that's ALPHA-CHAR-P, but not SB-IMPL::UCD-DECIMAL-DIGIT (to
-;; work around  <https://bugs.launchpad.net/sbcl/+bug/1177986>), then  combined into a  much smaller
-;; set of ranges. Yes, this can be compressed better.
+;; This list  comes from SBCL:  everything that's ALPHA-CHAR-P,  but not
+;; SB-IMPL::UCD-DECIMAL-DIGIT          (to          work          around
+;; <https://bugs.launchpad.net/sbcl/+bug/1177986>),  then combined  into
+;; a much smaller set of ranges. Yes, this can be compressed better.
 (defconstant +unicode-alphas+
   '((65 . 90) (97 . 122) (170 . 170) (181 . 181) (186 . 186) (192 . 214)
     (216 . 246) (248 . 705) (710 . 721) (736 . 740) (748 . 748) (750 . 750)
@@ -140,7 +144,7 @@
 (defun digit-char-p (char &optional (radix 10))
   "Includes ASCII 0-9 a-z A-Z, plus any Unicode decimal digit characters or fullwidth variants A-Z."
   (check-type char character)
-  (check-type radix integer) 
+  (check-type radix integer)
   (let* ((radix (or (and radix (<= 2 radix 36) radix) 10))
          (number (unicode-digit-value char))
          (code (char-code char))

--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -1,15 +1,17 @@
 ;;; ffi.lisp ---
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading ffi.lisp!")
 

--- a/src/hash-table.lisp
+++ b/src/hash-table.lisp
@@ -64,7 +64,7 @@
   )
 
 
-(defun make-hash-table (&key (test #'eql))
+(defun make-hash-table (&key (test #'eql) size)
   (let* ((test-fn (fdefinition test))
          (hash-fn
           (cond

--- a/src/hash-table.lisp
+++ b/src/hash-table.lisp
@@ -1,29 +1,33 @@
 ;;; hash-table.lisp ---
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
-;;; Plain Javascript  objects are  the natural way  to implement Common  Lisp hash  tables. However,
-;;; there  is a  big differences  betweent them  which we  need to  work around.  Javascript objects
-;;; require  the keys  to be  strings. To  solve  that, we  map Lisp  objects to  strings such  that
-;;; "equivalent" values map to the same string,  regarding the equality predicate used (one of `eq',
-;;; `eql', `equal' and `equalp').
+;;; Plain Javascript  objects are  the natural  way to  implement Common
+;;; Lisp hash tables. However, there  is a big differences betweent them
+;;; which we need to work around. Javascript objects require the keys to
+;;; be strings. To solve that, we  map Lisp objects to strings such that
+;;; "equivalent" values map  to the same string,  regarding the equality
+;;; predicate used (one of `eq', `eql', `equal' and `equalp').
 
-;;; Additionally, we  want to  iterate across the  hash table key-values.  So we  use a cons  (key .
-;;; value) as value in the Javascript object. It  implicitly gives the inverse mapping of strings to
-;;; our objects.
+;;; Additionally, we want  to iterate across the  hash table key-values.
+;;; So we use  a cons (key .  value) as value in  the Javascript object.
+;;; It implicitly gives the inverse mapping of strings to our objects.
 
-;;; If a hash table has `eq' as test, we need to generate unique strings for each Lisp object. To do
-;;; this, we tag the objects with a `$$jscl_id' property.  As a special case, numbers do not need to
-;;; be tagged, as they can be used to index Javascript objects.
+;;; If a hash table has `eq' as test, we need to generate unique strings
+;;; for  each  Lisp  object.  To  do  this,  we  tag  the  objects  with
+;;; a `$$jscl_id' property. As a special case, numbers do not need to be
+;;; tagged, as they can be used to index Javascript objects.
 (defvar *eq-hash-counter* 0)
 (defun eq-hash (x)
   (cond
@@ -40,8 +44,8 @@
   (eq-hash x))
 
 
-;;; In the case  of equal-based hash tables,  we do not store  the hash in the  objects, but compute
-;;; a hash from the elements it contains.
+;;; In the case of equal-based hash tables,  we do not store the hash in
+;;; the objects, but compute a hash from the elements it contains.
 (defun equal-hash (x)
   (typecase x
     (cons
@@ -59,11 +63,11 @@
 (defun make-hash-table (&key (test #'eql) size)
   (let* ((test-fn (fdefinition test))
          (hash-fn
-          (cond
-            ((eq test-fn #'eq)    #'eq-hash)
-            ((eq test-fn #'eql)   #'eql-hash)
-            ((eq test-fn #'equal) #'equal-hash)
-            ((eq test-fn #'equalp) #'equalp-hash))))
+           (cond
+             ((eq test-fn #'eq)    #'eq-hash)
+             ((eq test-fn #'eql)   #'eql-hash)
+             ((eq test-fn #'equal) #'equal-hash)
+             ((eq test-fn #'equalp) #'equalp-hash))))
     ;; TODO: Replace list with a storage-vector and tag
     ;; conveniently to implemnet `hash-table-p'.
     `(hash-table ,hash-fn ,(new))))

--- a/src/lambda-list.lisp
+++ b/src/lambda-list.lisp
@@ -2,16 +2,18 @@
 
 ;;; Copyright (C) 2013 David Vazquez
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading lambda-list.lisp!")
 
@@ -22,16 +24,16 @@
 ;;;; Lambda list parsing
 
 (def!struct optvar
-    variable initform supplied-p-parameter)
+  variable initform supplied-p-parameter)
 
 (def!struct keyvar
-    variable keyword-name initform supplied-p-parameter)
+  variable keyword-name initform supplied-p-parameter)
 
 (def!struct auxvar
-    variable initform)
+  variable initform)
 
 (def!struct lambda-list
-    wholevar
+  wholevar
   reqvars
   optvars
   restvar
@@ -190,16 +192,16 @@
 ;;; Return T if KEYWORD is supplied in the list of arguments LIST.
 (defun keyword-supplied-p (keyword list)
   (do-keywords key value list
-               (declare (ignore value))
-               (when (eq key keyword) (return t))
-               (setq list (cddr list))))
+    (declare (ignore value))
+    (when (eq key keyword) (return t))
+    (setq list (cddr list))))
 
 ;;; Return the value of KEYWORD in the list of arguments LIST or NIL
 ;;; if it is not supplied.
 (defun keyword-lookup (keyword list)
   (do-keywords key value list
-               (when (eq key keyword) (return value))
-               (setq list (cddr list))))
+    (when (eq key keyword) (return value))
+    (setq list (cddr list))))
 
 (defun validate-reqvars (list n)
   (unless (listp list)
@@ -218,12 +220,12 @@
   (let (;; If it is non-NIL, we have to check for unknown keyword
         ;; arguments in the list to signal an error in that case.
         (allow-other-keys
-         (or allow-other-keys (keyword-lookup :allow-other-keys list))))
+          (or allow-other-keys (keyword-lookup :allow-other-keys list))))
     (unless allow-other-keys
       (do-keywords key value list
-                   (declare (ignore value))
-                   (unless (find key keyword-list)
-                     (error "Unknown keyword argument `~S'." key))))
+        (declare (ignore value))
+        (unless (find key keyword-list)
+          (error "Unknown keyword argument `~S'." key))))
     (do* ((tail list (cddr tail))
           (key (car tail) (car tail)))
          ((null tail) list)
@@ -298,17 +300,17 @@
                             (pattern (or restvar (gensym)))
                             (keywords (mapcar #'keyvar-keyword-name (lambda-list-keyvars ll)))
                             (rest
-                             ;; Create a binding for the rest of the
-                             ;; arguments. If there is keywords, then
-                             ;; validate this list. If there is no
-                             ;; keywords and no &rest variable, then
-                             ;; validate that the rest is empty, it is
-                             ;; to say, there is no more arguments
-                             ;; that we expect.
-                             (cond
-                               (keywords (compute-pbindings pattern `(validate-keyvars ,chain ',keywords ,(lambda-list-allow-other-keys ll))))
-                               (restvar  (compute-pbindings pattern chain))
-                               (t        (compute-pbindings pattern `(validate-max-args ,chain))))))
+                              ;; Create a binding for the rest of the
+                              ;; arguments. If there is keywords, then
+                              ;; validate this list. If there is no
+                              ;; keywords and no &rest variable, then
+                              ;; validate that the rest is empty, it is
+                              ;; to say, there is no more arguments
+                              ;; that we expect.
+                              (cond
+                                (keywords (compute-pbindings pattern `(validate-keyvars ,chain ',keywords ,(lambda-list-allow-other-keys ll))))
+                                (restvar  (compute-pbindings pattern chain))
+                                (t        (compute-pbindings pattern `(validate-max-args ,chain))))))
                        (when (lambda-list-keyvars ll)
                          ;; Keywords
                          (dolist (keyvar (lambda-list-keyvars ll))
@@ -346,8 +348,8 @@
 #+jscl
 (eval-when (:compile-toplevel)
   (let ((macroexpander
-         '#'(lambda (form &optional environment)
-              (declare (ignore environment))
-              (apply #'!expand-destructuring-bind form))))
+          '#'(lambda (form &optional environment)
+               (declare (ignore environment))
+               (apply #'!expand-destructuring-bind form))))
     (%compile-defmacro '!destructuring-bind macroexpander)
     (%compile-defmacro  'destructuring-bind macroexpander)))

--- a/src/list.lisp
+++ b/src/list.lisp
@@ -1,15 +1,17 @@
-;;; list.lisp --- 
+;;; list.lisp ---
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading list.lisp!")
 
@@ -26,9 +28,9 @@
 
 (defun endp (object)
   "It returns true if OBJECT is NIL, false if OBJECT is a CONS, and an error
-   for any other type of OBJECT.
+ for any other type of OBJECT.
 
-   This is the recommended way to test for the end of a proper list."
+ This is the recommended way to test for the end of a proper list."
   (cond ((null object) t)
         ((consp object) nil)
         (t (error "The value `~S' is not a type list." object))))
@@ -156,7 +158,7 @@
 (defun subst (new old tree &key key (test #'eql testp) (test-not #'eql test-not-p))
   (labels ((s (x)
              (cond ((satisfies-test-p old x :key key :test test :testp testp
-                                      :test-not test-not :test-not-p test-not-p)
+                                            :test-not test-not :test-not-p test-not-p)
                     new)
                    ((atom x) x)
                    (t (let ((a (s (car x)))
@@ -169,36 +171,36 @@
 
 (defun copy-list (x)
   (if (null x)
-    nil
-    (let* ((new-list (list (car x)))
-           (last-cell new-list))
-      (do ((orig (cdr x) (cdr orig)))
-        ((atom orig) (rplacd last-cell orig))
-        (rplacd last-cell (cons (car orig) nil))
-        (setq last-cell (cdr last-cell)))
-      new-list)))
+      nil
+      (let* ((new-list (list (car x)))
+             (last-cell new-list))
+        (do ((orig (cdr x) (cdr orig)))
+            ((atom orig) (rplacd last-cell orig))
+          (rplacd last-cell (cons (car orig) nil))
+          (setq last-cell (cdr last-cell)))
+        new-list)))
 
 (defun copy-tree (tree)
   (if (consp tree)
-    (cons (copy-tree (car tree))
-          (copy-tree (cdr tree)))
-    tree))
+      (cons (copy-tree (car tree))
+            (copy-tree (cdr tree)))
+      tree))
 
 (defun tree-equal (tree1 tree2 &key (test #'eql testp)
-                         (test-not #'eql test-not-p))
+                                    (test-not #'eql test-not-p))
   (when (and testp test-not-p) (error "Both test and test-not are set"))
   (let ((func (if test-not-p (complement test-not) test)))
     (labels ((%tree-equal (tree1 tree2)
                (if (atom tree1)
-                 (and (atom tree2) (funcall func tree1 tree2))
-                 (and (consp tree2)
-                      (%tree-equal (car tree1) (car tree2))
-                      (%tree-equal (cdr tree1) (cdr tree2))))))
+                   (and (atom tree2) (funcall func tree1 tree2))
+                   (and (consp tree2)
+                        (%tree-equal (car tree1) (car tree2))
+                        (%tree-equal (cdr tree1) (cdr tree2))))))
       (%tree-equal tree1 tree2))))
 
 (defun tailp (object list)
   (do ((tail list (cdr tail)))
-    ((atom tail) (eq object tail))
+      ((atom tail) (eq object tail))
     (when (eql tail object)
       (return-from tailp t))))
 
@@ -209,50 +211,6 @@
   (let ((newlist))
     (dotimes (i size newlist)
       (push initial-element newlist))))
-
-(defun map1 (func list)
-  (with-collect
-    (while list
-      (collect (funcall func (car list)))
-      (setq list (cdr list)))))
-
-(defun mapcar (func list &rest lists)
-  (let ((lists (cons list lists)))
-    (with-collect
-      (block loop
-        (loop
-           (let ((elems (map1 #'car lists)))
-             (do ((tail lists (cdr tail)))
-                 ((null tail))
-               (when (null (car tail)) (return-from loop))
-               (rplaca tail (cdar tail)))
-             (collect (apply func elems))))))))
-
-(defun mapn (func list)
-  (with-collect
-    (while list
-      (collect (funcall func list))
-      (setq list (cdr list)))))
-
-(defun maplist (func list &rest lists)
-  (let ((lists (cons list lists)))
-    (with-collect
-      (block loop
-        (loop
-           (let ((elems (mapn #'car lists)))
-             (do ((tail lists (cdr tail)))
-                 ((null tail))
-               (when (null (car tail)) (return-from loop))
-               (rplaca tail (cdar tail)))
-             (collect (apply func elems))))))))
-
-(defun mapc (func &rest lists)
-  (do* ((tails lists (map1 #'cdr tails))
-        (elems (map1 #'car tails)
-               (map1 #'car tails)))
-       ((dolist (x tails) (when (null x) (return t)))
-        (car lists))
-    (apply func elems)))
 
 (defun last (x)
   (while (consp (cdr x))
@@ -272,7 +230,8 @@
     ;; trivial optimizations
     ((zerop n) x)
     (t
-     ;; O(n) walk of the linked list, trimming out the link where appropriate
+     ;; O(n)  walk of  the  linked  list, trimming  out  the link  where
+     ;; appropriate
      (let* ((head x)
             (trailing (nthcdr n x)))
        ;; If there are enough conses
@@ -287,7 +246,7 @@
 (defun member (x list &key key (test #'eql testp) (test-not #'eql test-not-p))
   (while list
     (when (satisfies-test-p x (car list) :key key :test test :testp testp
-                            :test-not test-not :test-not-p test-not-p)
+                                         :test-not test-not :test-not-p test-not-p)
       (return list))
     (setq list (cdr list))))
 
@@ -295,18 +254,18 @@
 (defun assoc (x alist &key key (test #'eql testp) (test-not #'eql test-not-p))
   (while alist
     (if (satisfies-test-p x (caar alist) :key key :test test :testp testp
-                          :test-not test-not :test-not-p test-not-p)
-      (return)
-      (setq alist (cdr alist))))
+                                         :test-not test-not :test-not-p test-not-p)
+        (return)
+        (setq alist (cdr alist))))
   (car alist))
 
 (defun rassoc (x alist &key key (test #'eql) (test #'eql testp)
-                 (test-not #'eql test-not-p))
+                            (test-not #'eql test-not-p))
   (while alist
     (if (satisfies-test-p x (cdar alist) :key key :test test :testp testp
-                          :test-not test-not :test-not-p test-not-p)
-      (return)
-      (setq alist (cdr alist))))
+                                         :test-not test-not :test-not-p test-not-p)
+        (return)
+        (setq alist (cdr alist))))
   (car alist))
 
 (defun acons (key datum alist)
@@ -361,7 +320,7 @@
                (let ((ele (car elements)))
                  (typecase ele
                    (cons (rplacd (last splice) ele)
-                         (setf splice ele))
+                    (setf splice ele))
                    (null (rplacd (last splice) nil))
                    (atom (if (cdr elements)
                              (fail ele)
@@ -384,8 +343,8 @@
 
 (defun adjoin (item list &key (test #'eql) (key #'identity))
   (if (member item list :key key :test test)
-    list
-    (cons item list)))
+      list
+      (cons item list)))
 
 (defun intersection (list1 list2 &key (test #'eql) (key #'identity))
   (let ((new-list ()))
@@ -398,7 +357,7 @@
   (do* ((plist plist (cddr plist))
         (cdr (cdr plist) (cdr plist))
         (car (car plist) (car plist)))
-      ((null plist) (values nil nil nil))
+       ((null plist) (values nil nil nil))
     (when (null cdr)
       (error "malformed property list ~S" plist))
     (let ((found (member car indicator-list :test #'eq)))
@@ -409,7 +368,7 @@
   (do* ((plist plist (cddr plist))
         (cdr (cdr plist) (cdr plist))
         (car (car plist) (car plist)))
-      ((null plist) default)
+       ((null plist) default)
     (when (null cdr)
       (error "malformed property list ~S" plist))
     (when (eq indicator car)
@@ -419,7 +378,7 @@
   (do* ((tail plist (cddr tail))
         (cdr (cdr tail) (cdr tail))
         (car (car tail) (car tail)))
-      ((null tail) (list* indicator new-value plist))
+       ((null tail) (list* indicator new-value plist))
     (when (null cdr)
       (error "malformed property list ~S" tail))
     (when (eq indicator car)
@@ -444,19 +403,18 @@
 
 
 
-;;; 
+;;;
 ;;; The following code has been taken from SBCL
-;;; 
 
 ;;; mapping functions
 
-;;; a helper function for implementation of MAPC, MAPCAR, MAPCAN,
-;;; MAPL, MAPLIST, and MAPCON
+;;; a helper function for implementation  of MAPC, MAPCAR, MAPCAN, MAPL,
+;;; MAPLIST, and MAPCON
 ;;;
-;;; Map the designated function over the arglists in the appropriate
-;;; way. It is done when any of the arglists runs out. Until then, it
-;;; CDRs down the arglists calling the function and accumulating
-;;; results as desired.
+;;; Map the  designated function  over the  arglists in  the appropriate
+;;; way. It is  done when any of  the arglists runs out.  Until then, it
+;;; CDRs down the arglists calling the function and accumulating results
+;;; as desired.
 (defun map1 (fun-designator arglists accumulate take-car)
   (do* ((fun fun-designator)
         (non-acc-result (car arglists))
@@ -478,11 +436,11 @@
       (:nconc
        (when res
          (setf (cdr temp) res)
-         ;; KLUDGE: it is said that MAPCON is equivalent to
-         ;; (apply #'nconc (maplist ...)) which means (nconc 1) would
-         ;; return 1, but (nconc 1 1) should signal an error.
-         ;; The transformed MAP code returns the last result, do that
-         ;; here as well for consistency and simplicity.
+         ;; KLUDGE:  it is  said  that MAPCON  is  equivalent to  (apply
+         ;; #'nconc (maplist ...)) which means (nconc 1) would return 1,
+         ;; but (nconc 1 1) should  signal an error. The transformed MAP
+         ;; code  returns the  last result,  do  that here  as well  for
+         ;; consistency and simplicity.
          (when (consp res)
            (setf temp (last res)))))
       (:list (setf (cdr temp) (list res)
@@ -494,12 +452,12 @@
 
 (defun mapcar (function list &rest more-lists)
   "Apply FUNCTION to successive elements of LIST. Return list of FUNCTION
-   return values."
+ return values."
   (map1 function (cons list more-lists) :list t))
 
 (defun mapcan (function list &rest more-lists)
   "Apply FUNCTION to successive elements of LIST. Return NCONC of FUNCTION
-   results."
+ results."
   (map1 function (cons list more-lists) :nconc t))
 
 (defun maplist (function list &rest more-lists)

--- a/src/misc.lisp
+++ b/src/misc.lisp
@@ -1,15 +1,17 @@
 ;;; misc.lisp --
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading misc.lisp!")
 

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -1,15 +1,17 @@
 ;;; numbers.lisp
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading numbers.lisp!")
 
@@ -26,8 +28,9 @@
   (def + 0)
   (def * 1))
 
-;; - and / work differently  from the above macro. If only one arg is given,  it negates it or takes
-;; its reciprocal. Otherwise all the other args are subtracted from or divided by it.
+;; - and  / work differently  from the above macro.  If only one  arg is
+;; given, it negates it or takes its reciprocal. Otherwise all the other
+;; args are subtracted from or divided by it.
 (macrolet ((def (operator unary-form)
              `(defun ,operator (x &rest args)
                 (cond

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,15 +1,17 @@
 ;;; package.lisp ---
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading package.lisp!")
 
@@ -28,8 +30,9 @@
       (oget *package-table* (string package-designator))))
 
 (defun delete-package (package-designator)
-  ;; TODO: Signal a correctlable error in case the package-designator does not name a package. TODO:
-  ;; Implement unuse-package and remove the deleted package from packages that use it.
+  ;; TODO: Signal  a correctlable  error in case  the package-designator
+  ;; does not name  a package. TODO: Implement  unuse-package and remove
+  ;; the deleted package from packages that use it.
   (delete-property (package-name (find-package-or-fail package-designator))
                    *package-table*))
 
@@ -191,7 +194,7 @@
      ,result-form))
 
 (defmacro do-external-symbols ((var &optional (package '*package*)
-                                    result-form)
+                                              result-form)
                                &body body)
   `(block nil
      (%map-external-symbols

--- a/src/print.lisp
+++ b/src/print.lisp
@@ -1,19 +1,22 @@
-;;; print.lisp ---
+;;;; print.lisp ---
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading print.lisp!")
 
-;;; HACK HACK — if an error occurs during startup before toplevel binds this correctly,
+;;; HACK HACK — if an error  occurs during startup before toplevel binds
+;;; this correctly,
 #+jscl
 (setq *standard-output*
       (vector 'stream
@@ -494,7 +497,7 @@ to streams."
            (#\[ #'format-conditional)
            (#\{ #'format-repeat)
            (t (warn "~~~a is not implemented yet, using ~~S instead" chr)
-              #'format-syntax))
+            #'format-syntax))
          arg colonp atp params))
 
 (defun !format (destination fmt &rest args)

--- a/src/read.lisp
+++ b/src/read.lisp
@@ -87,7 +87,7 @@
          (rplacd stream (1+ (cdr stream))))))
 
 (defun whitespacep (ch)
-  (or (char= ch #\space) (char= ch #\newline) (char= ch #\tab)))
+  (or (char= ch #\space) (char= ch #\newline) (char= ch #\tab) (char= ch (char "" 0))))
 
 (defun skip-whitespaces (stream)
   (let (ch)

--- a/src/read.lisp
+++ b/src/read.lisp
@@ -2,32 +2,35 @@
 
 ;; Copyright (C) 2012, 2013 David Vazquez Copyright (C) 2012 Raimon Grau
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading read.lisp!")
 
 ;;;; Reader
 
-;;; If it is not NIL,  we do not want to read the expression but just  ignore it. For example, it is
-;;; used in conditional reads #+.
+;;; If it  is not NIL, we  do not want  to read the expression  but just
+;;; ignore it. For example, it is used in conditional reads #+.
 (defvar *read-skip-p* nil)
 
-;;; The Lisp reader, parse strings and return Lisp  objects. The main entry points are `ls-read' and
-;;; `ls-read-from-string'.
+;;; The Lisp  reader, parse  strings and return  Lisp objects.  The main
+;;; entry points are `ls-read' and `ls-read-from-string'.
 
 ;;; #= / ## implementation
 
-;; For now  associations label->object are kept  in a plist  May be it  makes sense to use  a vector
-;; instead if speed is considered a problem with many labelled objects
+;; For now  associations label->object  are kept  in a  plist May  be it
+;; makes sense to use a vector  instead if speed is considered a problem
+;; with many labelled objects
 (defvar *labelled-objects* nil)
 
 (defun new-labelled-objects-table ()
@@ -261,14 +264,14 @@
               (let ((*read-base* 16))
                 (code-char (read-integer-from-stream stream))))
              (t (let ((cname
-                       (concat (string (%read-char stream))
-                               (read-until stream #'terminalp))))
+                        (concat (string (%read-char stream))
+                                (read-until stream #'terminalp))))
                   (let ((ch (name-char cname)))
                     (or ch (char cname 0)))))))
       ((#\+ #\-)
        (let* ((expression
-               (let ((*package* (find-package :keyword)))
-                 (ls-read stream eof-error-p eof-value t))))
+                (let ((*package* (find-package :keyword)))
+                  (ls-read stream eof-error-p eof-value t))))
 
          (if (eql (char= ch #\+) (eval-feature-expression expression))
              (ls-read stream eof-error-p eof-value t)
@@ -446,7 +449,7 @@
       (case (char string index)
         (#\+ (incf index))
         (#\- (setq sign -1)
-             (incf index)))
+         (incf index)))
       (unless (< index size) (return))
       ;; Optional integer part
       (awhen (digit-char-p (char string index))
@@ -484,7 +487,7 @@
         (case (char string index)
           (#\+ (incf index))
           (#\- (setq exponent-sign -1)
-               (incf index)))
+           (incf index)))
         (unless (< index size) (return))
         ;; Exponent digits
         (let ((value (digit-char-p (char string index))))
@@ -514,7 +517,7 @@
         (case (char string 0)
           (#\+ (incf index))
           (#\- (setq sign -1)
-               (incf index)))
+           (incf index)))
         ;; First digit
         (unless (and (< index size)
                      (setq value (digit-char-p (char string index) radix)))

--- a/src/sequence.lisp
+++ b/src/sequence.lisp
@@ -44,6 +44,24 @@
     (list (revappend sequence '()))
     (vector (vector-reverse sequence))))
 
+
+(defun list-nreverse (list)
+  (do ((1st (cdr list) (if (endp 1st) 1st (cdr 1st)))
+       (2nd list 1st)
+       (3rd '() 2nd))
+      ((atom 2nd) 3rd)
+    (rplacd 2nd 3rd)))
+
+(defun nreverse (sequence)
+  (etypecase sequence
+    (list (list-nreverse sequence))
+    (vector
+     (let ((size (length sequence)))
+       (do ((i 0 (1+ i)))
+           ((< i (/ size 2)) sequence)
+         (set (elt sequence i) (elt sequence (- size i 1))))))))
+
+
 (defmacro do-sequence ((elt seq &optional (index (gensym "i") index-p)) &body body)
   (let ((nseq (gensym "seq")))
     (unless (symbolp elt)

--- a/src/sequence.lisp
+++ b/src/sequence.lisp
@@ -1,15 +1,17 @@
 ;;; sequence.lisp
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading sequence.lisp!")
 
@@ -126,12 +128,12 @@
 
 (defun count-if-not (predicate sequence &key from-end (start 0) end key)
   (count-if (complement predicate) sequence :from-end from-end
-            :start start :end end :key key))
+                                            :start start :end end :key key))
 
 (defun find (item seq &key key (test #'eql testp) (test-not #'eql test-not-p))
   (do-sequence (x seq)
     (when (satisfies-test-p item x :key key :test test :testp testp
-                            :test-not test-not :test-not-p test-not-p)
+                                   :test-not test-not :test-not-p test-not-p)
       (return x))))
 
 (defun find-if (predicate sequence &key key)
@@ -252,7 +254,7 @@
             (tail head))
        (do-sequence (elt seq)
          (unless (satisfies-test-p x elt :key key :test test :testp testp
-                                   :test-not test-not :test-not-p test-not-p)
+                                         :test-not test-not :test-not-p test-not-p)
            (let ((new (list elt)))
              (rplacd tail new)
              (setq tail new))))
@@ -261,7 +263,7 @@
      (let (vector)
        (do-sequence (elt seq index)
          (if (satisfies-test-p x elt :key key :test test :testp testp
-                               :test-not test-not :test-not-p test-not-p)
+                                     :test-not test-not :test-not-p test-not-p)
              ;; Copy the beginning of the vector only when we find an element
              ;; that does not match.
              (unless vector

--- a/src/setf.lisp
+++ b/src/setf.lisp
@@ -1,15 +1,17 @@
 ;;; setf.lisp ---
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading setf!")
 
@@ -111,8 +113,8 @@
     (let ((d (gensym)))
       `(let* (,@(mapcar #'list dummies vals)
               (,d ,delta)
-                (,(car newval) (+ ,getter ,d))
-                ,@(cdr newval))
+              (,(car newval) (+ ,getter ,d))
+              ,@(cdr newval))
          ,setter))))
 
 (defmacro decf (place &optional (delta 1))
@@ -121,8 +123,8 @@
     (let ((d (gensym)))
       `(let* (,@(mapcar #'list dummies vals)
               (,d ,delta)
-                (,(car newval) (- ,getter ,d))
-                ,@(cdr newval))
+              (,(car newval) (- ,getter ,d))
+              ,@(cdr newval))
          ,setter))))
 
 (defmacro push (x place)
@@ -141,8 +143,8 @@
     (let ((head (gensym)))
       `(let* (,@(mapcar #'list dummies vals)
               (,head ,getter)
-                (,(car newval) (cdr ,head))
-                ,@(cdr newval))
+              (,(car newval) (cdr ,head))
+              ,@(cdr newval))
          ,setter
          (car ,head)))))
 

--- a/src/stream.lisp
+++ b/src/stream.lisp
@@ -2,18 +2,21 @@
 
 ;; copyright (C) 2012, 2013 David Vazquez Copyright (C) 2012 Raimon Grau
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
-;;; TODO: Use structures to represent streams, but we would need inheritance.
+;;; TODO:   Use  structures   to   represent  streams,   but  we   would
+;;; need inheritance.
 
 (/debug "loading stream.lisp!")
 

--- a/src/string.lisp
+++ b/src/string.lisp
@@ -1,15 +1,17 @@
 ;;; string.lisp
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading string.lisp!")
 

--- a/src/symbol.lisp
+++ b/src/symbol.lisp
@@ -1,15 +1,17 @@
 ;;; symbols ---
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (defun symbol-plist (x)
   (cond

--- a/src/toplevel.lisp
+++ b/src/toplevel.lisp
@@ -1,24 +1,27 @@
 ;;; toplevel.lisp ---
 
-;; Copyright (C) 2012, 2013, 2014 David Vazquez Copyright (C) 2012 Raimon Grau
+;; Copyright  (C) 2012,  2013,  2014 David  Vazquez  Copyright (C)  2012
+;; Raimon Grau
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading toplevel.lisp!")
 
 (defun eval (x)
   (let ((jscode
-         (with-compilation-environment
-             (compile-toplevel x t t))))
+          (with-compilation-environment
+            (compile-toplevel x t t))))
     (js-eval jscode)))
 
 (defvar * nil)

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -2,16 +2,18 @@
 
 ;; Copyright (C) 2012, 2013 David Vazquez Copyright (C) 2012 Raimon Grau
 
-;; JSCL is  free software:  you can  redistribute it  and/or modify it  under the  terms of  the GNU
-;; General Public  License as published  by the  Free Software Foundation,  either version 3  of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed  in the hope that it  will be useful, but WITHOUT ANY  WARRANTY; without even
-;; the implied warranty of MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE. See the GNU General
-;; Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have  received a copy of the GNU  General Public License along with JSCL.  If not, see
-;; <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading utils.lisp!")
 
@@ -49,7 +51,8 @@ accumulated, in the order."
 (defmacro concatf (variable &body form)
   `(setq ,variable (concat ,variable (progn ,@form))))
 
-;;; This couple of helper functions will be defined in both Common Lisp and in JSCL
+;;; This couple of helper functions will  be defined in both Common Lisp
+;;; and in JSCL
 (defun ensure-list (x)
   (if (listp x)
       x
@@ -79,8 +82,8 @@ accumulated, in the order."
 (defun vector-to-list (vector)
   (let ((size (length vector)))
     (with-collect
-        (dotimes (i size)
-          (collect (aref vector i))))))
+      (dotimes (i size)
+        (collect (aref vector i))))))
 
 (defun list-to-vector (list)
   (let ((v (make-array (length list)))
@@ -134,7 +137,7 @@ accumulated, in the order."
 (defun interleave (list element &optional after-last-p)
   (unless (null list)
     (with-collect
-        (collect (car list))
+      (collect (car list))
       (dolist (x (cdr list))
         (collect element)
         (collect x))

--- a/tests/apply.lisp
+++ b/tests/apply.lisp
@@ -1,4 +1,4 @@
-                                        ; Tests for funcall/apply
+;; Tests for funcall/apply
 
 (test (equal (funcall #'list 1 2 3) '(1 2 3)))
 (test (equal (apply #'list 1 2 3 '(4 5 6)) '(1 2 3 4 5 6)))

--- a/tests/characters.lisp
+++ b/tests/characters.lisp
@@ -31,16 +31,19 @@
 (test (char>= #\d #\d #\c #\a))
 (test (not (char> #\e #\d #\b #\c #\a)))
 (test (not (char>= #\e #\d #\b #\c #\a)))
-;; (char> #\z #\A) => implementation-dependent (char> #\Z #\a) => implementation-dependent
+;; (char>  #\z  #\A)  =>  implementation-dependent (char>  #\Z  #\a)  =>
+;; implementation-dependent
 (test (char-equal #\A #\a))
-;; (stable-sort  (list #\b  #\A  #\B  #\a #\c  #\C)  #'char-lessp)  => (#\A  #\a  #\b  #\B #\c  #\C)
-;; (stable-sort (list #\b #\A #\B #\a #\c #\C) #'char<) => implementation-dependent
+;; (stable-sort (list #\b #\A #\B #\a #\c #\C) #'char-lessp) => (#\A #\a
+;; #\b #\B #\c #\C) (stable-sort (list #\b #\A #\B #\a #\c #\C) #'char<)
+;; => implementation-dependent
 
 ;; CHARACTER
 (test (equal #\a (character #\a)))
 (test (equal #\a (character "a")))
-;; (test (equal #\A (character 'a))) (test (equal #\a (character '\a))) (expected-failure (character
-;; 65.)) (expected-failure (character 'apple))
+;; (test (equal #\A (character 'a)))  (test (equal #\a (character '\a)))
+;; (expected-failure   (character  65.))   (expected-failure  (character
+;; 'apple))
 
 ;; CHARACTERP
 (test (characterp #\a))
@@ -104,13 +107,13 @@
 (test (char= #\A (char-upcase #\a)))
 (test (char= #\A (char-upcase #\A)))
 (test (char= (code-char 223) (char-upcase (code-char 223))))  ;; changes length, so you get the original back
-(test (char= (code-char 127744) (char-upcase (code-char 127744))))  ;; no upper case
+(test (char= (code-char 127744) (char-upcase (code-char 127744))))  ;;no upper case
 
 ;; CHAR-DOWNCASE
 (test (char= #\a (char-downcase #\a)))
 (test (char= #\a (char-downcase #\A)))
-(test (char= (code-char 223) (char-downcase (code-char 223))))  ;; already lower case
-(test (char= (code-char 127744) (char-downcase (code-char 127744))))  ;; no lower case
+(test (char= (code-char 223) (char-downcase (code-char 223))))  ; already lower case
+(test (char= (code-char 127744) (char-downcase (code-char 127744))))  ; no lower case
 
 ;; UPPER-CASE-P, LOWER-CASE-P, BOTH-CASE-P
 (test (upper-case-p #\A))
@@ -127,7 +130,7 @@
 (test (= 127744 (char-code (code-char 127744))))
 
 ;; CHAR-INT
-(test (= (char-int #\A) (char-int #\A)))  ;; can be pretty much anything, as long as it's consistent
+(test (= (char-int #\A) (char-int #\A)))  ; can be pretty much anything, as long as it's consistent
 
 (test (= 1 (length (string (code-char 127744)))))
 
@@ -178,6 +181,6 @@
 (test (vectorp "string"))
 (test (stringp "string"))
 
-;; (test (= 2 (char-code #u+2))) CRASHER
+;; (test (= 2 (char-code #u+2))) FIXME
 (test (= 0 (char-code #\Null)))
 (test (= 10 (char-code #\Newline)))

--- a/tests/conditionals.lisp
+++ b/tests/conditionals.lisp
@@ -1,12 +1,13 @@
-                                        ; Tests  for  conditional  forms
-                                        ; Boolean operators
+;;;; Tests  for  conditional  forms
+
+;; Boolean operators
 (test (eql (and nil 1) nil))
 (test (=   (and 1   2)   2))
 
 (test (= (or  nil 1)   1))
 (test (= (or  1   2)   1))
 
-                                        ; COND
+;; COND
 (test (eql nil (cond)))
 (test (=   1   (cond (1))))
 (test (= 1
@@ -16,8 +17,7 @@
 (test (=   3   (cond (nil 1) (2 3))))
 (test (eql nil (cond (nil 1) (nil 2))))
 
-                                        ; CASE
-
+;; CASE
 (test (= (case 1 (2 3) (otherwise 42)) 42))
 (test (= (case 1 (2 3) (t 42)) 42))
 (test (= (case 1 (2 3) (1 42)) 42))

--- a/tests/control.lisp
+++ b/tests/control.lisp
@@ -1,5 +1,4 @@
-
-;;; Returning from a "dynamically" nested non local exists
+ ;;; Returning from a "dynamically" nested non local exists
 
 (defun foo (x)
   (when x (funcall x))

--- a/tests/ffi.lisp
+++ b/tests/ffi.lisp
@@ -1,9 +1,8 @@
 ;;; Tests for Javascript FFI routines.
 
-;;; TODO: Once these are exported under JSCL/FFI, just  :USE that into the testing package. For now,
-;;; using JSCL:: prefix.
+;;; TODO: Once  these are exported  under JSCL/FFI, just :USE  that into
+;;; the testing package. For now, using JSCL:: prefix.
 
 (test (= ((jscl::oget (jscl::make-new #j:Date 0) "getTime")) 0))
 (test (stringp (#j:Date 0)))
 (test (< 32 (length (#j:Date 0))))
-

--- a/tests/hash-tables.lisp
+++ b/tests/hash-tables.lisp
@@ -1,4 +1,3 @@
-
 (let ((ht (make-hash-table))
       (key "foo"))
   (setf (gethash key ht) 10)

--- a/tests/iter-macros.lisp
+++ b/tests/iter-macros.lisp
@@ -1,17 +1,18 @@
-                                        ; Tests for  macros implementing
-                                        ; iteration constructs DOTIMES
+;;;; Tests for  macros implementing iteration constructs 
+
+;;DOTIMES
 (test (let ((total 0))
         (dotimes (n 6)
           (incf total n))
         (= total 15)))
 
-                                        ; DOLIST
+;; DOLIST
 (test (let ((total 0))
         (dolist (n '(1 2 3 4 5))
           (incf total n))
         (= total 15)))
 
-                                        ; DO
+;; DO
 (test (do ((a 0 b)
            (b 1 (+ a b))
            (n 0 (1+ n)))
@@ -26,7 +27,7 @@
 (test (= 5
          (do ((x nil nil)) (t 5))))
 
-                                        ; DO*
+;; DO*
 (test (do* ((a 0 b)
             (b 1 (+ a b))
             (n 0 (1+ n)))

--- a/tests/list.lisp
+++ b/tests/list.lisp
@@ -1,4 +1,4 @@
-;; Tests for list functions
+;;;; Tests for list functions
 
 ;; CONS
 (test (equal (cons 1 2) '(1 . 2)))
@@ -144,32 +144,32 @@
   (test (= (ninth   nums) 9))
   (test (= (tenth   nums) 10)))
 
-                                        ; TAILP
+;; TAILP
 (let* ((a (list 1 2 3))
        (b (cdr a)))
   (test (tailp b a))
   (test (tailp a a)))
 (test (tailp 'a (cons 'b 'a)))
 
-                                        ; ACONS
+;; ACONS
 (test (equal '((1 . 2) (3 . 4))
              (acons 1 2 '((3 . 4)))))
 (test (equal '((1 . 2)) (acons 1 2 ())))
 
-                                        ; PAIRLIS
+;; PAIRLIS
 (test (equal '((1 . 3) (0 . 2))
              (pairlis '(0 1) '(2 3))))
 (test (equal '((1 . 2) (a . b))
              (pairlis '(1) '(2) '((a . b)))))
 
-                                        ; COPY-ALIST
+;; COPY-ALIST
 (let* ((alist '((1 . 2) (3 . 4)))
        (copy (copy-alist alist)))
   (test (not (eql alist copy)))
   (test (not (eql (car alist) (car copy))))
   (test (equal alist copy)))
 
-                                        ; ASSOC and RASSOC
+;; ASSOC and RASSOC
 (let ((alist '((1 . 2) (3 . 4))))
   (test (equal (assoc  1 alist) '(1 . 2)))
   (test (equal (rassoc 2 alist) '(1 . 2)))
@@ -180,7 +180,7 @@
   (test (equal (assoc  1 alist :key (lambda (x) (/ x 3))) '(3 . 4)))
   (test (equal (rassoc 2 alist :key (lambda (x) (/ x 2))) '(3 . 4))))
 
-                                        ; MEMBER
+;; MEMBER
 (test (equal (member 2 '(1 2 3)) '(2 3)))
 (test (not   (member 4 '(1 2 3))))
 (test (equal (member 4 '((1 . 2) (3 . 4)) :key #'cdr) '((3 . 4))))
@@ -200,7 +200,7 @@
              (intersection '((1 . 2) (2 . 3)) '((9 . 2) (9 . 4))
                            :test #'equal :key #'cdr)))
 
-                                        ; POP
+;; POP
 (test (let* ((foo '(1 2 3))
              (bar (pop foo)))
         (and (= bar 1)

--- a/tests/numbers.lisp
+++ b/tests/numbers.lisp
@@ -28,8 +28,8 @@
 (test (not (oddp  2)))
 (test (not (oddp  0)))
 
-;;; +, -, *, / The builtin definition of these is variadic, but the function definition should be as
-;;; well. So, test it using MAPCAR
+;;; +, -,  *, /  The builtin  definition of these  is variadic,  but the
+;;; function definition should be as well. So, test it using MAPCAR
 (let* ((a '(1 2))
        (b a)
        (c a))

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -41,5 +41,8 @@
 
 (test (member 'car (find-all-symbols (string 'car))))
 
-;; This  test is  failing. I  have disabled  temporarily. (test  (eq (eval  '(in-package #:cl-user))
-;; (find-package '#:cl-user)))
+;; This  test is  failing. I  have disabled  temporarily.
+;;
+;; TODO
+;;
+;; (test  (eq (eval  '(in-package #:cl-user)) (find-package '#:cl-user)))

--- a/tests/print.lisp
+++ b/tests/print.lisp
@@ -134,4 +134,4 @@
 (test (equal (read-from-string (format nil "~@c" #\u+2010)) #\u+2010))
 
 (test (equal (format nil "~5,':x" 4) "::::4"))
-;;(test (equal (format nil "~5,,2,':d" 400) " 4:00")) CRASHER
+;;(test (equal (format nil "~5,,2,':d" 400) " 4:00")) FIXME

--- a/tests/read.lisp
+++ b/tests/read.lisp
@@ -1,6 +1,9 @@
-;; TODO: Uncomment  when either read-from-string  supports all these  parameters or when  test macro
-;; supports  error  handling,  whichever  comes  first  (test (equal  (read-from-string  "  1  3  5"
-;; t nil :start 2) (values 3 5)))
+;; TODO:  Uncomment  when  either read-from-string  supports  all  these
+;; parameters  or when  test  macro supports  error handling,  whichever
+;; comes first 
+
+;; (test  (equal (read-from-string  " 1  3 5"  t nil  :start 2)  (values
+;; 3 5)))
 (test (equal 'THE-END
              (with-input-from-string (is " ")
                (read is nil 'the-end))))

--- a/tests/seq.lisp
+++ b/tests/seq.lisp
@@ -1,5 +1,4 @@
-                                        ; Functions    used   as    :KEY
-                                        ; argument in tests
+;; Functions used as :KEY argument in tests
 (defvar halve  (lambda (x) (/ x 2)))
 (defvar double (lambda (x) (* x 2)))
 
@@ -68,7 +67,7 @@
 (expected-failure (equal (substitute-if 9 #'evenp '(1 2 4 1 3 4 5) :count 1 :from-end t)
                          '(1 2 4 1 3 9 5)))
 
-                                        ; POSITION
+;; POSITION
 (test (= (position 1 #(1 2 3))  0))
 (test (= (position 1 '(1 2 3))  0))
 (test (= (position 1 #(1 2 3 1)) 0))
@@ -87,9 +86,9 @@
 
 ;; POSITION-IF, POSITION-IF-NOT
 (test (= 2 (position-if #'oddp '((1) (2) (3) (4)) :start 1 :key #'car)))
-(test (= 4 (position-if-not #'integerp '(1 2 3 4 X))))  ;; (hyperspec example used "5.0", but we don't have a full numeric tower yet!)
+(test (= 4 (position-if-not #'integerp '(1 2 3 4 X))))  ;; (hyperspec example used "5.0", but we don't have a full numeric tower yet!) TODO
 (test (= 4 (position-if #'oddp '((1) (2) (3) (4) (5)) :start 1 :key #'car :from-end t)))
-(test (= 4 (position-if-not #'integerp '(1 2 3 4 X Y))))  ;; (hyperspec example used "5.0", but we don't have a full numeric tower yet!)
+(test (= 4 (position-if-not #'integerp '(1 2 3 4 X Y))))  ;; (hyperspec example used "5.0", but we don't have a full numeric tower yet!) TODO
 (test (= 5 (position-if-not #'integerp '(1 2 3 4 X Y) :from-end t)))
 
                                         ; REMOVE-IF
@@ -101,11 +100,11 @@
 (test (every #'zerop (remove-if-not #'zerop #(1 0 2 0 3))))
 (test (every #'= '(0 1 2 3) '(0 1 2 3))) ; test “every” with two seqs
 
-                                        ; SUBSEQ
+;; SUBSEQ
 (let ((nums '(1 2 3 4 5)))
   (test (equal (subseq nums 3) '(4 5)))
   (test (equal (subseq nums 2 4) '(3 4)))
-                                        ; Test that nums hasn't been altered: SUBSEQ should construct fresh lists
+  ;; Test that nums hasn't been altered: SUBSEQ should construct fresh lists
   (test (equal nums '(1 2 3 4 5))))
 
 ;; REVERSE
@@ -159,16 +158,16 @@
 (test (equal (reduce #'cons '(a b c d e f) :start 1 :end 4 :from-end t)
              '(b c . d)))
 (test (equal (reduce #'cons '(a b c d e f) :start 1 :end 4 :from-end t
-                     :initial-value nil)
+                                           :initial-value nil)
              '(b c d)))
 
-                                        ; MISMATCH
+;; MISMATCH
 (test (= (mismatch '(1 2 3) '(1 2 3 4 5 6)) 3))
 (test (= (mismatch '(1 2 3) #(1 2 3 4 5 6)) 3))
 (test (= (mismatch #(1 2 3) '(1 2 3 4 5 6)) 3))
 (test (= (mismatch #(1 2 3) #(1 2 3 4 5 6)) 3))
 
-                                        ; SEARCH
+;; SEARCH
 (test (= (search '(1 2 3) '(4 5 6 1 2 3)) 3))
 (test (= (search '(1 2 3) #(4 5 6 1 2 3)) 3))
 (test (= (search #(1 2 3) '(4 5 6 1 2 3)) 3))
@@ -205,7 +204,7 @@
  (map 'list #'list "123")
  '((#\1) (#\2) (#\3)))
 
-                                        ; CHAR-UPCASE cannot be sharp-quoted currently
+;; CHAR-UPCASE cannot be sharp-quoted currently
 (test-equal
  (map 'string (lambda (c) (char-upcase c)) '(#\a #\b #\c))
  "ABC")

--- a/tests/setf.lisp
+++ b/tests/setf.lisp
@@ -1,4 +1,3 @@
-
 (test (= 2
          (let ((x 0))
            (incf x (setf x 1))

--- a/tests/strings.lisp
+++ b/tests/strings.lisp
@@ -24,38 +24,48 @@
 (test (= (string< "" "a") 0))
 (test (= (string< "aaa" "aaaaa") 3))
 
-;;; BUG: The  compiler will macroexpand the  forms below (char str  N) will expand to  internal SBCL
-;;; code instead  of our (setf  char). It is because  macrodefinitions during bootstrapping  are not
-;;; included in  the host's  environment. It should,  but we  have to think  how to  avoid conflicts
-;;; (package renaming??)
+;;; BUG: The compiler will macroexpand the forms below (char str N) will
+;;; expand  to internal  SBCL code  instead of  our (setf  char). It  is
+;;; because macrodefinitions  during bootstrapping  are not  included in
+;;; the host's environment. It should, but we have to think how to avoid
+;;; conflicts (package renaming??)
 
-;; (let  ((str "hello"))  (setf  (char str  0)  #\X) (setf  (char  str 4)  #\X)  (test (string=  str
-;;   "XellX")))
+;; (let ((str "hello")) (setf (char str  0) #\X) (setf (char str 4) #\X)
+;;   (test (string= str "XellX")))
 
-;; ---------------------------------------- The following  tests in this file were  derived from the
-;; file   "must-string.lisp",   part  of   SACLA   <http://homepage1.nifty.com/bmonkey/lisp/sacla/>.
-;; The origial copyright notice appears below:
+;; ---------------------------------------- The following  tests in this
+;; file were  derived from  the file  "must-string.lisp", part  of SACLA
+;; <http://homepage1.nifty.com/bmonkey/lisp/sacla/>.     The     origial
+;; copyright notice appears below:
 
-;; Copyright (C) 2002-2004, Yuji Minejima <ggb01164@nifty.ne.jp> ALL RIGHTS RESERVED.
+;; Copyright  (C) 2002-2004,  Yuji  Minejima <ggb01164@nifty.ne.jp>  ALL
+;; RIGHTS RESERVED.
 ;;
 ;; $Id: must-string.lisp,v 1.7 2004/02/20 07:23:42 yuji Exp $
 ;;
-;; Redistribution and use  in source and binary  forms, with or without  modification, are permitted
-;; provided that the following conditions are met:
+;; Redistribution and  use in source  and binary forms, with  or without
+;; modification, are  permitted provided  that the  following conditions
+;; are met:
 ;;
-;;  * Redistributions of source code must retain the above copyright notice, this list of conditions
-;;    and  the following  disclaimer. *  Redistributions  in binary  form must  reproduce the  above
-;;    copyright notice,  this list of conditions  and the following disclaimer  in the documentation
-;;    and/or other materials provided with the distribution.
+;;  * Redistributions  of source  code must  retain the  above copyright
+;;    notice, this list of conditions and the following disclaimer.
+;; 
+;;  * Redistributions in binary form  must reproduce the above copyright
+;;    notice, this  list of conditions  and the following  disclaimer in
+;;    the   documentation   and/or   other   materials   provided   with
+;;    the distribution.
 ;;
-;; THIS SOFTWARE IS  PROVIDED BY THE COPYRIGHT HOLDERS  AND CONTRIBUTORS "AS IS" AND  ANY EXPRESS OR
-;; IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-;; FITNESS  FOR A  PARTICULAR PURPOSE  ARE DISCLAIMED.  IN  NO EVENT  SHALL THE  COPYRIGHT OWNER  OR
-;; CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-;; DATA,  OR PROFITS;  OR BUSINESS  INTERRUPTION) HOWEVER  CAUSED AND  ON ANY  THEORY OF  LIABILITY,
-;; WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
-;; WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;; THIS SOFTWARE IS  PROVIDED BY THE COPYRIGHT  HOLDERS AND CONTRIBUTORS
+;; "AS IS"  AND ANY  EXPRESS OR IMPLIED  WARRANTIES, INCLUDING,  BUT NOT
+;; LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+;; A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+;; OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+;; SPECIAL,  EXEMPLARY, OR  CONSEQUENTIAL  DAMAGES  (INCLUDING, BUT  NOT
+;; LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+;; THEORY OF LIABILITY,  WHETHER IN CONTRACT, STRICT  LIABILITY, OR TORT
+;; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+;; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ;; JSCL: no SIMPLE-STRING-P yet, so disabled
 ;; (test (simple-string-p ""))


### PR DESCRIPTION
Upstream @davazp  may replace this LOOP with one from @PuercoPop but there are some commits to the main tree (I noticed NREVERSE in there and some other things) that would be good to catch up on.

It looks like the DEFPACKAGE/IN-PACKAGE problems plaguing the JSCL/FFI branch here also affect upstream, so hopefully as soon as those are sorted out I can begin parceling out PR's for upstream as well.

This PR might not get merged in very soon, but curious to see how far the forks may have diverged