### PR TITLE
- Adding STEP macro with minimal functionality, only for ANSI compliance

### DIFF
--- a/src/misc.lisp
+++ b/src/misc.lisp
@@ -123,3 +123,13 @@
 (defun get-universal-time ()
   (+ (get-unix-time) 2208988800))
 
+
+;;;; STEP
+
+;; Adding STEP macro entry here with no useful code for now, only for ANSI compliance as
+;; in other Lisp platforms (like Clozure CL). The expansion of this macro will be only the code passed
+;; as the argument
+
+(defmacro step (form)
+  "Stepping is no currently available"
+  form)

--- a/tests/misc.lisp
+++ b/tests/misc.lisp
@@ -1,0 +1,3 @@
+;; STEP macro
+(test (= 4
+         (step (progn (setf x 5) (decf x)))))


### PR DESCRIPTION
“It is technically permissible for a conforming implementation to take no action at all other than normal execution of the form. In such a situation, (step form) is equivalent to, for example, (let () form). In implementations where this is the case, the associated documentation should mention that fact. ”